### PR TITLE
Integrate NodeFlow materialization to dovetail flow planning with corps

### DIFF
--- a/src/flow/FlowMaterializer.ts
+++ b/src/flow/FlowMaterializer.ts
@@ -1,0 +1,360 @@
+/**
+ * FlowMaterializer - Converts Flow Solution to Corps
+ *
+ * This module bridges the gap between flow planning and execution by
+ * materializing the abstract FlowSolution into concrete Corps that
+ * manage creeps.
+ *
+ * Key insight: Instead of corps querying FlowEconomy for their assignments,
+ * the flow solution IS materialized into corps. Corps store their
+ * assignments directly and execute based on them.
+ *
+ * Flow:
+ *   FlowSolution → groupByNode() → NodeFlow[] → materializeCorps() → CorpRegistry
+ */
+
+import { CorpRegistry } from "../execution/CorpRunner";
+import { HarvestCorp } from "../corps/HarvestCorp";
+import { CarryCorp } from "../corps/CarryCorp";
+import { UpgradingCorp } from "../corps/UpgradingCorp";
+import { SpawningCorp } from "../corps/SpawningCorp";
+import { ConstructionCorp } from "../corps/ConstructionCorp";
+import {
+  FlowSolution,
+  MinerAssignment,
+  HaulerAssignment,
+  SinkAllocation,
+} from "./FlowTypes";
+import { NodeFlow, NodeFlowMap, groupByNode } from "./NodeFlow";
+import { FlowGraph } from "./FlowGraph";
+
+// =============================================================================
+// MATERIALIZATION RESULT
+// =============================================================================
+
+/**
+ * Result of materializing flow solution into corps.
+ */
+export interface MaterializationResult {
+  /** Tick when materialization occurred */
+  tick: number;
+
+  /** Number of HarvestCorps updated */
+  harvestCorpsUpdated: number;
+
+  /** Number of CarryCorps updated */
+  carryCorpsUpdated: number;
+
+  /** Number of UpgradingCorps updated */
+  upgradingCorpsUpdated: number;
+
+  /** Number of ConstructionCorps updated */
+  constructionCorpsUpdated: number;
+
+  /** Number of new corps created */
+  newCorpsCreated: number;
+
+  /** Warnings during materialization */
+  warnings: string[];
+}
+
+// =============================================================================
+// MAIN MATERIALIZATION FUNCTION
+// =============================================================================
+
+/**
+ * Materialize a FlowSolution into the CorpRegistry.
+ *
+ * This is the main entry point for converting flow planning results
+ * into executable corps. It:
+ *
+ * 1. Groups the solution by node (territory)
+ * 2. For each node, updates or creates corps with their assignments
+ * 3. Corps store assignments directly (no runtime querying)
+ *
+ * @param solution - The solved flow allocation
+ * @param graph - The flow graph (for node lookups)
+ * @param corps - The corp registry to update
+ * @param tick - Current game tick
+ */
+export function materializeCorps(
+  solution: FlowSolution,
+  graph: FlowGraph,
+  corps: CorpRegistry,
+  tick: number
+): MaterializationResult {
+  const result: MaterializationResult = {
+    tick,
+    harvestCorpsUpdated: 0,
+    carryCorpsUpdated: 0,
+    upgradingCorpsUpdated: 0,
+    constructionCorpsUpdated: 0,
+    newCorpsCreated: 0,
+    warnings: [],
+  };
+
+  // Build source/sink → node maps from graph
+  const sourceNodeMap = buildSourceNodeMap(graph);
+  const sinkNodeMap = buildSinkNodeMap(graph);
+
+  // Group solution by node
+  const nodeFlows = groupByNode(solution, sourceNodeMap, sinkNodeMap);
+
+  // Materialize each node flow into corps
+  for (const nodeFlow of nodeFlows.values()) {
+    materializeNodeFlow(nodeFlow, corps, tick, result);
+  }
+
+  console.log(`[FlowMaterializer] Materialized ${nodeFlows.size} node flows into corps`);
+  console.log(`  Harvest: ${result.harvestCorpsUpdated}, Carry: ${result.carryCorpsUpdated}`);
+  console.log(`  Upgrading: ${result.upgradingCorpsUpdated}, Construction: ${result.constructionCorpsUpdated}`);
+
+  if (result.warnings.length > 0) {
+    console.log(`  Warnings: ${result.warnings.join(", ")}`);
+  }
+
+  return result;
+}
+
+/**
+ * Build a map of sourceId → nodeId from the flow graph.
+ */
+function buildSourceNodeMap(graph: FlowGraph): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const source of graph.getSources()) {
+    map.set(source.id, source.nodeId);
+  }
+  return map;
+}
+
+/**
+ * Build a map of sinkId → nodeId from the flow graph.
+ */
+function buildSinkNodeMap(graph: FlowGraph): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const sink of graph.getSinks()) {
+    map.set(sink.id, sink.nodeId);
+  }
+  return map;
+}
+
+// =============================================================================
+// NODE FLOW MATERIALIZATION
+// =============================================================================
+
+/**
+ * Materialize a single NodeFlow into corps.
+ *
+ * Each NodeFlow becomes:
+ * - One HarvestCorp per source (miner assignment)
+ * - One CarryCorp for the room (all hauler assignments)
+ * - One UpgradingCorp if there's a controller sink
+ * - One ConstructionCorp if there are construction sinks
+ */
+function materializeNodeFlow(
+  nodeFlow: NodeFlow,
+  corps: CorpRegistry,
+  tick: number,
+  result: MaterializationResult
+): void {
+  const roomName = nodeFlow.roomName;
+  const room = Game.rooms[roomName];
+
+  // Need room visibility and ownership to materialize
+  if (!room || !room.controller?.my) {
+    return;
+  }
+
+  const spawn = room.find(FIND_MY_SPAWNS)[0];
+  if (!spawn) {
+    result.warnings.push(`No spawn in ${roomName}`);
+    return;
+  }
+
+  // Materialize HarvestCorps from miner assignments
+  for (const miner of nodeFlow.miners) {
+    materializeHarvestCorp(miner, room, spawn, corps, tick, result);
+  }
+
+  // Materialize CarryCorp from hauler assignments
+  if (nodeFlow.haulers.length > 0) {
+    materializeCarryCorp(nodeFlow, room, spawn, corps, tick, result);
+  }
+
+  // Materialize UpgradingCorp from controller sink
+  const controllerSink = nodeFlow.sinks.find(s => s.sinkType === "controller");
+  if (controllerSink) {
+    materializeUpgradingCorp(controllerSink, room, spawn, corps, tick, result);
+  }
+
+  // Materialize ConstructionCorp from construction sinks
+  const constructionSinks = nodeFlow.sinks.filter(s => s.sinkType === "construction");
+  if (constructionSinks.length > 0) {
+    materializeConstructionCorp(constructionSinks, room, spawn, corps, tick, result);
+  }
+}
+
+// =============================================================================
+// CORP-SPECIFIC MATERIALIZATION
+// =============================================================================
+
+/**
+ * Materialize a HarvestCorp from a MinerAssignment.
+ */
+function materializeHarvestCorp(
+  miner: MinerAssignment,
+  room: Room,
+  spawn: StructureSpawn,
+  corps: CorpRegistry,
+  tick: number,
+  result: MaterializationResult
+): void {
+  // Extract source game ID from flow source ID (e.g., "source-abc123" → "abc123")
+  const sourceGameId = miner.sourceId.replace("source-", "");
+
+  let harvestCorp = corps.harvestCorps[sourceGameId];
+
+  if (!harvestCorp) {
+    // Create new HarvestCorp
+    const source = Game.getObjectById(sourceGameId as Id<Source>);
+    if (!source) {
+      result.warnings.push(`Source ${sourceGameId} not found`);
+      return;
+    }
+
+    harvestCorp = new HarvestCorp(miner.nodeId, miner.spawnId, sourceGameId);
+    harvestCorp.createdAt = tick;
+    corps.harvestCorps[sourceGameId] = harvestCorp;
+    result.newCorpsCreated++;
+    console.log(`[FlowMaterializer] Created HarvestCorp for ${sourceGameId.slice(-4)}`);
+  }
+
+  // Update the corp with its miner assignment
+  harvestCorp.setMinerAssignment(miner);
+  result.harvestCorpsUpdated++;
+}
+
+/**
+ * Materialize a CarryCorp from HaulerAssignments.
+ */
+function materializeCarryCorp(
+  nodeFlow: NodeFlow,
+  room: Room,
+  spawn: StructureSpawn,
+  corps: CorpRegistry,
+  tick: number,
+  result: MaterializationResult
+): void {
+  const roomName = room.name;
+
+  let carryCorp = corps.haulingCorps[roomName];
+
+  if (!carryCorp) {
+    // Create new CarryCorp
+    const nodeId = `${roomName}-hauling`;
+    carryCorp = new CarryCorp(nodeId, spawn.id);
+    carryCorp.createdAt = tick;
+    corps.haulingCorps[roomName] = carryCorp;
+    result.newCorpsCreated++;
+    console.log(`[FlowMaterializer] Created CarryCorp for ${roomName}`);
+  }
+
+  // Update with all hauler assignments for this node
+  carryCorp.setHaulerAssignments(nodeFlow.haulers);
+  result.carryCorpsUpdated++;
+}
+
+/**
+ * Materialize an UpgradingCorp from a controller SinkAllocation.
+ */
+function materializeUpgradingCorp(
+  controllerSink: SinkAllocation,
+  room: Room,
+  spawn: StructureSpawn,
+  corps: CorpRegistry,
+  tick: number,
+  result: MaterializationResult
+): void {
+  const roomName = room.name;
+
+  let upgradingCorp = corps.upgradingCorps[roomName];
+
+  if (!upgradingCorp) {
+    // Create new UpgradingCorp
+    const nodeId = `${roomName}-upgrading`;
+    upgradingCorp = new UpgradingCorp(nodeId, spawn.id);
+    upgradingCorp.createdAt = tick;
+    corps.upgradingCorps[roomName] = upgradingCorp;
+    result.newCorpsCreated++;
+    console.log(`[FlowMaterializer] Created UpgradingCorp for ${roomName}`);
+  }
+
+  // Update with controller allocation
+  upgradingCorp.setSinkAllocation(controllerSink);
+  result.upgradingCorpsUpdated++;
+}
+
+/**
+ * Materialize a ConstructionCorp from construction SinkAllocations.
+ */
+function materializeConstructionCorp(
+  constructionSinks: SinkAllocation[],
+  room: Room,
+  spawn: StructureSpawn,
+  corps: CorpRegistry,
+  tick: number,
+  result: MaterializationResult
+): void {
+  const roomName = room.name;
+
+  let constructionCorp = corps.constructionCorps[roomName];
+
+  if (!constructionCorp) {
+    // Create new ConstructionCorp
+    const nodeId = `${roomName}-construction`;
+    constructionCorp = new ConstructionCorp(nodeId, spawn.id);
+    constructionCorp.createdAt = tick;
+    corps.constructionCorps[roomName] = constructionCorp;
+    result.newCorpsCreated++;
+    console.log(`[FlowMaterializer] Created ConstructionCorp for ${roomName}`);
+  }
+
+  // Update with construction allocations
+  constructionCorp.setConstructionAllocations(constructionSinks);
+  result.constructionCorpsUpdated++;
+}
+
+// =============================================================================
+// CLEANUP FUNCTIONS
+// =============================================================================
+
+/**
+ * Remove corps that are no longer in the flow solution.
+ * Call this after materialization to clean up stale corps.
+ */
+export function cleanupStaleCorps(
+  nodeFlows: NodeFlowMap,
+  corps: CorpRegistry
+): { removed: number } {
+  let removed = 0;
+
+  // Build set of active source IDs
+  const activeSourceIds = new Set<string>();
+  for (const nodeFlow of nodeFlows.values()) {
+    for (const miner of nodeFlow.miners) {
+      const sourceGameId = miner.sourceId.replace("source-", "");
+      activeSourceIds.add(sourceGameId);
+    }
+  }
+
+  // Remove HarvestCorps not in flow
+  for (const sourceId in corps.harvestCorps) {
+    if (!activeSourceIds.has(sourceId)) {
+      delete corps.harvestCorps[sourceId];
+      removed++;
+      console.log(`[FlowMaterializer] Removed stale HarvestCorp for ${sourceId.slice(-4)}`);
+    }
+  }
+
+  return { removed };
+}

