### PR TITLE
Remove hardcoded commitment tracking, use contracts instead

### DIFF
--- a/src/corps/CorpState.ts
+++ b/src/corps/CorpState.ts
@@ -207,10 +207,8 @@ export function createSourceState(
     expectedUnitsProduced: 0,
     unitsConsumed: 0,
     acquisitionCost: 0,
-    committedWorkTicks: 0,
-    committedEnergy: 0,
-    committedDeliveredEnergy: 0,
-    lastPlannedTick: 0
+    lastPlannedTick: 0,
+    contracts: []
   };
 }
 
@@ -246,10 +244,8 @@ export function createMiningState(
     expectedUnitsProduced: 0,
     unitsConsumed: 0,
     acquisitionCost: 0,
-    committedWorkTicks: 0,
-    committedEnergy: 0,
-    committedDeliveredEnergy: 0,
-    lastPlannedTick: 0
+    lastPlannedTick: 0,
+    contracts: []
   };
 }
 
@@ -285,10 +281,8 @@ export function createSpawningState(
     expectedUnitsProduced: 0,
     unitsConsumed: 0,
     acquisitionCost: 0,
-    committedWorkTicks: 0,
-    committedEnergy: 0,
-    committedDeliveredEnergy: 0,
-    lastPlannedTick: 0
+    lastPlannedTick: 0,
+    contracts: []
   };
 }
 
@@ -322,10 +316,8 @@ export function createUpgradingState(
     expectedUnitsProduced: 0,
     unitsConsumed: 0,
     acquisitionCost: 0,
-    committedWorkTicks: 0,
-    committedEnergy: 0,
-    committedDeliveredEnergy: 0,
-    lastPlannedTick: 0
+    lastPlannedTick: 0,
+    contracts: []
   };
 }
 
@@ -363,10 +355,8 @@ export function createHaulingState(
     expectedUnitsProduced: 0,
     unitsConsumed: 0,
     acquisitionCost: 0,
-    committedWorkTicks: 0,
-    committedEnergy: 0,
-    committedDeliveredEnergy: 0,
-    lastPlannedTick: 0
+    lastPlannedTick: 0,
+    contracts: []
   };
 }
 

--- a/src/corps/HaulingOperation.ts
+++ b/src/corps/HaulingOperation.ts
@@ -98,7 +98,8 @@ export class HaulingOperation extends Corp {
       return sum + (capacity * deliveries);
     }, 0);
 
-    const availableCapacity = deliveryCapacity - this.committedDeliveredEnergy;
+    const committedDelivery = this.getCommittedSellQuantity("haul-energy", Game.time);
+    const availableCapacity = deliveryCapacity - committedDelivery;
     if (availableCapacity <= 0) return [];
 
     const pricePerEnergy = TRANSPORT_FEE * (1 + this.getMargin());
@@ -184,9 +185,6 @@ export class HaulingOperation extends Corp {
         const result = creep.pickup(target);
         if (result === ERR_NOT_IN_RANGE) {
           creep.moveTo(target);
-        } else if (result === OK) {
-          const pickedUp = Math.min(target.amount, creep.store.getFreeCapacity());
-          this.fulfillEnergyCommitment(pickedUp);
         }
       }
     }
@@ -209,7 +207,6 @@ export class HaulingOperation extends Corp {
         creep.moveTo(target);
       } else if (result === OK) {
         this.recordProduction(creep.store[RESOURCE_ENERGY]);
-        this.fulfillDeliveredEnergyCommitment(creep.store[RESOURCE_ENERGY]);
       }
       return;
     }
@@ -225,7 +222,6 @@ export class HaulingOperation extends Corp {
     } else {
       creep.drop(RESOURCE_ENERGY);
       this.recordProduction(creep.store[RESOURCE_ENERGY]);
-      this.fulfillDeliveredEnergyCommitment(creep.store[RESOURCE_ENERGY]);
     }
   }
 

--- a/src/corps/MiningOperation.ts
+++ b/src/corps/MiningOperation.ts
@@ -89,7 +89,8 @@ export class MiningOperation extends Corp {
       return sum + (workParts * 2 * ttl);
     }, 0);
 
