### PR TITLE
Add HaulerCorp and TankerCorp for specialized carrier creeps

### DIFF
--- a/src/corps/HaulerCorp.ts
+++ b/src/corps/HaulerCorp.ts
@@ -1,0 +1,410 @@
+/**
+ * @fileoverview HaulerCorp - Manages hauler creeps that work on Edges.
+ *
+ * Haulers are "dumb" conveyor-belt style creeps that:
+ * - Pick up energy at the Source end of an edge
+ * - Deliver energy at the Sink end of an edge
+ * - Follow the path between source and sink like a rail system
+ *
+ * Haulers don't make decisions - they just follow their assigned route.
+ * Each hauler is assigned to a specific edge (source → sink path).
+ *
+ * @module corps/HaulerCorp
+ */
+
+import { Corp, SerializedCorp } from "./Corp";
+import { Position } from "../types/Position";
+import { CREEP_LIFETIME } from "../planning/EconomicConstants";
+import { HaulerAssignment } from "../flow/FlowTypes";
+
+/**
+ * Serialized state for HaulerCorp persistence
+ */
+export interface SerializedHaulerCorp extends SerializedCorp {
+  spawnId: string;
+  /** The edge this hauler corp serves */
+  edgeId: string;
+  /** Source position (pickup point) */
+  sourcePos: Position;
+  /** Sink position (delivery point) */
+  sinkPos: Position;
+  /** Flow rate requirement (energy per tick) */
+  flowRate: number;
+  /** Walking distance (one-way) */
+  distance: number;
+  /** Required CARRY parts based on flow planner */
+  requiredCarryParts: number;
+}
+
+/**
+ * HaulerCorp manages hauler creeps that transport energy along edges.
+ *
+ * Haulers are simple: they pick up at source, deliver at sink, repeat.
+ * No decision-making - they follow rails like a conveyor belt.
+ */
+export class HaulerCorp extends Corp {
+  private spawnId: string;
+  private edgeId: string;
+  private sourcePos: Position;
+  private sinkPos: Position;
+  private flowRate: number;
+  private distance: number;
+  private requiredCarryParts: number;
+
+  /** Creeps we've already recorded expected production for (session-only) */
+  private accountedCreeps: Set<string> = new Set();
+
+  constructor(
+    nodeId: string,
+    spawnId: string,
+    edgeId: string,
+    sourcePos: Position,
+    sinkPos: Position,
+    flowRate: number,
+    distance: number,
+    requiredCarryParts: number,
+    customId?: string
+  ) {
+    super("hauling", nodeId, customId);
+    this.spawnId = spawnId;
+    this.edgeId = edgeId;
+    this.sourcePos = sourcePos;
+    this.sinkPos = sinkPos;
+    this.flowRate = flowRate;
+    this.distance = distance;
+    this.requiredCarryParts = requiredCarryParts;
+  }
+
+  /**
+   * Get all hauler creeps assigned to this corp.
+   */
+  private getAssignedCreeps(): Creep[] {
+    const creeps: Creep[] = [];
+    for (const name in Game.creeps) {
+      const creep = Game.creeps[name];
+      if (
+        creep.memory.corpId === this.id &&
+        creep.memory.workType === "haul" &&
+        !creep.spawning
+      ) {
+        creeps.push(creep);
+
+        // Track expected production for new creeps
+        if (!this.accountedCreeps.has(name)) {
+          this.accountedCreeps.add(name);
+          const carryCapacity = creep.store.getCapacity();
+          const roundTrip = this.distance * 2 + 10;
+          const tripsPerLife = Math.floor(CREEP_LIFETIME / roundTrip);
+          this.recordExpectedProduction(carryCapacity * tripsPerLife);
+        }
+      }
+    }
+    return creeps;
+  }
+
+  /**
+   * Get position for this corp (source position).
+   */
+  getPosition(): Position {
+    return this.sourcePos;
+  }
+
+  /**
+   * Main work loop - run hauler creeps along the edge.
+   */
+  work(tick: number): void {
+    this.lastActivityTick = tick;
+    const creeps = this.getAssignedCreeps();
+
+    for (const creep of creeps) {
+      this.runHauler(creep);
+    }
+  }
+
+  /**
+   * Run a hauler creep - simple state machine.
+   *
+   * States:
+   * - working=false: Picking up energy at source
+   * - working=true: Delivering energy to sink
+   */
+  private runHauler(creep: Creep): void {
+    // State transitions
+    if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) {
+      creep.memory.working = false;
+      creep.say("pickup");
+    }
+    if (!creep.memory.working && creep.store.getFreeCapacity() === 0) {
+      creep.memory.working = true;
+      creep.say("deliver");
+    }
+
+    if (creep.memory.working) {
+      this.deliverEnergy(creep);
+    } else {
+      this.pickupEnergy(creep);
+    }
+  }
+
+  /**
+   * Pick up energy at the source position.
+   *
+   * Haulers look for:
+   * 1. Dropped energy near source
+   * 2. Containers near source
+   * 3. Tombstones/ruins near source
+   */
+  private pickupEnergy(creep: Creep): void {
+    const sourceRoomPos = new RoomPosition(
+      this.sourcePos.x,
+      this.sourcePos.y,
+      this.sourcePos.roomName
+    );
+
+    // If not in source room, travel there
+    if (creep.room.name !== this.sourcePos.roomName) {
+      creep.moveTo(sourceRoomPos, { visualizePathStyle: { stroke: "#ffaa00" } });
+      return;
+    }
+
+    // Priority 1: Dropped energy near source (within 5 tiles)
+    const dropped = creep.room.find(FIND_DROPPED_RESOURCES, {
+      filter: (r) =>
+        r.resourceType === RESOURCE_ENERGY &&
+        r.pos.getRangeTo(sourceRoomPos) <= 5,
+    });
+
+    if (dropped.length > 0) {
+      // Pick the largest pile
+      const target = dropped.reduce((best, curr) =>
+        curr.amount > best.amount ? curr : best
+      );
+      if (creep.pickup(target) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 2: Containers near source
+    const containers = creep.room.find(FIND_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_CONTAINER &&
+        (s as StructureContainer).store[RESOURCE_ENERGY] > 0 &&
+        s.pos.getRangeTo(sourceRoomPos) <= 3,
+    }) as StructureContainer[];
+
+    if (containers.length > 0) {
+      const target = containers[0];
+      if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 3: Tombstones near source
+    const tombstones = creep.room.find(FIND_TOMBSTONES, {
+      filter: (t) =>
+        t.store[RESOURCE_ENERGY] > 0 && t.pos.getRangeTo(sourceRoomPos) <= 5,
+    });
+
+    if (tombstones.length > 0) {
+      const target = tombstones[0];
+      if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Nothing to pick up - wait near source
+    if (creep.pos.getRangeTo(sourceRoomPos) > 2) {
+      creep.moveTo(sourceRoomPos, { visualizePathStyle: { stroke: "#ffaa00" } });
+    }
+  }
+
+  /**
+   * Deliver energy to the sink position.
+   *
+   * Haulers deliver to:
+   * 1. Storage at sink
+   * 2. Containers at sink
+   * 3. Drop at sink if nothing else
+   */
+  private deliverEnergy(creep: Creep): void {
+    const sinkRoomPos = new RoomPosition(
+      this.sinkPos.x,
+      this.sinkPos.y,
+      this.sinkPos.roomName
+    );
+
+    // If not in sink room, travel there
+    if (creep.room.name !== this.sinkPos.roomName) {
+      creep.moveTo(sinkRoomPos, { visualizePathStyle: { stroke: "#ffffff" } });
+      return;
+    }
+
+    // Opportunistic: pick up nearby dropped energy while traveling
+    if (creep.store.getFreeCapacity() > 0) {
+      const nearbyDropped = creep.pos.findInRange(FIND_DROPPED_RESOURCES, 1, {
+        filter: (r) => r.resourceType === RESOURCE_ENERGY,
+      });
+      if (nearbyDropped.length > 0) {
+        creep.pickup(nearbyDropped[0]);
+      }
+    }
+
+    // Priority 1: Storage near sink
+    const storage = creep.room.find(FIND_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_STORAGE &&
+        (s as StructureStorage).store.getFreeCapacity(RESOURCE_ENERGY) > 0 &&
+        s.pos.getRangeTo(sinkRoomPos) <= 5,
+    }) as StructureStorage[];
+
+    if (storage.length > 0) {
+      const target = storage[0];
+      const result = creep.transfer(target, RESOURCE_ENERGY);
+      if (result === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffffff" } });
+      } else if (result === OK) {
+        this.recordProduction(creep.store[RESOURCE_ENERGY]);
+      }
+      return;
+    }
+
+    // Priority 2: Containers near sink
+    const containers = creep.room.find(FIND_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_CONTAINER &&
+        (s as StructureContainer).store.getFreeCapacity(RESOURCE_ENERGY) > 0 &&
+        s.pos.getRangeTo(sinkRoomPos) <= 3,
+    }) as StructureContainer[];
+
+    if (containers.length > 0) {
+      const target = containers[0];
+      const result = creep.transfer(target, RESOURCE_ENERGY);
+      if (result === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffffff" } });
+      } else if (result === OK) {
+        this.recordProduction(creep.store[RESOURCE_ENERGY]);
+      }
+      return;
+    }
+
+    // Priority 3: Drop at sink position
+    if (creep.pos.getRangeTo(sinkRoomPos) <= 2) {
+      const dropped = creep.store[RESOURCE_ENERGY];
+      creep.drop(RESOURCE_ENERGY);
+      this.recordProduction(dropped);
+    } else {
+      creep.moveTo(sinkRoomPos, { visualizePathStyle: { stroke: "#ffffff" } });
+    }
+  }
+
+  /**
+   * Get number of active hauler creeps.
+   */
+  getCreepCount(): number {
+    return this.getAssignedCreeps().length;
+  }
+
+  /**
+   * Get total CARRY parts currently assigned.
+   */
+  getCurrentCarryParts(): number {
+    return this.getAssignedCreeps().reduce(
+      (sum, creep) => sum + creep.getActiveBodyparts(CARRY),
+      0
+    );
+  }
+
+  /**
+   * Get the required CARRY parts from flow planning.
+   */
+  getRequiredCarryParts(): number {
+    return this.requiredCarryParts;
+  }
+
+  /**
+   * Set the required CARRY parts (called by flow planner).
+   */
+  setRequiredCarryParts(parts: number): void {
+    this.requiredCarryParts = parts;
+  }
+
+  /**
+   * Get the edge ID this hauler serves.
+   */
+  getEdgeId(): string {
+    return this.edgeId;
+  }
+
+  /**
+   * Get the flow rate requirement.
+   */
+  getFlowRate(): number {
+    return this.flowRate;
+  }
+
+  /**
+   * Update from a HaulerAssignment.
+   */
+  updateFromAssignment(assignment: HaulerAssignment): void {
+    this.flowRate = assignment.flowRate;
+    this.distance = assignment.distance;
+    this.requiredCarryParts = assignment.carryParts;
+  }
+
+  /**
+   * Serialize for persistence.
+   */
+  serialize(): SerializedHaulerCorp {
+    return {
+      ...super.serialize(),
+      spawnId: this.spawnId,
+      edgeId: this.edgeId,
+      sourcePos: this.sourcePos,
+      sinkPos: this.sinkPos,
+      flowRate: this.flowRate,
+      distance: this.distance,
+      requiredCarryParts: this.requiredCarryParts,
+    };
+  }
+
+  /**
+   * Deserialize from persistence.
+   */
+  deserialize(data: SerializedHaulerCorp): void {
+    super.deserialize(data);
+    this.edgeId = data.edgeId;
+    this.sourcePos = data.sourcePos;
+    this.sinkPos = data.sinkPos;
+    this.flowRate = data.flowRate;
+    this.distance = data.distance;
+    this.requiredCarryParts = data.requiredCarryParts;
+  }
+}
+
+/**
+ * Create a HaulerCorp for an edge.
+ */
+export function createHaulerCorp(
+  nodeId: string,
+  spawnId: string,
+  edgeId: string,
+  sourcePos: Position,
+  sinkPos: Position,
+  flowRate: number,
+  distance: number,
+  requiredCarryParts: number
+): HaulerCorp {
+  return new HaulerCorp(
+    nodeId,
+    spawnId,
+    edgeId,
+    sourcePos,
+    sinkPos,
+    flowRate,
+    distance,
+    requiredCarryParts
+  );
+}

