### PR TITLE
Implement forward capital flow (BankCorp model)

### DIFF
--- a/src/market/CapitalBudget.ts
+++ b/src/market/CapitalBudget.ts
@@ -1,0 +1,431 @@
+/**
+ * @fileoverview CapitalBudget - Tracks capital allocation and spending for corps.
+ *
+ * In the forward capital flow model, corps receive capital from:
+ * 1. Investment contracts (goal corps like upgraders)
+ * 2. Sub-contracts (intermediate corps like haulers)
+ *
+ * This module tracks:
+ * - Capital received from upstream buyers
+ * - Capital committed to downstream suppliers
+ * - Available capital for new contracts
+ *
+ * Key insight: A corp's "buying power" is limited by the capital
+ * they have from upstream contracts, not by infinite demand.
+ *
+ * @module market/CapitalBudget
+ */
+
+import { InvestmentContract, SubContract, remainingBudget } from "./InvestmentContract";
+
+/**
+ * Capital source - where the capital came from.
+ */
+export interface CapitalSource {
+  /** Type of source */
+  type: "investment" | "sub-contract";
+
+  /** Source contract ID */
+  contractId: string;
+
+  /** Amount of capital from this source */
+  amount: number;
+
+  /** Amount already spent from this source */
+  spent: number;
+
+  /** Resource that must be produced to earn this capital */
+  requiredResource: string;
+
+  /** Units that must be delivered */
+  requiredQuantity: number;
+
+  /** Units delivered so far */
+  deliveredQuantity: number;
+}
+
+/**
+ * Capital commitment - how capital is allocated to suppliers.
+ */
+export interface CapitalCommitment {
+  /** Sub-contract ID */
+  contractId: string;
+
+  /** Supplier corp ID */
+  supplierId: string;
+
+  /** Resource being purchased */
+  resource: string;
+
+  /** Total committed amount */
+  amount: number;
+
+  /** Amount paid so far */
+  paid: number;
+
+  /** Linked capital source */
+  sourceId: string;
+}
+
+/**
+ * CapitalBudget tracks a corp's capital allocation.
+ */
+export class CapitalBudget {
+  /** Corp ID this budget belongs to */
+  readonly corpId: string;
+
+  /** Capital sources */
+  private sources: Map<string, CapitalSource> = new Map();
+
+  /** Capital commitments to suppliers */
+  private commitments: Map<string, CapitalCommitment> = new Map();
+
+  constructor(corpId: string) {
+    this.corpId = corpId;
+  }
+
+  // ===========================================================================
+  // Capital Sources
+  // ===========================================================================
+
+  /**
+   * Add capital from an investment contract.
+   */
+  addInvestmentCapital(investment: InvestmentContract): void {
+    const source: CapitalSource = {
+      type: "investment",
+      contractId: investment.id,
+      amount: remainingBudget(investment),
+      spent: 0,
+      requiredResource: investment.resource,
+      requiredQuantity: remainingBudget(investment) / investment.ratePerUnit,
+      deliveredQuantity: 0
+    };
+    this.sources.set(investment.id, source);
+  }
+
+  /**
+   * Add capital from a sub-contract (as seller).
+   */
+  addSubContractCapital(contract: SubContract): void {
+    const remainingPayment = contract.price - contract.paid;
+    const remainingQuantity = contract.quantity - contract.delivered;
+
+    const source: CapitalSource = {
+      type: "sub-contract",
+      contractId: contract.id,
+      amount: remainingPayment,
+      spent: 0,
+      requiredResource: contract.resource,
+      requiredQuantity: remainingQuantity,
+      deliveredQuantity: 0
+    };
+    this.sources.set(contract.id, source);
+  }
+
+  /**
+   * Get total capital available (not yet committed).
+   */
+  getAvailableCapital(): number {
+    let total = 0;
+    for (const source of this.sources.values()) {
+      total += source.amount - source.spent;
+    }
+    return total;
+  }
+
+  /**
+   * Get total capital from all sources (including committed).
+   */
+  getTotalCapital(): number {
+    let total = 0;
+    for (const source of this.sources.values()) {
+      total += source.amount;
+    }
+    return total;
+  }
+
+  /**
+   * Get capital committed to suppliers.
+   */
+  getCommittedCapital(): number {
+    let total = 0;
+    for (const commitment of this.commitments.values()) {
+      total += commitment.amount - commitment.paid;
+    }
+    return total;
+  }
+
+  // ===========================================================================
+  // Capital Allocation
+  // ===========================================================================
+
+  /**
+   * Commit capital to a supplier.
+   * Returns true if successful, false if insufficient capital.
+   */
+  commitToSupplier(
+    contractId: string,
+    supplierId: string,
+    resource: string,
+    amount: number
+  ): boolean {
+    const available = this.getAvailableCapital();
+    if (amount > available) {
+      return false;
+    }
+
+    // Find a source to draw from
+    const sourceId = this.findSourceForSpending(amount);
+    if (!sourceId) return false;
+
+    const source = this.sources.get(sourceId);
+    if (!source) return false;
+
+    // Record spending from source
+    source.spent += amount;
+
+    // Record commitment
+    const commitment: CapitalCommitment = {
+      contractId,
+      supplierId,
+      resource,
+      amount,
+      paid: 0,
+      sourceId
+    };
+    this.commitments.set(contractId, commitment);
+
+    return true;
+  }
+
+  /**
+   * Find a source with enough remaining capital.
+   */
+  private findSourceForSpending(amount: number): string | null {
+    for (const [id, source] of this.sources) {
+      const remaining = source.amount - source.spent;
+      if (remaining >= amount) {
+        return id;
+      }
+    }
+
+    // Try combining sources (pro-rata)
+    let available = 0;
+    for (const source of this.sources.values()) {
+      available += source.amount - source.spent;
+    }
+    if (available >= amount) {
+      // Return first source - spending will be distributed
+      for (const [id, source] of this.sources) {
+        if (source.amount - source.spent > 0) {
+          return id;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Record payment to a supplier.
+   */
+  recordPayment(contractId: string, amount: number): void {
+    const commitment = this.commitments.get(contractId);
+    if (!commitment) return;
+
+    commitment.paid = Math.min(commitment.paid + amount, commitment.amount);
+  }
+
+  /**
+   * Record delivery of our product (earns capital from source).
+   */
+  recordDelivery(sourceId: string, units: number): number {
+    const source = this.sources.get(sourceId);
+    if (!source) return 0;
+
+    source.deliveredQuantity += units;
+
+    // Capital is earned proportionally to delivery
+    const deliveryRatio = source.requiredQuantity > 0
+      ? source.deliveredQuantity / source.requiredQuantity
+      : 0;
+    const earnedCapital = source.amount * deliveryRatio;
+
+    return earnedCapital;
+  }
+
+  // ===========================================================================
+  // Budget Queries
+  // ===========================================================================
+
+  /**
+   * Get maximum we can bid for a resource.
+   * This is the available capital that can be spent on suppliers.
+   */
+  getMaxBid(resource: string): number {
+    // Available capital can be spent on any supplier
+    return this.getAvailableCapital();
+  }
+
+  /**
+   * Get budget for a specific supplier type/resource.
+   */
+  getBudgetFor(resource: string): number {
+    // For now, all available capital can be used for any resource
+    // Future: could prioritize based on production requirements
+    return this.getAvailableCapital();
+  }
+
+  /**
+   * Check if we can afford a purchase.
+   */
+  canAfford(amount: number): boolean {
+    return amount <= this.getAvailableCapital();
+  }
+
+  /**
+   * Get required output to fully earn capital.
+   */
+  getRequiredOutput(): { resource: string; quantity: number }[] {
+    const requirements: { resource: string; quantity: number }[] = [];
+
+    for (const source of this.sources.values()) {
+      const remaining = source.requiredQuantity - source.deliveredQuantity;
+      if (remaining > 0) {
+        requirements.push({
+          resource: source.requiredResource,
+          quantity: remaining
+        });
+      }
+    }
+
+    return requirements;
+  }
+
+  // ===========================================================================
+  // Serialization
+  // ===========================================================================
+
+  /**
+   * Serialize budget state.
+   */
+  serialize(): SerializedCapitalBudget {
+    return {
+      corpId: this.corpId,
+      sources: Array.from(this.sources.values()),
+      commitments: Array.from(this.commitments.values())
+    };
+  }
+
+  /**
+   * Restore budget state.
+   */
+  deserialize(data: SerializedCapitalBudget): void {
+    this.sources.clear();
+    this.commitments.clear();
+
+    for (const source of data.sources) {
+      this.sources.set(source.contractId, source);
+    }
+
+    for (const commitment of data.commitments) {
+      this.commitments.set(commitment.contractId, commitment);
+    }
+  }
+
+  /**
+   * Clear all capital (for testing or reset).
+   */
+  clear(): void {
+    this.sources.clear();
+    this.commitments.clear();
+  }
+
+  /**
+   * Get summary for debugging.
+   */
+  getSummary(): {
+    totalCapital: number;
+    availableCapital: number;
+    committedCapital: number;
+    sourceCount: number;
+    commitmentCount: number;
+  } {
+    return {
+      totalCapital: this.getTotalCapital(),
+      availableCapital: this.getAvailableCapital(),
+      committedCapital: this.getCommittedCapital(),
+      sourceCount: this.sources.size,
+      commitmentCount: this.commitments.size
+    };
+  }
+}
+
+/**
+ * Serialized budget state.
+ */
+export interface SerializedCapitalBudget {
+  corpId: string;
+  sources: CapitalSource[];
+  commitments: CapitalCommitment[];
+}
+
+/**
+ * Global registry of capital budgets by corp ID.
+ */
+const budgetRegistry: Map<string, CapitalBudget> = new Map();
+
+/**
+ * Get or create a capital budget for a corp.
+ */
+export function getCapitalBudget(corpId: string): CapitalBudget {
+  let budget = budgetRegistry.get(corpId);
+  if (!budget) {
+    budget = new CapitalBudget(corpId);
+    budgetRegistry.set(corpId, budget);
+  }
+  return budget;
+}
+
+/**
+ * Clear all capital budgets (for testing).
+ */
+export function clearAllBudgets(): void {
+  budgetRegistry.clear();
+}
+
+/**
+ * Get all corps with capital budgets.
+ */
+export function getCorpsWithCapital(): string[] {
+  return Array.from(budgetRegistry.keys()).filter(
+    corpId => budgetRegistry.get(corpId)!.getAvailableCapital() > 0
+  );
+}
+
+/**
+ * Distribute investment capital to recipient corps.
+ * Called by InvestmentPlanner after creating investments.
+ */
+export function distributeInvestmentCapital(
+  investments: InvestmentContract[]
+): void {
+  for (const investment of investments) {
+    const budget = getCapitalBudget(investment.recipientCorpId);
+    budget.addInvestmentCapital(investment);
+  }
+}
+
+/**
+ * Distribute sub-contract capital.
+ * Called when sub-contracts are created.
+ */
+export function distributeSubContractCapital(
+  contracts: SubContract[]
+): void {
+  for (const contract of contracts) {
+    const budget = getCapitalBudget(contract.sellerId);
+    budget.addSubContractCapital(contract);
+  }
+}

--- a/src/market/InvestmentContract.ts
+++ b/src/market/InvestmentContract.ts
@@ -1,0 +1,436 @@
+/**
+ * @fileoverview Investment contracts for forward capital flow.
+ *
+ * The BankCorp model flips the economic flow from "trace backwards from demand"
+ * to "capital flows forward from source."
+ *
+ * Current Model (problematic):
+ *   Upgrader (infinite demand) ← Hauler ← Mining ← Spawning
+ *   └── Mint value appears at the end, traced backwards
+ *
+ * BankCorp Model:
+ *   Bank (source of $)
+ *     ↓ loans $ to upgraders (contract: $X per upgrade point)
+ *   Upgrader (now has $, can buy services)
+ *     ↓ pays haulers for delivered-energy
+ *   Hauler (earns $, pays miners + spawn)
+ *     ↓
+ *   Mining + Spawning (earn $)
+ *
+ * Key benefits:
+ * - Capital flows forward - Bank invests, money cascades down
+ * - Throughput determined by investment - Bank decides how much $ to put in
+ * - ROI tracking is natural - Each corp earns based on actual work
+ * - Investment optimization - Bank can invest MORE in high-ROI chains next cycle
+ *
+ * @module market/InvestmentContract
+ */
+
+import { Position } from "./Offer";
+
+/**
+ * Goal types that the bank can invest in.
+ * These are the terminal value sinks that justify capital investment.
+ */
+export type InvestmentGoalType =
+  | "rcl-progress"    // Controller upgrades
+  | "gcl-progress"    // Global control level
+  | "construction"    // Building structures
+  | "defense";        // Military operations
+
+/**
+ * An investment contract represents capital allocated by the bank to a goal corp.
+ *
+ * The bank commits to pay a rate per unit of output produced.
+ * This gives the goal corp "future earnings" they can use to contract suppliers.
+ */
+export interface InvestmentContract {
+  /** Unique contract identifier */
+  id: string;
+
+  /** Bank/investor corp ID */
+  bankId: string;
+
+  /** Recipient corp ID (upgrader, builder, etc.) */
+  recipientCorpId: string;
+
+  /** Type of goal being invested in */
+  goalType: InvestmentGoalType;
+
+  /** Resource produced by the recipient */
+  resource: string;
+
+  /** Credits paid per unit of output */
+  ratePerUnit: number;
+
+  /** Maximum budget allocated for this contract */
+  maxBudget: number;
+
+  /** Tick when contract was created */
+  createdAt: number;
+
+  /** Duration in ticks (typically one creep lifetime) */
+  duration: number;
+
+  /** Units delivered so far */
+  unitsDelivered: number;
+
+  /** Credits paid so far */
+  creditsPaid: number;
+
+  /** Priority (higher = more important) */
+  priority: number;
+
+  /** Expected ROI based on historical performance */
+  expectedROI: number;
+}
+
+/**
+ * Capital allocation represents contracted future earnings a corp can spend.
+ * When a corp has an investment contract, they have capital to buy services.
+ */
+export interface CapitalAllocation {
+  /** Corp ID that has the capital */
+  corpId: string;
+
+  /** Total capital available (from investment contracts) */
+  totalCapital: number;
+
+  /** Capital already committed to sub-contracts */
+  committedCapital: number;
+
+  /** Available capital (total - committed) */
+  availableCapital: number;
+
+  /** Source investment contract IDs */
+  sourceContracts: string[];
+}
+
+/**
+ * Sub-contract created when a corp with capital buys from a supplier.
+ * This is how capital cascades down the supply chain.
+ */
+export interface SubContract {
+  /** Unique identifier */
+  id: string;
+
+  /** Buyer corp ID (has capital from investment) */
+  buyerId: string;
+
+  /** Seller corp ID (supplier) */
+  sellerId: string;
+
+  /** Resource being purchased */
+  resource: string;
+
+  /** Quantity agreed */
+  quantity: number;
+
+  /** Total price agreed */
+  price: number;
+
+  /** Duration in ticks */
+  duration: number;
+
+  /** Start tick */
+  startTick: number;
+
+  /** Units delivered */
+  delivered: number;
+
+  /** Credits paid */
+  paid: number;
+
+  /** Parent investment contract ID (traces back to bank) */
+  parentInvestmentId: string;
+}
+
+/**
+ * Investment performance tracking for ROI optimization.
+ */
+export interface InvestmentPerformance {
+  /** Investment contract ID */
+  investmentId: string;
+
+  /** Recipient corp ID */
+  recipientCorpId: string;
+
+  /** Goal type */
+  goalType: InvestmentGoalType;
+
+  /** Total credits invested */
+  totalInvested: number;
+
+  /** Total units produced */
+  totalUnitsProduced: number;
+
+  /** Credits per unit (actual cost) */
+  actualCostPerUnit: number;
+
+  /** Expected credits per unit (from rate) */
+  expectedCostPerUnit: number;
+
+  /** ROI = (mintValue - actualCost) / actualCost */
+  roi: number;
+
+  /** Efficiency = actualUnits / expectedUnits */
+  efficiency: number;
+}
+
+/**
+ * Investment decision factors for the bank.
+ */
+export interface InvestmentOpportunity {
+  /** Corp that could receive investment */
+  corpId: string;
+
+  /** Goal type */
+  goalType: InvestmentGoalType;
+
+  /** Position (for distance calculations) */
+  position: Position;
+
+  /** Maximum throughput this corp can handle */
+  maxThroughput: number;
+
+  /** Historical ROI (or estimated if new) */
+  historicalROI: number;
+
+  /** Suggested rate per unit */
+  suggestedRate: number;
+
+  /** Suggested budget */
+  suggestedBudget: number;
+
+  /** Supply chain depth estimate */
+  supplyChainDepth: number;
+}
+
+// =============================================================================
+// Pure Functions
+// =============================================================================
+
+/**
+ * Create a unique investment contract ID.
+ */
+export function createInvestmentId(
+  bankId: string,
+  recipientId: string,
+  tick: number
+): string {
+  return `inv-${bankId.slice(-6)}-${recipientId.slice(-6)}-${tick}`;
+}
+
+/**
+ * Create a new investment contract.
+ */
+export function createInvestmentContract(
+  bankId: string,
+  recipientCorpId: string,
+  goalType: InvestmentGoalType,
+  resource: string,
+  ratePerUnit: number,
+  maxBudget: number,
+  duration: number,
+  tick: number,
+  priority: number = 1,
+  expectedROI: number = 0
+): InvestmentContract {
+  return {
+    id: createInvestmentId(bankId, recipientCorpId, tick),
+    bankId,
+    recipientCorpId,
+    goalType,
+    resource,
+    ratePerUnit,
+    maxBudget,
+    createdAt: tick,
+    duration,
+    unitsDelivered: 0,
+    creditsPaid: 0,
+    priority,
+    expectedROI
+  };
+}
+
+/**
+ * Calculate remaining budget for an investment contract.
+ */
+export function remainingBudget(contract: InvestmentContract): number {
+  return Math.max(0, contract.maxBudget - contract.creditsPaid);
+}
+
+/**
+ * Calculate expected units remaining.
+ */
+export function expectedUnitsRemaining(contract: InvestmentContract): number {
+  const remaining = remainingBudget(contract);
+  return remaining / contract.ratePerUnit;
+}
+
+/**
+ * Check if investment contract is still active.
+ */
+export function isInvestmentActive(
+  contract: InvestmentContract,
+  currentTick: number
+): boolean {
+  const expired = currentTick >= contract.createdAt + contract.duration;
+  const exhausted = contract.creditsPaid >= contract.maxBudget;
+  return !expired && !exhausted;
+}
+
+/**
+ * Record delivery on an investment contract.
+ * Returns the credits to pay the recipient.
+ */
+export function recordInvestmentDelivery(
+  contract: InvestmentContract,
+  units: number
+): number {
+  const remainingBudgetAmount = remainingBudget(contract);
+  const payment = Math.min(units * contract.ratePerUnit, remainingBudgetAmount);
+
+  contract.unitsDelivered += units;
+  contract.creditsPaid += payment;
+
+  return payment;
+}
+
+/**
+ * Create a capital allocation from investment contracts.
+ */
+export function createCapitalAllocation(
+  corpId: string,
+  investments: InvestmentContract[]
+): CapitalAllocation {
+  const sourceContracts = investments.map(i => i.id);
+  const totalCapital = investments.reduce(
+    (sum, i) => sum + remainingBudget(i),
+    0
+  );
+
+  return {
+    corpId,
+    totalCapital,
+    committedCapital: 0,
+    availableCapital: totalCapital,
+    sourceContracts
+  };
+}
+
+/**
+ * Commit capital from an allocation (for sub-contracting).
+ */
+export function commitCapital(
+  allocation: CapitalAllocation,
+  amount: number
+): boolean {
+  if (amount > allocation.availableCapital) {
+    return false;
+  }
+
+  allocation.committedCapital += amount;
+  allocation.availableCapital -= amount;
+  return true;
+}
+
+/**
+ * Create a sub-contract ID.
+ */
+export function createSubContractId(
+  buyerId: string,
+  sellerId: string,
+  tick: number
+): string {
+  return `sub-${buyerId.slice(-6)}-${sellerId.slice(-6)}-${tick}`;
+}
+
+/**
+ * Create a sub-contract.
+ */
+export function createSubContract(
+  buyerId: string,
+  sellerId: string,
+  resource: string,
+  quantity: number,
+  price: number,
+  duration: number,
+  startTick: number,
+  parentInvestmentId: string
+): SubContract {
+  return {
+    id: createSubContractId(buyerId, sellerId, startTick),
+    buyerId,
+    sellerId,
+    resource,
+    quantity,
+    price,
+    duration,
+    startTick,
+    delivered: 0,
+    paid: 0,
+    parentInvestmentId
+  };
+}
+
+/**
+ * Calculate investment performance metrics.
+ */
+export function calculatePerformance(
+  contract: InvestmentContract,
+  mintValuePerUnit: number
+): InvestmentPerformance {
+  const actualCostPerUnit = contract.unitsDelivered > 0
+    ? contract.creditsPaid / contract.unitsDelivered
+    : Infinity;
+
+  const roi = contract.creditsPaid > 0
+    ? (mintValuePerUnit * contract.unitsDelivered - contract.creditsPaid) / contract.creditsPaid
+    : 0;
+
+  const expectedUnits = contract.maxBudget / contract.ratePerUnit;
+  const efficiency = expectedUnits > 0
+    ? contract.unitsDelivered / expectedUnits
+    : 0;
+
+  return {
+    investmentId: contract.id,
+    recipientCorpId: contract.recipientCorpId,
+    goalType: contract.goalType,
+    totalInvested: contract.creditsPaid,
+    totalUnitsProduced: contract.unitsDelivered,
+    actualCostPerUnit,
+    expectedCostPerUnit: contract.ratePerUnit,
+    roi,
+    efficiency
+  };
+}
+
+/**
+ * Suggest investment rate based on supply chain costs.
+ *
+ * The rate should be high enough to cover:
+ * - Direct supplier costs (energy, labor)
+ * - Margins for each supplier in the chain
+ * - Some buffer for inefficiency
+ *
+ * @param mintValuePerUnit - Credits minted when unit is produced
+ * @param estimatedSupplyChainCost - Estimated total cost to produce
+ * @param targetROI - Desired return on investment (e.g., 0.1 for 10%)
+ */
+export function suggestInvestmentRate(
+  mintValuePerUnit: number,
+  estimatedSupplyChainCost: number,
+  targetROI: number = 0.1
+): number {
+  // Rate should allow supplier costs + target ROI
+  // rate = cost / (1 - targetROI) would give exact target
+  // But we want room for error, so use more conservative formula
+  const minRate = estimatedSupplyChainCost * 1.1; // 10% buffer for costs
+  const maxRate = mintValuePerUnit * (1 - targetROI); // Leave targetROI for bank
+
+  // Use the higher of minRate or lower of maxRate
+  // This ensures suppliers can be paid while bank gets return
+  return Math.max(minRate, Math.min(maxRate, mintValuePerUnit * 0.8));
+}

--- a/src/orchestration/InvestmentPhase.ts
+++ b/src/orchestration/InvestmentPhase.ts
@@ -1,0 +1,284 @@
+/**
+ * @fileoverview Investment phase for forward capital flow.
+ *
+ * This module integrates the BankCorp investment model with the existing
+ * orchestration phases. It runs before the standard planning phase to:
+ *
+ * 1. Allocate capital from treasury to investment contracts
+ * 2. Distribute capital to recipient corps
+ * 3. Enable capital-aware projections for planning
+ *
+ * The investment phase is OPTIONAL and works alongside the existing
+ * backward-tracing chain planner. When investments are active, corps
+ * use capital-aware projections that limit demand based on available capital.
+ *
+ * @module orchestration/InvestmentPhase
+ */
+
+import { Colony } from "../colony/Colony";
+import { CorpRegistry } from "../execution/CorpRunner";
+import { AnyCorpState } from "../corps/CorpState";
+import {
+  InvestmentPlanner,
+  createInvestmentPlanner,
+  InvestmentPlanResult,
+  CapitalChain
+} from "../planning/InvestmentPlanner";
+import {
+  InvestmentContract,
+  InvestmentPerformance,
+  calculatePerformance
+} from "../market/InvestmentContract";
+import {
+  distributeInvestmentCapital,
+  distributeSubContractCapital,
+  clearAllBudgets,
+  getCapitalBudget
+} from "../market/CapitalBudget";
+import { getMintValue } from "../colony/MintValues";
+
+/**
+ * Result of the investment phase.
+ */
+export interface InvestmentPhaseResult {
+  /** Investment contracts created */
+  investments: InvestmentContract[];
+  /** Capital chains built */
+  chains: CapitalChain[];
+  /** Total budget allocated */
+  totalBudgetAllocated: number;
+  /** Corps that received capital */
+  corpsWithCapital: number;
+}
+
+/**
+ * Investment phase state - persisted across ticks.
+ */
+export interface InvestmentState {
+  /** Active investment contracts */
+  activeInvestments: InvestmentContract[];
+  /** Performance history for ROI tracking */
+  performanceHistory: InvestmentPerformance[];
+  /** Last tick investments were refreshed */
+  lastInvestmentTick: number;
+}
+
+// Singleton investment planner
+let investmentPlanner: InvestmentPlanner | null = null;
+
+// In-memory state (could be persisted to Memory if needed)
+let investmentState: InvestmentState = {
+  activeInvestments: [],
+  performanceHistory: [],
+  lastInvestmentTick: 0
+};
+
+/**
+ * Get or create the investment planner.
+ */
+export function getInvestmentPlanner(colony: Colony): InvestmentPlanner {
+  if (!investmentPlanner) {
+    investmentPlanner = createInvestmentPlanner(colony.getMintValues());
+  }
+  return investmentPlanner;
+}
+
+/**
+ * Check if investments should be refreshed.
+ * Investments refresh alongside the standard planning interval.
+ */
+export function shouldRefreshInvestments(tick: number, planningInterval: number): boolean {
+  return tick % planningInterval === 0;
+}
+
+/**
+ * Run the investment phase.
+ *
+ * This runs BEFORE standard planning to:
+ * 1. Calculate how much budget to invest
+ * 2. Create investment contracts for goal corps
+ * 3. Distribute capital to recipients
+ * 4. Build capital chains through supply network
+ *
+ * @param corps - Corp registry
+ * @param colony - Colony for treasury access
+ * @param tick - Current game tick
+ * @returns Investment phase result
+ */
+export function runInvestmentPhase(
+  corps: CorpRegistry,
+  colony: Colony,
+  tick: number
+): InvestmentPhaseResult {
+  console.log(`[Investment] Running investment phase at tick ${tick}`);
+
+  // Get planner
+  const planner = getInvestmentPlanner(colony);
+
+  // Clear any stale capital budgets
+  clearAllBudgets();
+
+  // Collect corp states for planning
+  const corpStates = collectCorpStates(corps);
+  planner.registerCorpStates(corpStates, tick);
+
+  // Calculate investment budget from treasury
+  // Use a portion of treasury for investments
+  const treasury = colony.treasury;
+  const investmentBudget = calculateInvestmentBudget(treasury);
+
+  console.log(`[Investment] Treasury: ${treasury.toFixed(0)}, Investment budget: ${investmentBudget.toFixed(0)}`);
+
+  // Run investment planning
+  const planResult = planner.plan(investmentBudget, tick);
+
+  // Distribute capital to recipient corps
+  distributeInvestmentCapital(planResult.investments);
+  distributeSubContractCapital(planResult.subContracts);
+
+  // Track state
+  investmentState.activeInvestments = planner.getActiveInvestments();
+  investmentState.lastInvestmentTick = tick;
+
+  // Count corps that received capital
+  let corpsWithCapital = 0;
+  for (const state of corpStates) {
+    if (getCapitalBudget(state.id).getAvailableCapital() > 0) {
+      corpsWithCapital++;
+    }
+  }
+
+  console.log(`[Investment] Created ${planResult.investments.length} investments, ${corpsWithCapital} corps received capital`);
+
+  return {
+    investments: planResult.investments,
+    chains: planResult.chains,
+    totalBudgetAllocated: planResult.totalBudget,
+    corpsWithCapital
+  };
+}
+
+/**
+ * Calculate how much of the treasury to invest.
+ *
+ * Investment strategy:
+ * - Keep a buffer for operational costs
+ * - Invest remaining capital for growth
+ */
+function calculateInvestmentBudget(treasury: number): number {
+  // Keep 20% as operational buffer
+  const bufferRatio = 0.2;
+  const buffer = Math.max(1000, treasury * bufferRatio);
+
+  // Invest the rest
+  return Math.max(0, treasury - buffer);
+}
+
+/**
+ * Collect corp states from all corps in the registry.
+ */
+function collectCorpStates(corps: CorpRegistry): AnyCorpState[] {
+  const states: AnyCorpState[] = [];
+
+  // Spawning corps
+  for (const spawnId in corps.spawningCorps) {
+    states.push(corps.spawningCorps[spawnId].toCorpState());
+  }
+
+  // Mining corps
+  for (const sourceId in corps.miningCorps) {
+    states.push(corps.miningCorps[sourceId].toCorpState());
+  }
+
+  // Hauling corps
+  for (const roomName in corps.haulingCorps) {
+    states.push(corps.haulingCorps[roomName].toCorpState());
+  }
+
+  // Upgrading corps
+  for (const roomName in corps.upgradingCorps) {
+    states.push(corps.upgradingCorps[roomName].toCorpState());
+  }
+
+  return states;
+}
+
+/**
+ * Record delivery against an investment.
+ * Called when a goal corp produces output.
+ */
+export function recordInvestmentDelivery(
+  corpId: string,
+  units: number,
+  colony: Colony
+): number {
+  const planner = getInvestmentPlanner(colony);
+  const investment = planner.getInvestmentForCorp(corpId);
+
+  if (!investment) {
+    return 0; // No investment for this corp
+  }
+
+  const payment = planner.recordDelivery(investment.id, units);
+
+  // Record performance for ROI tracking
+  const mintValue = getMintValue(colony.getMintValues(), getMintKeyForResource(investment.resource));
+  const performance = calculatePerformance(investment, mintValue);
+  planner.recordPerformance(performance);
+
+  return payment;
+}
+
+/**
+ * Map resource to mint value key.
+ */
+function getMintKeyForResource(resource: string): keyof ReturnType<Colony["getMintValues"]> {
+  switch (resource) {
+    case "rcl-progress":
+      return "rcl_upgrade";
+    case "gcl-progress":
+      return "gcl_upgrade";
+    default:
+      return "rcl_upgrade";
+  }
+}
+
+/**
+ * Get available capital for a corp.
+ */
+export function getCorpCapital(corpId: string): number {
+  return getCapitalBudget(corpId).getAvailableCapital();
+}
+
+/**
+ * Get investment state for debugging.
+ */
+export function getInvestmentState(): InvestmentState {
+  return { ...investmentState };
+}
+
+/**
+ * Get investment summary for display.
+ */
+export function getInvestmentSummary(colony: Colony): {
+  activeInvestments: number;
+  totalDeployed: number;
+  totalReturns: number;
+  averageROI: number;
+} {
+  const planner = getInvestmentPlanner(colony);
+  return planner.getPortfolioSummary();
+}
+
+/**
+ * Reset investment state (for testing).
+ */
+export function resetInvestmentState(): void {
+  investmentPlanner = null;
+  investmentState = {
+    activeInvestments: [],
+    performanceHistory: [],
+    lastInvestmentTick: 0
+  };
+  clearAllBudgets();
+}

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -4,6 +4,7 @@
  * This module contains the phased orchestration logic:
  * - Init phase (once per code push, lazy initialization)
  * - Survey phase (when nodes are created)
+ * - Investment phase (allocates capital before planning)
  * - Planning phase (every 5000 ticks)
  * - Execution phase (every tick)
  *
@@ -38,3 +39,16 @@ export {
   getLastPlanningTick,
   setLastPlanningTick,
 } from "./Phases";
+
+export {
+  // Investment phase (forward capital flow)
+  runInvestmentPhase,
+  shouldRefreshInvestments,
+  recordInvestmentDelivery,
+  getCorpCapital,
+  getInvestmentSummary,
+  getInvestmentState,
+  resetInvestmentState,
+  InvestmentPhaseResult,
+  InvestmentState,
+} from "./InvestmentPhase";

--- a/src/planning/InvestmentPlanner.ts
+++ b/src/planning/InvestmentPlanner.ts
@@ -1,0 +1,802 @@
+/**
+ * @fileoverview InvestmentPlanner - Forward capital flow planning.
+ *
+ * This planner implements the BankCorp model where capital flows forward
+ * from investment to production, rather than tracing backwards from demand.
+ *
+ * Planning Flow:
+ * 1. Survey: Bank identifies investment opportunities (goals)
+ * 2. Allocate: Bank creates investment contracts with budget
+ * 3. Cascade: Corps with capital contract suppliers
+ * 4. Execute: Work is performed, money flows to workers
+ *
+ * @module planning/InvestmentPlanner
+ */
+
+import { Position } from "../market/Offer";
+import { AnyCorpState, getCorpPosition as getStatePosition } from "../corps/CorpState";
+import { calculateMargin } from "../corps/Corp";
+import { getMintValue, MintValues } from "../colony/MintValues";
+import { project, CorpProjection } from "./projections";
+import {
+  InvestmentContract,
+  InvestmentOpportunity,
+  InvestmentGoalType,
+  CapitalAllocation,
+  SubContract,
+  InvestmentPerformance,
+  createInvestmentContract,
+  createCapitalAllocation,
+  commitCapital,
+  createSubContract,
+  remainingBudget,
+  isInvestmentActive,
+  suggestInvestmentRate
+} from "../market/InvestmentContract";
+
+/**
+ * Supply chain segment representing one step in the capital cascade.
+ */
+export interface CapitalChainSegment {
+  /** Corp ID */
+  corpId: string;
+
+  /** Corp type */
+  corpType: string;
+
+  /** Resource produced */
+  resource: string;
+
+  /** Quantity contracted */
+  quantity: number;
+
+  /** Capital received (from buyer) */
+  capitalReceived: number;
+
+  /** Capital spent (to suppliers) */
+  capitalSpent: number;
+
+  /** Margin earned */
+  marginEarned: number;
+}
+
+/**
+ * Complete capital chain from investment to raw production.
+ */
+export interface CapitalChain {
+  /** Unique chain ID */
+  id: string;
+
+  /** Investment contract that funds this chain */
+  investmentId: string;
+
+  /** Segments from goal corp down to source */
+  segments: CapitalChainSegment[];
+
+  /** Total capital allocated */
+  totalCapital: number;
+
+  /** Expected output */
+  expectedOutput: number;
+
+  /** Expected mint value */
+  expectedMintValue: number;
+
+  /** Expected ROI */
+  expectedROI: number;
+}
+
+/**
+ * Investment portfolio - all current investments and their performance.
+ */
+export interface InvestmentPortfolio {
+  /** Active investment contracts */
+  activeInvestments: InvestmentContract[];
+
+  /** Capital chains being executed */
+  activeChains: CapitalChain[];
+
+  /** Historical performance by goal type */
+  performanceByGoalType: Map<InvestmentGoalType, InvestmentPerformance[]>;
+
+  /** Total capital deployed */
+  totalDeployed: number;
+
+  /** Total returns (mint value) */
+  totalReturns: number;
+
+  /** Portfolio ROI */
+  portfolioROI: number;
+}
+
+/**
+ * Result of the investment planning phase.
+ */
+export interface InvestmentPlanResult {
+  /** Investment contracts created */
+  investments: InvestmentContract[];
+
+  /** Capital chains built */
+  chains: CapitalChain[];
+
+  /** Sub-contracts created for the supply chain */
+  subContracts: SubContract[];
+
+  /** Total budget allocated */
+  totalBudget: number;
+
+  /** Unallocated budget (if any) */
+  remainingBudget: number;
+}
+
+/**
+ * InvestmentPlanner implements forward capital flow.
+ *
+ * Instead of tracing backwards from unlimited demand, this planner:
+ * 1. Takes a budget from the treasury
+ * 2. Identifies goal corps (upgraders, builders)
+ * 3. Creates investment contracts allocating capital to goals
+ * 4. Each goal corp then has capital to contract suppliers
+ * 5. Capital cascades down the supply chain
+ */
+export class InvestmentPlanner {
+  /** Registered corp states */
+  private corpStates: Map<string, AnyCorpState> = new Map();
+
+  /** Cached projections */
+  private projectionCache: Map<string, CorpProjection> = new Map();
+
+  /** Mint values for calculating ROI */
+  private mintValues: MintValues;
+
+  /** Current tick */
+  private currentTick: number = 0;
+
+  /** Historical performance for ROI optimization */
+  private performanceHistory: InvestmentPerformance[] = [];
+
+  /** Active investment contracts */
+  private activeInvestments: InvestmentContract[] = [];
+
+  /** Active sub-contracts */
+  private activeSubContracts: SubContract[] = [];
+
+  constructor(mintValues: MintValues) {
+    this.mintValues = mintValues;
+  }
+
+  /**
+   * Register corp states for planning.
+   */
+  registerCorpStates(states: AnyCorpState[], tick: number): void {
+    this.corpStates.clear();
+    this.projectionCache.clear();
+    this.currentTick = tick;
+
+    for (const state of states) {
+      this.corpStates.set(state.id, state);
+    }
+  }
+
+  /**
+   * Get projection for a corp (cached).
+   */
+  private getProjection(corpId: string): CorpProjection | null {
+    const cached = this.projectionCache.get(corpId);
+    if (cached) return cached;
+
+    const state = this.corpStates.get(corpId);
+    if (!state) return null;
+
+    const projection = project(state, this.currentTick);
+    this.projectionCache.set(corpId, projection);
+    return projection;
+  }
+
+  /**
+   * Main planning entry point: allocate budget to investments.
+   *
+   * @param budget - Total credits available for investment
+   * @param tick - Current game tick
+   * @returns Investment plan with contracts and chains
+   */
+  plan(budget: number, tick: number): InvestmentPlanResult {
+    this.currentTick = tick;
+
+    // Clean up expired investments and contracts
+    this.pruneExpired(tick);
+
+    // 1. Find investment opportunities (goal corps)
+    const opportunities = this.findOpportunities();
+
+    // 2. Rank opportunities by expected ROI
+    const rankedOpportunities = this.rankByROI(opportunities);
+
+    // 3. Allocate budget to opportunities
+    const { investments, remainingBudget: budgetLeft } = this.allocateBudget(
+      rankedOpportunities,
+      budget,
+      tick
+    );
+
+    // 4. Build capital chains for each investment
+    const chains: CapitalChain[] = [];
+    const subContracts: SubContract[] = [];
+
+    for (const investment of investments) {
+      const chainResult = this.buildCapitalChain(investment, tick);
+      if (chainResult) {
+        chains.push(chainResult.chain);
+        subContracts.push(...chainResult.subContracts);
+      }
+    }
+
+    // Store active investments
+    this.activeInvestments.push(...investments);
+    this.activeSubContracts.push(...subContracts);
+
+    return {
+      investments,
+      chains,
+      subContracts,
+      totalBudget: budget - budgetLeft,
+      remainingBudget: budgetLeft
+    };
+  }
+
+  /**
+   * Find investment opportunities (goal corps that mint value).
+   */
+  private findOpportunities(): InvestmentOpportunity[] {
+    const opportunities: InvestmentOpportunity[] = [];
+
+    for (const [corpId, state] of this.corpStates) {
+      // Only upgrading and building corps are investment targets
+      if (state.type !== "upgrading" && state.type !== "building") {
+        continue;
+      }
+
+      const projection = this.getProjection(corpId);
+      if (!projection) continue;
+
+      // Find sell offers for mintable resources
+      for (const offer of projection.sells) {
+        const goalType = this.resourceToGoalType(offer.resource);
+        if (!goalType) continue;
+
+        const position = getStatePosition(state);
+        if (!position) continue;
+
+        // Estimate supply chain cost
+        const supplyChainCost = this.estimateSupplyChainCost(corpId);
+        const mintValuePerUnit = this.getMintValueForResource(offer.resource);
+
+        // Calculate historical or estimated ROI
+        const historicalROI = this.getHistoricalROI(corpId, goalType);
+
+        opportunities.push({
+          corpId,
+          goalType,
+          position,
+          maxThroughput: offer.quantity,
+          historicalROI,
+          suggestedRate: suggestInvestmentRate(mintValuePerUnit, supplyChainCost),
+          suggestedBudget: offer.quantity * suggestInvestmentRate(mintValuePerUnit, supplyChainCost),
+          supplyChainDepth: this.estimateSupplyChainDepth(corpId)
+        });
+      }
+    }
+
+    return opportunities;
+  }
+
+  /**
+   * Convert resource type to goal type.
+   */
+  private resourceToGoalType(resource: string): InvestmentGoalType | null {
+    switch (resource) {
+      case "rcl-progress":
+        return "rcl-progress";
+      case "gcl-progress":
+        return "gcl-progress";
+      case "construction-progress":
+        return "construction";
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Get mint value for a resource type.
+   */
+  private getMintValueForResource(resource: string): number {
+    switch (resource) {
+      case "rcl-progress":
+        return getMintValue(this.mintValues, "rcl_upgrade");
+      case "gcl-progress":
+        return getMintValue(this.mintValues, "gcl_upgrade");
+      default:
+        return 0;
+    }
+  }
+
+  /**
+   * Get historical ROI for a corp/goal type combination.
+   */
+  private getHistoricalROI(corpId: string, goalType: InvestmentGoalType): number {
+    const history = this.performanceHistory.filter(
+      p => p.recipientCorpId === corpId && p.goalType === goalType
+    );
+
+    if (history.length === 0) {
+      // No history - use default estimate
+      return 0.2; // 20% expected ROI
+    }
+
+    // Weight recent performance more heavily
+    let weightedROI = 0;
+    let totalWeight = 0;
+    for (let i = 0; i < history.length; i++) {
+      const weight = i + 1; // More recent = higher weight
+      weightedROI += history[i].roi * weight;
+      totalWeight += weight;
+    }
+
+    return weightedROI / totalWeight;
+  }
+
+  /**
+   * Estimate supply chain cost for a goal corp.
+   * Traces what the corp needs and sums supplier prices.
+   */
+  private estimateSupplyChainCost(goalCorpId: string): number {
+    const projection = this.getProjection(goalCorpId);
+    if (!projection) return Infinity;
+
+    let totalCost = 0;
+
+    for (const buyOffer of projection.buys) {
+      // Find cheapest supplier for this resource
+      const supplierCost = this.findCheapestSupplier(buyOffer.resource, buyOffer.quantity);
+      totalCost += supplierCost;
+    }
+
+    return totalCost;
+  }
+
+  /**
+   * Find cheapest supplier for a resource.
+   */
+  private findCheapestSupplier(resource: string, quantity: number): number {
+    let cheapestCost = Infinity;
+
+    for (const [corpId, state] of this.corpStates) {
+      const projection = this.getProjection(corpId);
+      if (!projection) continue;
+
+      for (const offer of projection.sells) {
+        if (offer.resource !== resource) continue;
+        if (offer.quantity < quantity) continue;
+
+        const pricePerUnit = offer.price / offer.quantity;
+        const totalCost = pricePerUnit * quantity;
+
+        if (totalCost < cheapestCost) {
+          cheapestCost = totalCost;
+        }
+      }
+    }
+
+    return cheapestCost === Infinity ? quantity : cheapestCost;
+  }
+
+  /**
+   * Estimate supply chain depth for prioritization.
+   */
+  private estimateSupplyChainDepth(goalCorpId: string): number {
+    const visited = new Set<string>();
+    return this.traceDepth(goalCorpId, visited);
+  }
+
+  private traceDepth(corpId: string, visited: Set<string>): number {
+    if (visited.has(corpId)) return 0;
+    visited.add(corpId);
+
+    const projection = this.getProjection(corpId);
+    if (!projection || projection.buys.length === 0) {
+      return 1; // Leaf node
+    }
+
+    let maxChildDepth = 0;
+    for (const buyOffer of projection.buys) {
+      // Find a supplier and trace their depth
+      for (const [supplierId, _] of this.corpStates) {
+        const supplierProjection = this.getProjection(supplierId);
+        if (!supplierProjection) continue;
+
+        const hasResource = supplierProjection.sells.some(
+          s => s.resource === buyOffer.resource
+        );
+        if (hasResource) {
+          const childDepth = this.traceDepth(supplierId, visited);
+          maxChildDepth = Math.max(maxChildDepth, childDepth);
+        }
+      }
+    }
+
+    return 1 + maxChildDepth;
+  }
+
+  /**
+   * Rank opportunities by expected ROI.
+   */
+  private rankByROI(opportunities: InvestmentOpportunity[]): InvestmentOpportunity[] {
+    return [...opportunities].sort((a, b) => b.historicalROI - a.historicalROI);
+  }
+
+  /**
+   * Allocate budget to opportunities.
+   */
+  private allocateBudget(
+    opportunities: InvestmentOpportunity[],
+    budget: number,
+    tick: number
+  ): { investments: InvestmentContract[]; remainingBudget: number } {
+    const investments: InvestmentContract[] = [];
+    let remaining = budget;
+
+    for (const opportunity of opportunities) {
+      if (remaining <= 0) break;
+
+      // Allocate up to suggested budget or remaining, whichever is smaller
+      const allocation = Math.min(opportunity.suggestedBudget, remaining);
+
+      if (allocation < 100) {
+        // Minimum investment threshold
+        continue;
+      }
+
+      const investment = createInvestmentContract(
+        "bank", // Bank ID
+        opportunity.corpId,
+        opportunity.goalType,
+        this.goalTypeToResource(opportunity.goalType),
+        opportunity.suggestedRate,
+        allocation,
+        1500, // One creep lifetime
+        tick,
+        1, // Priority
+        opportunity.historicalROI
+      );
+
+      investments.push(investment);
+      remaining -= allocation;
+    }
+
+    return { investments, remainingBudget: remaining };
+  }
+
+  /**
+   * Convert goal type to resource.
+   */
+  private goalTypeToResource(goalType: InvestmentGoalType): string {
+    switch (goalType) {
+      case "rcl-progress":
+        return "rcl-progress";
+      case "gcl-progress":
+        return "gcl-progress";
+      case "construction":
+        return "construction-progress";
+      case "defense":
+        return "defense-value";
+    }
+  }
+
+  /**
+   * Build a capital chain for an investment.
+   * This cascades capital down through the supply chain.
+   */
+  private buildCapitalChain(
+    investment: InvestmentContract,
+    tick: number
+  ): { chain: CapitalChain; subContracts: SubContract[] } | null {
+    const recipientState = this.corpStates.get(investment.recipientCorpId);
+    if (!recipientState) return null;
+
+    const segments: CapitalChainSegment[] = [];
+    const subContracts: SubContract[] = [];
+
+    // Create capital allocation for the recipient
+    const allocation = createCapitalAllocation(investment.recipientCorpId, [investment]);
+
+    // Build the chain recursively
+    const result = this.cascadeCapital(
+      investment.recipientCorpId,
+      allocation,
+      investment.id,
+      tick,
+      new Set<string>()
+    );
+
+    if (!result.success) return null;
+
+    segments.push(...result.segments);
+    subContracts.push(...result.subContracts);
+
+    // Calculate expected output and ROI
+    const expectedOutput = investment.maxBudget / investment.ratePerUnit;
+    const mintValuePerUnit = this.getMintValueForResource(investment.resource);
+    const expectedMintValue = expectedOutput * mintValuePerUnit;
+    const expectedROI = investment.maxBudget > 0
+      ? (expectedMintValue - investment.maxBudget) / investment.maxBudget
+      : 0;
+
+    const chain: CapitalChain = {
+      id: `chain-${investment.id}`,
+      investmentId: investment.id,
+      segments,
+      totalCapital: investment.maxBudget,
+      expectedOutput,
+      expectedMintValue,
+      expectedROI
+    };
+
+    return { chain, subContracts };
+  }
+
+  /**
+   * Cascade capital down through suppliers.
+   */
+  private cascadeCapital(
+    corpId: string,
+    allocation: CapitalAllocation,
+    investmentId: string,
+    tick: number,
+    visited: Set<string>
+  ): {
+    success: boolean;
+    segments: CapitalChainSegment[];
+    subContracts: SubContract[];
+  } {
+    if (visited.has(corpId)) {
+      return { success: false, segments: [], subContracts: [] };
+    }
+    visited.add(corpId);
+
+    const state = this.corpStates.get(corpId);
+    if (!state) {
+      return { success: false, segments: [], subContracts: [] };
+    }
+
+    const projection = this.getProjection(corpId);
+    if (!projection) {
+      return { success: false, segments: [], subContracts: [] };
+    }
+
+    const segments: CapitalChainSegment[] = [];
+    const subContracts: SubContract[] = [];
+
+    // Calculate how much capital this corp needs for its suppliers
+    let capitalSpent = 0;
+
+    for (const buyOffer of projection.buys) {
+      // Find a supplier
+      const supplier = this.findBestSupplier(buyOffer.resource, buyOffer.quantity);
+      if (!supplier) continue;
+
+      // Check if we have enough capital
+      if (!commitCapital(allocation, supplier.cost)) {
+        // Not enough capital - scale down
+        const scaleFactor = allocation.availableCapital / supplier.cost;
+        if (scaleFactor < 0.1) continue; // Too little to be useful
+
+        supplier.quantity *= scaleFactor;
+        supplier.cost *= scaleFactor;
+        commitCapital(allocation, supplier.cost);
+      }
+
+      // Create sub-contract
+      const subContract = createSubContract(
+        corpId,
+        supplier.corpId,
+        buyOffer.resource,
+        supplier.quantity,
+        supplier.cost,
+        1500,
+        tick,
+        investmentId
+      );
+      subContracts.push(subContract);
+
+      // Create allocation for supplier
+      const supplierAllocation = createCapitalAllocation(supplier.corpId, []);
+      supplierAllocation.totalCapital = supplier.cost;
+      supplierAllocation.availableCapital = supplier.cost;
+
+      // Recurse to supplier
+      const supplierResult = this.cascadeCapital(
+        supplier.corpId,
+        supplierAllocation,
+        investmentId,
+        tick,
+        visited
+      );
+
+      if (supplierResult.success) {
+        segments.push(...supplierResult.segments);
+        subContracts.push(...supplierResult.subContracts);
+      }
+
+      capitalSpent += supplier.cost;
+    }
+
+    // Add segment for this corp
+    const margin = calculateMargin(state.balance);
+    const capitalReceived = allocation.totalCapital;
+    const marginEarned = capitalReceived - capitalSpent;
+
+    // Determine output resource from sells
+    const sellResource = projection.sells.length > 0
+      ? projection.sells[0].resource
+      : "unknown";
+    const quantity = projection.sells.length > 0
+      ? projection.sells[0].quantity
+      : 0;
+
+    segments.push({
+      corpId,
+      corpType: state.type,
+      resource: sellResource,
+      quantity,
+      capitalReceived,
+      capitalSpent,
+      marginEarned
+    });
+
+    return { success: true, segments, subContracts };
+  }
+
+  /**
+   * Find best supplier for a resource.
+   */
+  private findBestSupplier(
+    resource: string,
+    quantity: number
+  ): { corpId: string; quantity: number; cost: number } | null {
+    let best: { corpId: string; quantity: number; cost: number } | null = null;
+    let bestPricePerUnit = Infinity;
+
+    for (const [corpId, _] of this.corpStates) {
+      const projection = this.getProjection(corpId);
+      if (!projection) continue;
+
+      for (const offer of projection.sells) {
+        if (offer.resource !== resource) continue;
+
+        const pricePerUnit = offer.quantity > 0 ? offer.price / offer.quantity : Infinity;
+        if (pricePerUnit < bestPricePerUnit) {
+          bestPricePerUnit = pricePerUnit;
+          const availableQty = Math.min(offer.quantity, quantity);
+          best = {
+            corpId,
+            quantity: availableQty,
+            cost: pricePerUnit * availableQty
+          };
+        }
+      }
+    }
+
+    return best;
+  }
+
+  /**
+   * Prune expired investments and contracts.
+   */
+  private pruneExpired(tick: number): void {
+    this.activeInvestments = this.activeInvestments.filter(
+      i => isInvestmentActive(i, tick)
+    );
+
+    this.activeSubContracts = this.activeSubContracts.filter(
+      c => tick < c.startTick + c.duration
+    );
+  }
+
+  /**
+   * Record delivery on an investment (called when work is done).
+   */
+  recordDelivery(investmentId: string, units: number): number {
+    const investment = this.activeInvestments.find(i => i.id === investmentId);
+    if (!investment) return 0;
+
+    const remaining = remainingBudget(investment);
+    const payment = Math.min(units * investment.ratePerUnit, remaining);
+
+    investment.unitsDelivered += units;
+    investment.creditsPaid += payment;
+
+    return payment;
+  }
+
+  /**
+   * Get active investments.
+   */
+  getActiveInvestments(): InvestmentContract[] {
+    return [...this.activeInvestments];
+  }
+
+  /**
+   * Get active sub-contracts.
+   */
+  getActiveSubContracts(): SubContract[] {
+    return [...this.activeSubContracts];
+  }
+
+  /**
+   * Get investment by recipient corp ID.
+   */
+  getInvestmentForCorp(corpId: string): InvestmentContract | undefined {
+    return this.activeInvestments.find(
+      i => i.recipientCorpId === corpId && remainingBudget(i) > 0
+    );
+  }
+
+  /**
+   * Get capital available to a corp from active investments.
+   */
+  getAvailableCapital(corpId: string): number {
+    const investment = this.getInvestmentForCorp(corpId);
+    if (!investment) return 0;
+    return remainingBudget(investment);
+  }
+
+  /**
+   * Record performance for ROI tracking.
+   */
+  recordPerformance(performance: InvestmentPerformance): void {
+    this.performanceHistory.push(performance);
+
+    // Keep history bounded
+    if (this.performanceHistory.length > 100) {
+      this.performanceHistory.shift();
+    }
+  }
+
+  /**
+   * Get portfolio summary.
+   */
+  getPortfolioSummary(): {
+    totalDeployed: number;
+    totalReturns: number;
+    activeInvestments: number;
+    averageROI: number;
+  } {
+    const totalDeployed = this.activeInvestments.reduce(
+      (sum, i) => sum + i.creditsPaid,
+      0
+    );
+
+    const totalReturns = this.activeInvestments.reduce((sum, i) => {
+      const mintValue = this.getMintValueForResource(i.resource);
+      return sum + i.unitsDelivered * mintValue;
+    }, 0);
+
+    const averageROI = totalDeployed > 0
+      ? (totalReturns - totalDeployed) / totalDeployed
+      : 0;
+
+    return {
+      totalDeployed,
+      totalReturns,
+      activeInvestments: this.activeInvestments.length,
+      averageROI
+    };
+  }
+}
+
+/**
+ * Create an investment planner instance.
+ */
+export function createInvestmentPlanner(mintValues: MintValues): InvestmentPlanner {
+  return new InvestmentPlanner(mintValues);
+}

--- a/test/unit/market/Contract.test.ts
+++ b/test/unit/market/Contract.test.ts
@@ -30,6 +30,7 @@ describe("Contract", () => {
     startTick: 0,
     delivered: 0,
     paid: 0,
+    creepIds: [],
     ...overrides
   });
 

--- a/test/unit/market/InvestmentContract.test.ts
+++ b/test/unit/market/InvestmentContract.test.ts
@@ -1,0 +1,301 @@
+import { expect } from "chai";
+import {
+  InvestmentContract,
+  InvestmentGoalType,
+  createInvestmentContract,
+  createInvestmentId,
+  remainingBudget,
+  expectedUnitsRemaining,
+  isInvestmentActive,
+  recordInvestmentDelivery,
+  createCapitalAllocation,
+  commitCapital,
+  createSubContract,
+  calculatePerformance,
+  suggestInvestmentRate
+} from "../../../src/market/InvestmentContract";
+
+describe("InvestmentContract", () => {
+  const createTestInvestment = (overrides: Partial<InvestmentContract> = {}): InvestmentContract => ({
+    id: "inv-test-001",
+    bankId: "bank-001",
+    recipientCorpId: "upgrading-room1",
+    goalType: "rcl-progress" as InvestmentGoalType,
+    resource: "rcl-progress",
+    ratePerUnit: 10,
+    maxBudget: 1000,
+    createdAt: 0,
+    duration: 1500,
+    unitsDelivered: 0,
+    creditsPaid: 0,
+    priority: 1,
+    expectedROI: 0.2,
+    ...overrides
+  });
+
+  describe("createInvestmentId()", () => {
+    it("should create unique ID from bank, recipient, and tick", () => {
+      const id = createInvestmentId("bank-001", "upgrading-room1", 1000);
+      expect(id).to.include("inv-");
+      expect(id).to.include("1000");
+    });
+  });
+
+  describe("createInvestmentContract()", () => {
+    it("should create contract with correct values", () => {
+      const contract = createInvestmentContract(
+        "bank-001",
+        "upgrading-room1",
+        "rcl-progress",
+        "rcl-progress",
+        10,
+        1000,
+        1500,
+        0,
+        1,
+        0.2
+      );
+
+      expect(contract.bankId).to.equal("bank-001");
+      expect(contract.recipientCorpId).to.equal("upgrading-room1");
+      expect(contract.ratePerUnit).to.equal(10);
+      expect(contract.maxBudget).to.equal(1000);
+      expect(contract.duration).to.equal(1500);
+      expect(contract.unitsDelivered).to.equal(0);
+      expect(contract.creditsPaid).to.equal(0);
+    });
+  });
+
+  describe("remainingBudget()", () => {
+    it("should return full budget when nothing paid", () => {
+      const investment = createTestInvestment();
+      expect(remainingBudget(investment)).to.equal(1000);
+    });
+
+    it("should return remaining after partial payment", () => {
+      const investment = createTestInvestment({ creditsPaid: 300 });
+      expect(remainingBudget(investment)).to.equal(700);
+    });
+
+    it("should return 0 when fully paid", () => {
+      const investment = createTestInvestment({ creditsPaid: 1000 });
+      expect(remainingBudget(investment)).to.equal(0);
+    });
+  });
+
+  describe("expectedUnitsRemaining()", () => {
+    it("should calculate expected units from budget and rate", () => {
+      const investment = createTestInvestment();
+      // 1000 budget / 10 per unit = 100 units
+      expect(expectedUnitsRemaining(investment)).to.equal(100);
+    });
+
+    it("should account for already paid credits", () => {
+      const investment = createTestInvestment({ creditsPaid: 500 });
+      // 500 remaining / 10 per unit = 50 units
+      expect(expectedUnitsRemaining(investment)).to.equal(50);
+    });
+  });
+
+  describe("isInvestmentActive()", () => {
+    it("should return true for active investment", () => {
+      const investment = createTestInvestment();
+      expect(isInvestmentActive(investment, 500)).to.be.true;
+    });
+
+    it("should return false when expired", () => {
+      const investment = createTestInvestment();
+      expect(isInvestmentActive(investment, 2000)).to.be.false;
+    });
+
+    it("should return false when budget exhausted", () => {
+      const investment = createTestInvestment({ creditsPaid: 1000 });
+      expect(isInvestmentActive(investment, 500)).to.be.false;
+    });
+  });
+
+  describe("recordInvestmentDelivery()", () => {
+    it("should calculate payment based on units and rate", () => {
+      const investment = createTestInvestment();
+      const payment = recordInvestmentDelivery(investment, 10);
+      expect(payment).to.equal(100); // 10 units × 10 per unit
+      expect(investment.unitsDelivered).to.equal(10);
+      expect(investment.creditsPaid).to.equal(100);
+    });
+
+    it("should cap payment at remaining budget", () => {
+      const investment = createTestInvestment({ creditsPaid: 950 });
+      const payment = recordInvestmentDelivery(investment, 100);
+      expect(payment).to.equal(50); // Only 50 remaining
+    });
+
+    it("should accumulate deliveries", () => {
+      const investment = createTestInvestment();
+      recordInvestmentDelivery(investment, 5);
+      recordInvestmentDelivery(investment, 10);
+      expect(investment.unitsDelivered).to.equal(15);
+      expect(investment.creditsPaid).to.equal(150);
+    });
+  });
+
+  describe("createCapitalAllocation()", () => {
+    it("should aggregate capital from multiple investments", () => {
+      const inv1 = createTestInvestment({ id: "inv-1", maxBudget: 1000 });
+      const inv2 = createTestInvestment({ id: "inv-2", maxBudget: 500 });
+
+      const allocation = createCapitalAllocation("corp-1", [inv1, inv2]);
+
+      expect(allocation.corpId).to.equal("corp-1");
+      expect(allocation.totalCapital).to.equal(1500);
+      expect(allocation.availableCapital).to.equal(1500);
+      expect(allocation.committedCapital).to.equal(0);
+      expect(allocation.sourceContracts).to.deep.equal(["inv-1", "inv-2"]);
+    });
+
+    it("should use remaining budget not max budget", () => {
+      const inv = createTestInvestment({ creditsPaid: 300 });
+      const allocation = createCapitalAllocation("corp-1", [inv]);
+      expect(allocation.totalCapital).to.equal(700);
+    });
+  });
+
+  describe("commitCapital()", () => {
+    it("should commit capital when available", () => {
+      const allocation = createCapitalAllocation("corp-1", [createTestInvestment()]);
+      const success = commitCapital(allocation, 400);
+
+      expect(success).to.be.true;
+      expect(allocation.committedCapital).to.equal(400);
+      expect(allocation.availableCapital).to.equal(600);
+    });
+
+    it("should reject commitment exceeding available", () => {
+      const allocation = createCapitalAllocation("corp-1", [createTestInvestment()]);
+      const success = commitCapital(allocation, 1200);
+
+      expect(success).to.be.false;
+      expect(allocation.committedCapital).to.equal(0);
+      expect(allocation.availableCapital).to.equal(1000);
+    });
+  });
+
+  describe("createSubContract()", () => {
+    it("should create sub-contract with parent reference", () => {
+      const subContract = createSubContract(
+        "hauling-1",
+        "mining-1",
+        "energy",
+        500,
+        100,
+        1500,
+        0,
+        "inv-001"
+      );
+
+      expect(subContract.buyerId).to.equal("hauling-1");
+      expect(subContract.sellerId).to.equal("mining-1");
+      expect(subContract.resource).to.equal("energy");
+      expect(subContract.quantity).to.equal(500);
+      expect(subContract.price).to.equal(100);
+      expect(subContract.parentInvestmentId).to.equal("inv-001");
+    });
+  });
+
+  describe("calculatePerformance()", () => {
+    it("should calculate ROI correctly", () => {
+      const investment = createTestInvestment({
+        unitsDelivered: 50,
+        creditsPaid: 500
+      });
+
+      // Mint value of 15 per unit
+      // Returns = 50 * 15 = 750
+      // Investment = 500
+      // ROI = (750 - 500) / 500 = 0.5
+      const performance = calculatePerformance(investment, 15);
+
+      expect(performance.investmentId).to.equal(investment.id);
+      expect(performance.totalInvested).to.equal(500);
+      expect(performance.totalUnitsProduced).to.equal(50);
+      expect(performance.actualCostPerUnit).to.equal(10);
+      expect(performance.roi).to.equal(0.5);
+    });
+
+    it("should calculate efficiency correctly", () => {
+      const investment = createTestInvestment({
+        maxBudget: 1000,
+        ratePerUnit: 10,
+        unitsDelivered: 80, // Expected 100 (1000/10)
+        creditsPaid: 800
+      });
+
+      const performance = calculatePerformance(investment, 15);
+      expect(performance.efficiency).to.equal(0.8);
+    });
+  });
+
+  describe("suggestInvestmentRate()", () => {
+    it("should suggest rate allowing supplier costs plus ROI", () => {
+      // Mint value: 100, supply chain cost: 50, target ROI: 20%
+      const rate = suggestInvestmentRate(100, 50, 0.2);
+
+      // Rate should be at least 55 (50 * 1.1) and at most 80 (100 * 0.8)
+      expect(rate).to.be.at.least(55);
+      expect(rate).to.be.at.most(80);
+    });
+
+    it("should ensure minimum rate covers supply chain costs", () => {
+      // High supply chain cost relative to mint value
+      const rate = suggestInvestmentRate(100, 90, 0.1);
+
+      // Should at least cover costs with 10% buffer
+      expect(rate).to.be.at.least(99); // 90 * 1.1
+    });
+  });
+});
+
+describe("Capital Flow Model", () => {
+  it("should demonstrate forward capital flow", () => {
+    // 1. Bank creates investment to upgrader
+    const investment = createInvestmentContract(
+      "bank",
+      "upgrader-1",
+      "rcl-progress",
+      "rcl-progress",
+      10, // $10 per upgrade point
+      1000, // $1000 budget
+      1500,
+      0
+    );
+
+    // 2. Upgrader now has capital allocation
+    const upgraderCapital = createCapitalAllocation("upgrader-1", [investment]);
+    expect(upgraderCapital.availableCapital).to.equal(1000);
+
+    // 3. Upgrader can commit capital to pay haulers
+    const haulerPayment = 300;
+    const committed = commitCapital(upgraderCapital, haulerPayment);
+    expect(committed).to.be.true;
+    expect(upgraderCapital.availableCapital).to.equal(700);
+
+    // 4. Hauler creates sub-contract with miner
+    const subContract = createSubContract(
+      "hauler-1",
+      "miner-1",
+      "energy",
+      500,
+      haulerPayment,
+      1500,
+      0,
+      investment.id
+    );
+    expect(subContract.parentInvestmentId).to.equal(investment.id);
+
+    // 5. When upgrader delivers, investment pays out
+    recordInvestmentDelivery(investment, 50);
+    expect(investment.creditsPaid).to.equal(500); // 50 × $10
+
+    // The key insight: capital flows FORWARD from bank → upgrader → hauler → miner
+    // Rather than backward from upgrader demand → hauler → miner → spawner
+  });
+});


### PR DESCRIPTION
Flips the economic model from "trace backwards from demand" to "capital flows forward from source."

Key changes:
- Add InvestmentContract interface for bank investments in goal corps
- Add InvestmentPlanner for forward capital allocation
- Add CapitalBudget for tracking corp capital from investments
- Add capital-aware projections that limit demand by available capital
- Integrate investment phase into planning loop
- Add global.invest() command for investment status

Old model (problematic):
  Upgrader (infinite demand) ← Hauler ← Mining ← Spawning └── Mint value appears at the end, traced backwards

New BankCorp model:
  Bank (source of $) ↓ loans $ to upgraders (contract: $X per upgrade point) Upgrader (now has $, can buy services) ↓ pays haulers for delivered-energy Hauler (earns $, pays miners + spawn) ↓ Mining + Spawning (earn $)

Benefits:
- Capital flows forward - Bank invests, money cascades down
- Throughput determined by investment - Bank decides allocation
- ROI tracking is natural - Each corp earns based on actual work
- Investment optimization - Bank can invest MORE in high-ROI chains