-    const availableEnergy = energyCapacity - this.committedEnergy;
+    const committedEnergy = this.getCommittedSellQuantity("energy", Game.time);
+    const availableEnergy = energyCapacity - committedEnergy;
     if (availableEnergy <= 0) return [];
 
     return [{
@@ -150,7 +151,6 @@ export class MiningOperation extends Corp {
     } else if (result === OK) {
       const workParts = creep.getActiveBodyparts(WORK);
       this.recordProduction(workParts * 2);
-      this.fulfillEnergyCommitment(workParts * 2);
     }
 
     // Drop when full

--- a/src/corps/RealMiningCorp.ts
+++ b/src/corps/RealMiningCorp.ts
@@ -144,10 +144,8 @@ export class RealMiningCorp extends Corp {
       expectedUnitsProduced: this.expectedUnitsProduced,
       unitsConsumed: this.unitsConsumed,
       acquisitionCost: this.acquisitionCost,
-      committedWorkTicks: this.committedWorkTicks,
-      committedEnergy: this.committedEnergy,
-      committedDeliveredEnergy: this.committedDeliveredEnergy,
-      lastPlannedTick: this.lastPlannedTick
+      lastPlannedTick: this.lastPlannedTick,
+      contracts: this.contracts
     };
   }
 
@@ -300,8 +298,6 @@ export class RealMiningCorp extends Corp {
       const workParts = creep.getActiveBodyparts(WORK);
       const energyHarvested = workParts * 2;
       this.recordProduction(energyHarvested);
-      // Fulfill energy commitment as we produce
-      this.fulfillEnergyCommitment(energyHarvested);
     }
 
     // Drop energy when full (let haulers pick it up)

--- a/src/corps/RealUpgradingCorp.ts
+++ b/src/corps/RealUpgradingCorp.ts
@@ -108,10 +108,8 @@ export class RealUpgradingCorp extends Corp {
       expectedUnitsProduced: this.expectedUnitsProduced,
       unitsConsumed: this.unitsConsumed,
       acquisitionCost: this.acquisitionCost,
-      committedWorkTicks: this.committedWorkTicks,
-      committedEnergy: this.committedEnergy,
-      committedDeliveredEnergy: this.committedDeliveredEnergy,
-      lastPlannedTick: this.lastPlannedTick
+      lastPlannedTick: this.lastPlannedTick,
+      contracts: this.contracts
     };
   }
 
@@ -186,8 +184,9 @@ export class RealUpgradingCorp extends Corp {
         return sum + (workParts * ttl); // energy consumed over remaining lifespan
       }, 0);
 
-      // Subtract already-committed haul-energy to prevent double-ordering
-      const energyNeeded = energyCapacity - this.committedDeliveredEnergy;
+      // Subtract already-committed haul-energy from buy contracts to prevent double-ordering
+      const committedDeliveredEnergy = this.getCommittedBuyQuantity("haul-energy", Game.time);
+      const energyNeeded = energyCapacity - committedDeliveredEnergy;
 
       if (energyNeeded > 0) {
         const bidPricePerUnit = BASE_ENERGY_VALUE * urgency;
@@ -353,12 +352,7 @@ export class RealUpgradingCorp extends Corp {
 
       if (nearbyDropped.length > 0) {
         const target = nearbyDropped[0];
-        const result = creep.pickup(target);
-        if (result === OK) {
-          // Fulfill delivered-energy commitment as we receive energy
-          const pickedUp = Math.min(target.amount, creep.store.getFreeCapacity());
-          this.fulfillDeliveredEnergyCommitment(pickedUp);
-        }
+        creep.pickup(target);
       }
       // Otherwise just wait - hauler will transfer energy to us
     }

--- a/src/corps/SpawningCorp.ts
+++ b/src/corps/SpawningCorp.ts
@@ -300,10 +300,8 @@ export class SpawningCorp extends Corp {
       expectedUnitsProduced: this.expectedUnitsProduced,
       unitsConsumed: this.unitsConsumed,
       acquisitionCost: this.acquisitionCost,
-      committedWorkTicks: this.committedWorkTicks,
-      committedEnergy: this.committedEnergy,
-      committedDeliveredEnergy: this.committedDeliveredEnergy,
-      lastPlannedTick: this.lastPlannedTick
+      lastPlannedTick: this.lastPlannedTick,
+      contracts: this.contracts
     };
   }
 

