### PR TITLE
Integrate FlowEconomy with main game loop

### DIFF
--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -93,6 +93,12 @@ declare global {
     lastSurveyTick?: number;
 
     /**
+     * Tick when the controller RCL last increased.
+     * Used by FlowEconomy to boost construction priority after RCL-up.
+     */
+    lastRclUpTick?: number;
+
+    /**
      * Room map cache metadata (tick when last computed).
      */
     roomMapCache?: { [roomName: string]: number };


### PR DESCRIPTION
Wire the flow-based planning system into the main game loop:
- Create NodeNavigator from persisted edges (Memory.nodeEdges, Memory.economicEdges)
- Instantiate FlowEconomy on startup and expose via globals
- Build PriorityContext from game state during planning phase
- Call FlowEconomy.update() to solve optimal energy allocations
- Add global.flowStatus() console command for debugging
- Add lastRclUpTick to Memory types for RCL-up tracking

This connects the Colony Node Graph and Flow-Based Planning systems that were previously implemented in isolation.