--- a/src/flow/NodeFlow.ts
+++ b/src/flow/NodeFlow.ts
@@ -1,0 +1,248 @@
+/**
+ * NodeFlow - Flow-based Economy Materialization
+ *
+ * Bridges the FlowSolution to Corps by grouping flow assignments by node.
+ * Each NodeFlow represents all economic activity for a territory node,
+ * which can then be materialized into corps.
+ *
+ * Architecture:
+ *   FlowSolution → groupByNode() → NodeFlow[] → materializeCorps() → Corps
+ *
+ * This replaces the query-based integration where corps ask FlowEconomy
+ * for their assignments. Instead, the flow solution IS the corps.
+ */
+
+import {
+  FlowSolution,
+  MinerAssignment,
+  HaulerAssignment,
+  SinkAllocation,
+} from "./FlowTypes";
+
+// =============================================================================
+// NODE FLOW TYPE
+// =============================================================================
+
+/**
+ * NodeFlow represents all economic activity for a single territory node.
+ *
+ * A node contains:
+ * - Sources that are mined (miners)
+ * - Edges that transport energy out (haulers)
+ * - Sinks that consume energy (controller, construction, storage)
+ *
+ * This groups the flat FlowSolution into a hierarchical structure
+ * that maps directly to corps.
+ */
+export interface NodeFlow {
+  /** Node (territory) ID */
+  nodeId: string;
+
+  /** Room name (derived from nodeId or first miner) */
+  roomName: string;
+
+  /** Miner assignments for sources in this node */
+  miners: MinerAssignment[];
+
+  /** Hauler assignments for edges originating from this node's sources */
+  haulers: HaulerAssignment[];
+
+  /** Sink allocations for sinks in this node */
+  sinks: SinkAllocation[];
+
+  /** Total energy harvested in this node (sum of miner harvestRates) */
+  totalHarvest: number;
+
+  /** Total energy flowing out of this node (sum of hauler flowRates) */
+  totalOutflow: number;
+
+  /** Total energy consumed by sinks in this node */
+  totalConsumption: number;
+
+  /** Spawn IDs serving this node (for creep spawning) */
+  spawnIds: Set<string>;
+}
+
+/**
+ * NodeFlowMap indexes NodeFlows by nodeId for fast lookup.
+ */
+export type NodeFlowMap = Map<string, NodeFlow>;
+
+// =============================================================================
+// GROUPING FUNCTION
+// =============================================================================
+
+/**
+ * Groups a FlowSolution by node to create NodeFlows.
+ *
+ * This transforms the flat solution into a hierarchical structure:
+ * - Each node gets its own NodeFlow
+ * - Miners are grouped by their nodeId
+ * - Haulers are grouped by the source's nodeId (origin of flow)
+ * - Sinks are grouped by their nodeId
+ *
+ * @param solution - The flow solution from FlowSolver
+ * @param sourceNodeMap - Map of sourceId → nodeId (from FlowGraph)
+ * @param sinkNodeMap - Map of sinkId → nodeId (from FlowGraph)
+ * @returns Map of nodeId → NodeFlow
+ */
+export function groupByNode(
+  solution: FlowSolution,
+  sourceNodeMap: Map<string, string>,
+  sinkNodeMap: Map<string, string>
+): NodeFlowMap {
+  const nodeFlows: NodeFlowMap = new Map();
+
+  // Helper to get or create a NodeFlow
+  const getOrCreateNodeFlow = (nodeId: string): NodeFlow => {
+    let nodeFlow = nodeFlows.get(nodeId);
+    if (!nodeFlow) {
+      nodeFlow = {
+        nodeId,
+        roomName: extractRoomName(nodeId),
+        miners: [],
+        haulers: [],
+        sinks: [],
+        totalHarvest: 0,
+        totalOutflow: 0,
+        totalConsumption: 0,
+        spawnIds: new Set(),
+      };
+      nodeFlows.set(nodeId, nodeFlow);
+    }
+    return nodeFlow;
+  };
+
+  // Group miners by node
+  for (const miner of solution.miners) {
+    const nodeFlow = getOrCreateNodeFlow(miner.nodeId);
+    nodeFlow.miners.push(miner);
+    nodeFlow.totalHarvest += miner.harvestRate;
+    nodeFlow.spawnIds.add(miner.spawnId);
+  }
+
+  // Group haulers by source node (where energy originates)
+  for (const hauler of solution.haulers) {
+    // fromId is the source ID; look up its node
+    const sourceNodeId = sourceNodeMap.get(hauler.fromId);
+    if (sourceNodeId) {
+      const nodeFlow = getOrCreateNodeFlow(sourceNodeId);
+      nodeFlow.haulers.push(hauler);
+      nodeFlow.totalOutflow += hauler.flowRate;
+      nodeFlow.spawnIds.add(hauler.spawnId);
+    }
+  }
+
+  // Group sink allocations by node
+  for (const sink of solution.sinkAllocations) {
+    const sinkNodeId = sinkNodeMap.get(sink.sinkId);
+    if (sinkNodeId) {
+      const nodeFlow = getOrCreateNodeFlow(sinkNodeId);
+      nodeFlow.sinks.push(sink);
+      nodeFlow.totalConsumption += sink.allocated;
+    }
+  }
+
+  return nodeFlows;
+}
+
+/**
+ * Extract room name from node ID.
+ * Node IDs are typically formatted as "roomName-xxx" or similar.
+ */
+function extractRoomName(nodeId: string): string {
+  // Try to extract room name (e.g., "W1N1-peak-0" → "W1N1")
+  const parts = nodeId.split("-");
+  if (parts.length > 0) {
+    // Check if first part looks like a room name
+    const roomPattern = /^[WE]\d+[NS]\d+$/;
+    if (roomPattern.test(parts[0])) {
+      return parts[0];
+    }
+  }
+  return nodeId;
+}
+
+// =============================================================================
+// QUERY FUNCTIONS
+// =============================================================================
+
+/**
+ * Get all node IDs that have active flows.
+ */
+export function getActiveNodeIds(nodeFlows: NodeFlowMap): string[] {
+  return Array.from(nodeFlows.keys());
+}
+
+/**
+ * Get total CARRY parts needed for a node's hauling.
+ */
+export function getTotalCarryParts(nodeFlow: NodeFlow): number {
+  return nodeFlow.haulers.reduce((sum, h) => sum + h.carryParts, 0);
+}
+
+/**
+ * Get the primary spawn for a node (first spawn serving it).
+ */
+export function getPrimarySpawn(nodeFlow: NodeFlow): string | undefined {
+  return nodeFlow.spawnIds.values().next().value;
+}
+
+/**
+ * Get sink allocation for a specific sink type in a node.
+ */
+export function getSinkAllocationByType(
+  nodeFlow: NodeFlow,
+  sinkType: string
+): SinkAllocation | undefined {
+  return nodeFlow.sinks.find(s => s.sinkType === sinkType);
+}
+
+/**
+ * Check if a node is self-sustaining (harvest covers overhead + consumption).
+ */
+export function isNodeSelfSustaining(nodeFlow: NodeFlow): boolean {
+  // A node is self-sustaining if its harvest is enough for its consumption
+  // This is a simplified check; full sustainability includes spawn overhead
+  return nodeFlow.totalHarvest >= nodeFlow.totalConsumption;
+}
+
+// =============================================================================
+// DEBUGGING
+// =============================================================================
+
+/**
+ * Print a NodeFlow summary for debugging.
+ */
+export function printNodeFlow(nodeFlow: NodeFlow): void {
+  console.log(`\n=== NodeFlow: ${nodeFlow.nodeId} (${nodeFlow.roomName}) ===`);
+  console.log(`  Harvest: ${nodeFlow.totalHarvest.toFixed(2)} e/tick`);
+  console.log(`  Outflow: ${nodeFlow.totalOutflow.toFixed(2)} e/tick`);
+  console.log(`  Consumption: ${nodeFlow.totalConsumption.toFixed(2)} e/tick`);
+  console.log(`  Spawns: ${Array.from(nodeFlow.spawnIds).join(", ")}`);
+
+  console.log(`\n  Miners (${nodeFlow.miners.length}):`);
+  for (const m of nodeFlow.miners) {
+    console.log(`    ${m.sourceId.slice(-8)}: ${m.harvestRate} e/tick`);
+  }
+
+  console.log(`\n  Haulers (${nodeFlow.haulers.length}):`);
+  for (const h of nodeFlow.haulers) {
+    console.log(`    ${h.fromId.slice(-8)} → ${h.toId.slice(-8)}: ${h.carryParts}C, ${h.flowRate.toFixed(2)} e/tick`);
+  }
+
+  console.log(`\n  Sinks (${nodeFlow.sinks.length}):`);
+  for (const s of nodeFlow.sinks) {
+    console.log(`    ${s.sinkType}[${s.sinkId.slice(-8)}]: ${s.allocated.toFixed(2)}/${s.demand.toFixed(2)} e/tick`);
+  }
+}
+
+/**
+ * Print all NodeFlows summary.
+ */
+export function printAllNodeFlows(nodeFlows: NodeFlowMap): void {
+  console.log(`\n=== NodeFlow Summary (${nodeFlows.size} nodes) ===`);
+  for (const nodeFlow of nodeFlows.values()) {
+    printNodeFlow(nodeFlow);
+  }
+}