--- a/src/execution/CorpRunner.ts
+++ b/src/execution/CorpRunner.ts
@@ -376,8 +376,8 @@ export function processSpawnContracts(
     const creepType = mapCorpTypeToCreepType(buyerCorpType);
     if (!creepType) continue;
 
-    // Record commitment on buyer corp to prevent double-ordering
-    buyerCorp.recordWorkTicksCommitment(contract.quantity);
+    // Contract is already assigned to the buyer corp via Market.matchOffers
+    // No need for separate commitment tracking
 
     if (contract.resource === "carry-ticks") {
       spawningCorp.queueSpawn({

--- a/src/main.ts
+++ b/src/main.ts
@@ -559,24 +559,20 @@ global.forgiveDebt = (amount: number = 1000) => {
     totalRevenue: number;
     totalCost: number;
     id: string;
-    committedWorkTicks: number;
-    committedEnergy: number;
-    committedDeliveredEnergy: number;
     unitsProduced: number;
     expectedUnitsProduced: number;
     unitsConsumed: number;
     acquisitionCost: number;
+    contracts: unknown[];
   }) => {
     corp.balance = amount;
     corp.totalRevenue = 0;
     corp.totalCost = 0;
-    corp.committedWorkTicks = 0;
-    corp.committedEnergy = 0;
-    corp.committedDeliveredEnergy = 0;
     corp.unitsProduced = 0;
     corp.expectedUnitsProduced = 0;
     corp.unitsConsumed = 0;
     corp.acquisitionCost = 0;
+    corp.contracts = []; // Clear all contracts
     corpsReset++;
   };
 

--- a/src/market/Contract.ts
+++ b/src/market/Contract.ts
@@ -34,6 +34,9 @@ export interface Contract {
 
   /** Amount paid so far */
   paid: number;
+
+  /** Creep IDs assigned to execute this contract */
+  creepIds: string[];
 }
 
 /**
@@ -184,7 +187,8 @@ export function createContract(
     duration,
     startTick,
     delivered: 0,
-    paid: 0
+    paid: 0,
+    creepIds: []
   };
 }
 
@@ -203,4 +207,23 @@ export function recordDelivery(contract: Contract, amount: number): void {
  */
 export function recordPayment(contract: Contract, amount: number): void {
   contract.paid = Math.min(contract.price, contract.paid + amount);
+}
+
+/**
+ * Assign a creep to a contract
+ */
+export function assignCreep(contract: Contract, creepId: string): void {
+  if (!contract.creepIds.includes(creepId)) {
+    contract.creepIds.push(creepId);
+  }
+}
+
+/**
+ * Remove a creep from a contract
+ */
+export function unassignCreep(contract: Contract, creepId: string): void {
+  const index = contract.creepIds.indexOf(creepId);
+  if (index !== -1) {
+    contract.creepIds.splice(index, 1);
+  }
 }

--- a/src/market/Market.ts
+++ b/src/market/Market.ts
@@ -226,6 +226,16 @@ export class Market {
         );
         contracts.push(contract);
 
+        // Assign contract to both buyer and seller corps
+        const seller = this.corps.get(sellOffer.corpId);
+        const buyer = this.corps.get(buyOffer.corpId);
+        if (seller) {
+          seller.addContract(contract);
+        }
+        if (buyer) {
+          buyer.addContract(contract);
+        }
+
         console.log(`[Market] Matched: ${sellOffer.resource} x${tradeQty} @ ${tradePricePerUnit.toFixed(3)}/unit (${contract.sellerId.slice(-6)} → ${contract.buyerId.slice(-6)})`);
 
         // Record transaction
@@ -304,26 +314,12 @@ export class Market {
     const seller = this.corps.get(sellerId);
     if (seller) {
       seller.recordRevenue(totalPayment);
-
-      // Record energy commitment for the seller (prevents double-selling)
-      if (resource === "energy") {
-        seller.recordEnergyCommitment(quantity);
-      } else if (resource === "delivered-energy" || resource === "haul-energy") {
-        seller.recordDeliveredEnergyCommitment(quantity);
-      }
     }
 
     // Update buyer: record cost
     const buyer = this.corps.get(buyerId);
     if (buyer) {
       buyer.recordCost(totalPayment);
-
-      // Record energy commitment for the buyer (prevents double-ordering)
-      if (resource === "energy") {
-        buyer.recordEnergyCommitment(quantity);
-      } else if (resource === "delivered-energy" || resource === "haul-energy") {
-        buyer.recordDeliveredEnergyCommitment(quantity);
-      }
 
       // For middleman corps (hauling), also record acquisition cost
       if (buyer.type === "hauling") {

--- a/test/unit/planning/projections.test.ts
+++ b/test/unit/planning/projections.test.ts
@@ -249,10 +249,8 @@ describe("projections", () => {
         expectedUnitsProduced: 0,
         unitsConsumed: 0,
         acquisitionCost: 0,
-        committedWorkTicks: 0,
-        committedEnergy: 0,
-        committedDeliveredEnergy: 0,
-        lastPlannedTick: 0
+        lastPlannedTick: 0,
+        contracts: []
       };
       const projection = project(state, 0);
 


### PR DESCRIPTION
- Add creepIds field to Contract interface for tracking assigned creeps
- Add contracts array to Corp base class
- Add helper methods to Corp: addContract, removeContract, getSellContracts, getBuyContracts, getCommittedSellQuantity, getCommittedBuyQuantity, pruneContracts
- Update Market to assign contracts to both buyer and seller corps on creation
- Remove committedWorkTicks, committedEnergy, committedDeliveredEnergy fields
- Remove the 6 commitment methods (record*Commitment, fulfill*Commitment)
- Remove commitment recording from Market.recordTransaction
- Update projections.ts to query contracts for committed quantities
- Update all corps to query contracts instead of commitment fields:
  - RealMiningCorp, RealHaulingCorp, RealUpgradingCorp
  - MiningOperation, HaulingOperation
- Remove all fulfill*Commitment calls from corps
- Update CorpState factory functions to include contracts array
- Update main.ts forgiveDebt to clear contracts instead of commitment fields
- Update test file to use new contract structure

Corps now hold their contracts and query them to know their obligations, replacing the previous separate commitment tracking system.