### PR TITLE
Fix missing expansionScore field in NodeTelemetry interface

### DIFF
--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -136,6 +136,7 @@ export interface NodeTelemetry {
     }[];
     roi?: {
       s: number;   // score
+      e: number;   // expansionScore
       o: number;   // openness
       d: number;   // distanceFromOwned
       own: boolean;  // isOwned


### PR DESCRIPTION
Added the 'e' (expansionScore) field to the compact ROI definition in the NodeTelemetry interface. The field was already being sent in the telemetry data (line 555) and handled by the telemetry-app, but the TypeScript interface was incomplete.