--- a/src/flow/index.ts
+++ b/src/flow/index.ts
@@ -119,3 +119,30 @@ export {
   createFlowEconomy,
   createFlowEconomyWithPreset,
 } from "./FlowEconomy";
+
+// =============================================================================
+// NODE FLOW (Flow Solution → Node Grouping)
+// =============================================================================
+
+export {
+  NodeFlow,
+  NodeFlowMap,
+  groupByNode,
+  getActiveNodeIds,
+  getTotalCarryParts,
+  getPrimarySpawn,
+  getSinkAllocationByType,
+  isNodeSelfSustaining,
+  printNodeFlow,
+  printAllNodeFlows,
+} from "./NodeFlow";
+
+// =============================================================================
+// FLOW MATERIALIZER (Flow Solution → Corps)
+// =============================================================================
+
+export {
+  MaterializationResult,
+  materializeCorps,
+  cleanupStaleCorps,
+} from "./FlowMaterializer";

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@
 
 import { Colony, createColony } from "./colony";
 import { deserializeNode, SerializedNode, createNodeNavigator, NodeNavigator, EdgeType, parseEdgeKey } from "./nodes";
-import { FlowEconomy, PriorityContext, PriorityManager } from "./flow";
+import { FlowEconomy, PriorityContext, PriorityManager, materializeCorps, groupByNode } from "./flow";
 import { ErrorMapper } from "./utils";
 import { getTelemetry } from "./telemetry";
 import {
@@ -227,6 +227,12 @@ export const loop = ErrorMapper.wrapLoop(() => {
         if (solution.warnings.length > 0) {
           console.log(`[FlowEconomy] Warnings: ${solution.warnings.join(", ")}`);
         }
+
+        // Materialize flow solution into corps
+        // This replaces corps querying FlowEconomy - corps ARE the flow now
+        const graph = flowEconomy.getFlowGraph();
+        const result = materializeCorps(solution, graph, corps, Game.time);
+        console.log(`[FlowEconomy] Materialized: ${result.harvestCorpsUpdated} harvest, ${result.carryCorpsUpdated} carry, ${result.upgradingCorpsUpdated} upgrading corps`);
       }
     }
 


### PR DESCRIPTION
Instead of corps querying FlowEconomy for assignments, the flow solution now materializes directly INTO corps. This dovetails planning and execution:

Architecture:
  FlowSolution → groupByNode() → NodeFlow[] → materializeCorps() → Corps

New modules:
- NodeFlow.ts: Groups flow solution by territory node
  - Each NodeFlow contains miners, haulers, sinks for one node
  - Query functions for node-level metrics (carry parts, flow rate, etc.)

- FlowMaterializer.ts: Converts NodeFlows into Corps
  - materializeCorps(): Creates/updates corps from flow solution
  - Each MinerAssignment → HarvestCorp with stored assignment
  - Each HaulerAssignment[] → CarryCorp with stored routes
  - Each SinkAllocation → UpgradingCorp/ConstructionCorp

Corps now store their flow assignments directly:
- HarvestCorp.setMinerAssignment() / getMinerAssignment()
- CarryCorp.setHaulerAssignments() / getHaulerAssignments()
- UpgradingCorp.setSinkAllocation() / getSinkAllocation()
- ConstructionCorp.setConstructionAllocations()

Planning phase now calls materializeCorps() after solving flow.