### PR TITLE
Fix corps tab not displaying data in telemetry app

### DIFF
--- a/telemetry-app/dist/index.js
+++ b/telemetry-app/dist/index.js
@@ -172,10 +172,11 @@ function loadTelemetryCache() {
 async function pollTelemetry() {
     console.log(`[${new Date().toISOString()}] Polling telemetry...`);
     try {
-        // Fetch core and nodes segments (with delay between to avoid rate limiting)
+        // Fetch core, nodes, and corps segments (with delay between to avoid rate limiting)
         const segments = await api.readSegments([
             TELEMETRY_SEGMENTS.CORE,
             TELEMETRY_SEGMENTS.NODES,
+            TELEMETRY_SEGMENTS.CORPS,
         ]);
         // Parse segments (nodes uses special parser for v2 compact format)
         const newTelemetry = {
@@ -183,7 +184,7 @@ async function pollTelemetry() {
             nodes: parseNodeTelemetry(segments[TELEMETRY_SEGMENTS.NODES]),
             terrain: null,
             intel: null,
-            corps: null,
+            corps: parseTelemetry(segments[TELEMETRY_SEGMENTS.CORPS]),
             chains: null,
             lastUpdate: Date.now(),
         };

--- a/telemetry-app/src/index.ts
+++ b/telemetry-app/src/index.ts
@@ -18,6 +18,7 @@ import {
   NodeTelemetry,
   NodeTelemetryNode,
   NodeTelemetryNodeCompact,
+  CorpsTelemetry,
 } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -200,10 +201,11 @@ async function pollTelemetry(): Promise<void> {
   console.log(`[${new Date().toISOString()}] Polling telemetry...`);
 
   try {
-    // Fetch core and nodes segments (with delay between to avoid rate limiting)
+    // Fetch core, nodes, and corps segments (with delay between to avoid rate limiting)
     const segments = await api.readSegments([
       TELEMETRY_SEGMENTS.CORE,
       TELEMETRY_SEGMENTS.NODES,
+      TELEMETRY_SEGMENTS.CORPS,
     ]);
 
     // Parse segments (nodes uses special parser for v2 compact format)
@@ -212,7 +214,7 @@ async function pollTelemetry(): Promise<void> {
       nodes: parseNodeTelemetry(segments[TELEMETRY_SEGMENTS.NODES]),
       terrain: null,
       intel: null,
-      corps: null,
+      corps: parseTelemetry<CorpsTelemetry>(segments[TELEMETRY_SEGMENTS.CORPS]),
       chains: null,
       lastUpdate: Date.now(),
     };


### PR DESCRIPTION
The corps segment was never being fetched from the Screeps API - only CORE and NODES were included in readSegments(). Added TELEMETRY_SEGMENTS.CORPS to the fetch call and parse the response into the telemetry object.