--- a/src/corps/TankerCorp.ts
+++ b/src/corps/TankerCorp.ts
@@ -1,0 +1,578 @@
+/**
+ * @fileoverview TankerCorp - Manages tanker creeps that work within Nodes.
+ *
+ * Tankers are local distributors that:
+ * - Pick up energy from any source within the node (containers, dropped, storage, links)
+ * - Deliver energy to sinks within the node (extensions, spawns, towers)
+ * - Work reactively based on what needs filling
+ *
+ * Unlike Haulers (which follow fixed edge routes), Tankers are intelligent
+ * and prioritize based on what needs energy most urgently.
+ *
+ * Tanker requirements are modeled per-node based on:
+ * - Number of extensions/spawns to fill
+ * - Average distance within the node
+ * - Spawn rate (how fast energy drains)
+ *
+ * @module corps/TankerCorp
+ */
+
+import { Corp, SerializedCorp } from "./Corp";
+import { Position } from "../types/Position";
+import { CREEP_LIFETIME } from "../planning/EconomicConstants";
+
+/**
+ * Demand modeling for tanker requirements.
+ * Used to calculate how many CARRY parts the node needs.
+ */
+export interface TankerDemand {
+  /** Number of extensions in the node */
+  extensionCount: number;
+  /** Number of spawns in the node */
+  spawnCount: number;
+  /** Number of towers in the node */
+  towerCount: number;
+  /** Average fill distance within the node */
+  averageFillDistance: number;
+  /** Estimated spawn rate (creeps per tick, ~0.01-0.05) */
+  spawnRate: number;
+  /** Energy consumption rate per tick */
+  energyPerTick: number;
+}
+
+/**
+ * Serialized state for TankerCorp persistence
+ */
+export interface SerializedTankerCorp extends SerializedCorp {
+  spawnId: string;
+  /** Node center position */
+  nodeCenter: Position;
+  /** Current demand model */
+  demand?: TankerDemand;
+  /** Required CARRY parts based on demand */
+  requiredCarryParts: number;
+}
+
+/**
+ * TankerCorp manages tanker creeps that distribute energy within a node.
+ *
+ * Tankers are smart local distributors. They look at all sources of energy
+ * (containers, dropped, storage) and deliver to sinks (extensions, spawns, towers).
+ */
+export class TankerCorp extends Corp {
+  private spawnId: string;
+  private nodeCenter: Position;
+  private demand: TankerDemand;
+  private requiredCarryParts: number;
+
+  /** Creeps we've already recorded expected production for (session-only) */
+  private accountedCreeps: Set<string> = new Set();
+
+  /** Rolling average of fill operations for reactive scaling */
+  private fillOperationsPerTick: number = 0;
+  private lastMeasureTick: number = 0;
+
+  constructor(
+    nodeId: string,
+    spawnId: string,
+    nodeCenter: Position,
+    demand?: TankerDemand,
+    customId?: string
+  ) {
+    super("hauling", nodeId, customId);
+    this.spawnId = spawnId;
+    this.nodeCenter = nodeCenter;
+    this.demand = demand ?? {
+      extensionCount: 0,
+      spawnCount: 1,
+      towerCount: 0,
+      averageFillDistance: 5,
+      spawnRate: 0.02,
+      energyPerTick: 10,
+    };
+    this.requiredCarryParts = this.calculateRequiredCarryParts();
+  }
+
+  /**
+   * Calculate required CARRY parts based on demand model.
+   *
+   * The formula considers:
+   * - Energy throughput needed (extensions + spawns + towers)
+   * - Round-trip time within the node
+   * - Buffer for efficiency losses
+   */
+  private calculateRequiredCarryParts(): number {
+    const { extensionCount, spawnCount, towerCount, averageFillDistance, energyPerTick } = this.demand;
+
+    // Base energy throughput: spawn consumption + tower upkeep
+    // Spawns consume ~10 energy/tick when actively spawning
+    // Extensions need refilling after each spawn (~50 energy each)
+    const structureCount = extensionCount + spawnCount + towerCount;
+
+    // Round trip time for tanker operations
+    const roundTrip = averageFillDistance * 2 + 2; // +2 for pickup/dropoff
+
+    // Energy per round trip that needs to be moved
+    const energyPerRoundTrip = energyPerTick * roundTrip;
+
+    // Each CARRY part holds 50 energy
+    const carryPartsNeeded = Math.ceil(energyPerRoundTrip / 50);
+
+    // Add buffer for reactive capacity (20%) and minimum of 2 parts
+    const withBuffer = Math.max(2, Math.ceil(carryPartsNeeded * 1.2));
+
+    // Cap at reasonable maximum based on structure count
+    const maxParts = Math.max(4, structureCount * 2);
+
+    return Math.min(withBuffer, maxParts);
+  }
+
+  /**
+   * Update demand model and recalculate requirements.
+   * Called periodically to adjust to changing node conditions.
+   */
+  updateDemand(room: Room): void {
+    const extensions = room.find(FIND_MY_STRUCTURES, {
+      filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+    const spawns = room.find(FIND_MY_SPAWNS);
+    const towers = room.find(FIND_MY_STRUCTURES, {
+      filter: (s) => s.structureType === STRUCTURE_TOWER,
+    });
+
+    // Calculate average distance from node center to structures
+    const allStructures = [...extensions, ...spawns, ...towers];
+    let totalDistance = 0;
+    const centerPos = new RoomPosition(
+      this.nodeCenter.x,
+      this.nodeCenter.y,
+      this.nodeCenter.roomName
+    );
+
+    for (const s of allStructures) {
+      totalDistance += s.pos.getRangeTo(centerPos);
+    }
+
+    const avgDistance = allStructures.length > 0
+      ? totalDistance / allStructures.length
+      : 5;
+
+    // Estimate spawn rate based on RCL and spawn count
+    // RCL 1-2: ~0.01, RCL 3-4: ~0.02, RCL 5+: ~0.03
+    const rcl = room.controller?.level ?? 1;
+    const spawnRate = Math.min(0.05, 0.01 + rcl * 0.005);
+
+    // Energy per tick: spawn consumption + tower consumption (when attacking/healing)
+    // Base: ~10 energy/tick for spawning, towers can add up to 10 more each when active
+    const energyPerTick = 10 + towers.length * 2; // Conservative estimate
+
+    this.demand = {
+      extensionCount: extensions.length,
+      spawnCount: spawns.length,
+      towerCount: towers.length,
+      averageFillDistance: avgDistance,
+      spawnRate,
+      energyPerTick,
+    };
+
+    this.requiredCarryParts = this.calculateRequiredCarryParts();
+  }
+
+  /**
+   * Get all tanker creeps assigned to this corp.
+   */
+  private getAssignedCreeps(): Creep[] {
+    const creeps: Creep[] = [];
+    for (const name in Game.creeps) {
+      const creep = Game.creeps[name];
+      if (
+        creep.memory.corpId === this.id &&
+        creep.memory.workType === "tank" &&
+        !creep.spawning
+      ) {
+        creeps.push(creep);
+
+        // Track expected production for new creeps
+        if (!this.accountedCreeps.has(name)) {
+          this.accountedCreeps.add(name);
+          const carryCapacity = creep.store.getCapacity();
+          // Estimate based on local round trips
+          const roundTrip = this.demand.averageFillDistance * 2 + 4;
+          const tripsPerLife = Math.floor(CREEP_LIFETIME / roundTrip);
+          this.recordExpectedProduction(carryCapacity * tripsPerLife);
+        }
+      }
+    }
+    return creeps;
+  }
+
+  /**
+   * Get position for this corp (node center).
+   */
+  getPosition(): Position {
+    return this.nodeCenter;
+  }
+
+  /**
+   * Main work loop - run tanker creeps.
+   */
+  work(tick: number): void {
+    this.lastActivityTick = tick;
+
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    if (!spawn) return;
+
+    const room = spawn.room;
+    const creeps = this.getAssignedCreeps();
+
+    // Update demand model every 100 ticks
+    if (tick - this.lastMeasureTick >= 100) {
+      this.updateDemand(room);
+      this.lastMeasureTick = tick;
+    }
+
+    for (const creep of creeps) {
+      this.runTanker(creep, room);
+    }
+  }
+
+  /**
+   * Run a tanker creep - intelligent local distribution.
+   *
+   * States:
+   * - working=false: Finding and picking up energy
+   * - working=true: Delivering energy to structures
+   */
+  private runTanker(creep: Creep, room: Room): void {
+    // State transitions
+    if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) {
+      creep.memory.working = false;
+      creep.say("collect");
+    }
+    if (!creep.memory.working && creep.store.getFreeCapacity() === 0) {
+      creep.memory.working = true;
+      creep.say("fill");
+    }
+
+    if (creep.memory.working) {
+      this.deliverEnergy(creep, room);
+    } else {
+      this.collectEnergy(creep, room);
+    }
+  }
+
+  /**
+   * Collect energy from sources within the node.
+   *
+   * Priority:
+   * 1. Dropped energy (decays fastest)
+   * 2. Tombstones/ruins (decay)
+   * 3. Containers near storage/spawn area
+   * 4. Storage
+   * 5. Links (if configured as receivers)
+   */
+  private collectEnergy(creep: Creep, room: Room): void {
+    // Priority 1: Dropped energy (anywhere in room, prioritize larger piles)
+    const dropped = room.find(FIND_DROPPED_RESOURCES, {
+      filter: (r) => r.resourceType === RESOURCE_ENERGY && r.amount >= 50,
+    });
+
+    if (dropped.length > 0) {
+      // Sort by amount descending, then by distance
+      dropped.sort((a, b) => {
+        const amountDiff = b.amount - a.amount;
+        if (Math.abs(amountDiff) > 100) return amountDiff;
+        return creep.pos.getRangeTo(a) - creep.pos.getRangeTo(b);
+      });
+      const target = dropped[0];
+      if (creep.pickup(target) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 2: Tombstones with energy
+    const tombstones = room.find(FIND_TOMBSTONES, {
+      filter: (t) => t.store[RESOURCE_ENERGY] > 0,
+    });
+
+    if (tombstones.length > 0) {
+      const target = creep.pos.findClosestByRange(tombstones);
+      if (target && creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 3: Ruins with energy
+    const ruins = room.find(FIND_RUINS, {
+      filter: (r) => r.store[RESOURCE_ENERGY] > 0,
+    });
+
+    if (ruins.length > 0) {
+      const target = creep.pos.findClosestByRange(ruins);
+      if (target && creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 4: Containers with significant energy
+    const containers = room.find(FIND_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_CONTAINER &&
+        (s as StructureContainer).store[RESOURCE_ENERGY] >= 100,
+    }) as StructureContainer[];
+
+    if (containers.length > 0) {
+      // Prefer containers with more energy
+      containers.sort((a, b) => b.store[RESOURCE_ENERGY] - a.store[RESOURCE_ENERGY]);
+      const target = containers[0];
+      if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 5: Storage
+    if (room.storage && room.storage.store[RESOURCE_ENERGY] > 0) {
+      if (creep.withdraw(room.storage, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(room.storage, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Priority 6: Links (receiver links near spawn/controller)
+    const links = room.find(FIND_MY_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_LINK &&
+        (s as StructureLink).store[RESOURCE_ENERGY] > 0,
+    }) as StructureLink[];
+
+    if (links.length > 0) {
+      const target = creep.pos.findClosestByRange(links);
+      if (target && creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
+      }
+      return;
+    }
+
+    // Nothing to collect - wait near node center
+    const centerPos = new RoomPosition(
+      this.nodeCenter.x,
+      this.nodeCenter.y,
+      this.nodeCenter.roomName
+    );
+    if (creep.pos.getRangeTo(centerPos) > 3) {
+      creep.moveTo(centerPos, { visualizePathStyle: { stroke: "#ffaa00" } });
+    }
+  }
+
+  /**
+   * Deliver energy to sinks within the node.
+   *
+   * Priority:
+   * 1. Spawns (critical for creep production)
+   * 2. Extensions (needed for larger creeps)
+   * 3. Towers (defense/repair)
+   * 4. Storage (buffer for later)
+   */
+  private deliverEnergy(creep: Creep, room: Room): void {
+    // Opportunistic: pick up nearby dropped energy while delivering
+    if (creep.store.getFreeCapacity() > 0) {
+      const nearbyDropped = creep.pos.findInRange(FIND_DROPPED_RESOURCES, 1, {
+        filter: (r) => r.resourceType === RESOURCE_ENERGY,
+      });
+      if (nearbyDropped.length > 0) {
+        creep.pickup(nearbyDropped[0]);
+      }
+    }
+
+    // Priority 1: Spawns that need energy
+    const spawns = room.find(FIND_MY_SPAWNS, {
+      filter: (s) => s.store.getFreeCapacity(RESOURCE_ENERGY) > 0,
+    });
+
+    if (spawns.length > 0) {
+      const target = creep.pos.findClosestByRange(spawns);
+      if (target) {
+        const result = creep.transfer(target, RESOURCE_ENERGY);
+        if (result === ERR_NOT_IN_RANGE) {
+          creep.moveTo(target, { visualizePathStyle: { stroke: "#ffffff" } });
+        } else if (result === OK) {
+          this.recordProduction(
+            Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY))
+          );
+        }
+        return;
+      }
+    }
+
+    // Priority 2: Extensions that need energy (use slot-based to avoid herding)
+    const extensions = room.find(FIND_MY_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_EXTENSION &&
+        (s as StructureExtension).store.getFreeCapacity(RESOURCE_ENERGY) > 0,
+    }) as StructureExtension[];
+
+    if (extensions.length > 0) {
+      // Use slot-based targeting to avoid all tankers going to same extension
+      const target = this.getSlotBasedTarget(creep, extensions);
+      if (target) {
+        const result = creep.transfer(target, RESOURCE_ENERGY);
+        if (result === ERR_NOT_IN_RANGE) {
+          creep.moveTo(target, { visualizePathStyle: { stroke: "#ffffff" } });
+        } else if (result === OK) {
+          this.recordProduction(
+            Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY))
+          );
+        }
+        return;
+      }
+    }
+
+    // Priority 3: Towers below 80% energy
+    const towers = room.find(FIND_MY_STRUCTURES, {
+      filter: (s) =>
+        s.structureType === STRUCTURE_TOWER &&
+        (s as StructureTower).store[RESOURCE_ENERGY] < 800, // 80% of 1000
+    }) as StructureTower[];
+
+    if (towers.length > 0) {
+      // Prioritize towers with lowest energy
+      towers.sort((a, b) => a.store[RESOURCE_ENERGY] - b.store[RESOURCE_ENERGY]);
+      const target = towers[0];
+      const result = creep.transfer(target, RESOURCE_ENERGY);
+      if (result === ERR_NOT_IN_RANGE) {
+        creep.moveTo(target, { visualizePathStyle: { stroke: "#ffffff" } });
+      } else if (result === OK) {
+        this.recordProduction(
+          Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY))
+        );
+      }
+      return;
+    }
+
+    // Priority 4: Storage (if nothing else needs energy)
+    if (room.storage && room.storage.store.getFreeCapacity(RESOURCE_ENERGY) > 0) {
+      const result = creep.transfer(room.storage, RESOURCE_ENERGY);
+      if (result === ERR_NOT_IN_RANGE) {
+        creep.moveTo(room.storage, { visualizePathStyle: { stroke: "#ffffff" } });
+      } else if (result === OK) {
+        this.recordProduction(creep.store[RESOURCE_ENERGY]);
+      }
+      return;
+    }
+
+    // Nothing needs energy - wait near node center
+    const centerPos = new RoomPosition(
+      this.nodeCenter.x,
+      this.nodeCenter.y,
+      this.nodeCenter.roomName
+    );
+    if (creep.pos.getRangeTo(centerPos) > 3) {
+      creep.moveTo(centerPos, { visualizePathStyle: { stroke: "#ffffff" } });
+    }
+  }
+
+  /**
+   * Get a target using slot-based distribution to prevent herding.
+   */
+  private getSlotBasedTarget<T extends Structure>(
+    creep: Creep,
+    structures: T[]
+  ): T | null {
+    if (structures.length === 0) return null;
+
+    // Sort by ID for consistent ordering
+    const sorted = [...structures].sort((a, b) => a.id.localeCompare(b.id));
+
+    // Get tanker's slot index
+    const allTankers = this.getAssignedCreeps();
+    const myIndex = allTankers.findIndex((c) => c.name === creep.name);
+    const slot = myIndex >= 0 ? myIndex : 0;
+
+    // Start from slot offset and wrap around
+    const count = sorted.length;
+    for (let i = 0; i < count; i++) {
+      const target = sorted[(slot + i) % count];
+      return target;
+    }
+
+    return sorted[0];
+  }
+
+  /**
+   * Get number of active tanker creeps.
+   */
+  getCreepCount(): number {
+    return this.getAssignedCreeps().length;
+  }
+
+  /**
+   * Get total CARRY parts currently assigned.
+   */
+  getCurrentCarryParts(): number {
+    return this.getAssignedCreeps().reduce(
+      (sum, creep) => sum + creep.getActiveBodyparts(CARRY),
+      0
+    );
+  }
+
+  /**
+   * Get the required CARRY parts based on demand model.
+   */
+  getRequiredCarryParts(): number {
+    return this.requiredCarryParts;
+  }
+
+  /**
+   * Get the current demand model.
+   */
+  getDemand(): TankerDemand {
+    return this.demand;
+  }
+
+  /**
+   * Check if tanker capacity is sufficient.
+   * Returns true if current CARRY parts meet or exceed required.
+   */
+  hasAdequateCapacity(): boolean {
+    return this.getCurrentCarryParts() >= this.requiredCarryParts;
+  }
+
+  /**
+   * Serialize for persistence.
+   */
+  serialize(): SerializedTankerCorp {
+    return {
+      ...super.serialize(),
+      spawnId: this.spawnId,
+      nodeCenter: this.nodeCenter,
+      demand: this.demand,
+      requiredCarryParts: this.requiredCarryParts,
+    };
+  }
+
+  /**
+   * Deserialize from persistence.
+   */
+  deserialize(data: SerializedTankerCorp): void {
+    super.deserialize(data);
+    this.nodeCenter = data.nodeCenter;
+    this.demand = data.demand ?? this.demand;
+    this.requiredCarryParts = data.requiredCarryParts;
+  }
+}
+
+/**
+ * Create a TankerCorp for a node.
+ */
+export function createTankerCorp(
+  nodeId: string,
+  spawnId: string,
+  nodeCenter: Position,
+  demand?: TankerDemand
+): TankerCorp {
+  return new TankerCorp(nodeId, spawnId, nodeCenter, demand);
+}

--- a/src/corps/index.ts
+++ b/src/corps/index.ts
@@ -38,6 +38,19 @@ export {
 } from "./CarryCorp";
 
 export {
+  HaulerCorp,
+  SerializedHaulerCorp,
+  createHaulerCorp
+} from "./HaulerCorp";
+
+export {
+  TankerCorp,
+  TankerDemand,
+  SerializedTankerCorp,
+  createTankerCorp
+} from "./TankerCorp";
+
+export {
   UpgradingCorp,
   SerializedUpgradingCorp,
   createUpgradingCorp

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -18,6 +18,8 @@ import {
   SerializedScoutCorp,
   SerializedConstructionCorp,
   SerializedSpawningCorp,
+  SerializedHaulerCorp,
+  SerializedTankerCorp,
 } from "../corps";
 
 declare global {
@@ -125,10 +127,22 @@ declare global {
     harvestCorps?: { [sourceId: string]: SerializedHarvestCorp };
 
     /**
-     * Serialized hauling corps by source ID.
+     * Serialized hauling corps by source ID (legacy CarryCorp).
      * Each source has its own CarryCorp for independent hauler scaling.
      */
     haulingCorps?: { [sourceId: string]: SerializedCarryCorp };
+
+    /**
+     * Serialized hauler corps by edge ID.
+     * Haulers work on edges, transporting energy from source to sink.
+     */
+    haulerCorps?: { [edgeId: string]: SerializedHaulerCorp };
+
+    /**
+     * Serialized tanker corps by node ID.
+     * Tankers work within nodes, distributing energy locally.
+     */
+    tankerCorps?: { [nodeId: string]: SerializedTankerCorp };
 
     /**
      * Serialized upgrading corps by room name.
@@ -177,8 +191,15 @@ declare global {
 
     /**
      * The type of work this creep performs.
+     * - harvest: Mining energy from sources
+     * - haul: Edge-based transport (source to sink via paths)
+     * - tank: Node-based local distribution (fill extensions/spawns)
+     * - upgrade: Controller upgrading
+     * - build: Construction
+     * - repair: Structure repair
+     * - scout: Room scouting
      */
-    workType?: "harvest" | "haul" | "upgrade" | "build" | "repair" | "scout";
+    workType?: "harvest" | "haul" | "tank" | "upgrade" | "build" | "repair" | "scout";
 
     /**
      * Target ID for current task.


### PR DESCRIPTION
Create two separate carrier creep types:
- HaulerCorp: Edge-based "dumb" transport that picks up at source and delivers at sink, following paths like a conveyor belt
- TankerCorp: Node-based intelligent local distribution that fills extensions, spawns, and towers from containers/storage

Key features:
- Haulers use flow planner requirements (requiredCarryParts from edge)
- Tankers model demand reactively based on structures in node
- New workType "tank" for tanker creeps
- buildTankerBody() with road-optimized 2:1 CARRY:MOVE ratio
- calculateTankerCarryNeeded() for demand modeling