### PR TITLE
Fix hauler not picking up remote-mined energy (range-2 stop)

### DIFF
--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -67,9 +67,13 @@ export function controllerDeliverySpot(controller: StructureController): EnergyS
  * still travelling), so the caller can account for what it delivered.
  */
 export function workSpot(creep: Creep, spot: EnergySpot, mode: "collect" | "deposit"): number {
-  // A bare drop spot only needs range 2 (drop/pickup reach an adjacent tile);
-  // a structure must be touched at range 1.
-  const range = spot.structure ? 1 : 2;
+  // pickup/withdraw must be adjacent to the energy (range 1); a structure is
+  // likewise touched at range 1. Only a bare DROP can be done from range 2 - the
+  // energy lands on the creep's own tile, so it just needs to be near the spot.
+  // Collecting from a bare drop pile at range 2 was the bug: the hauler stopped a
+  // tile short of the pile (common in remote mining, where there is no container)
+  // and the range-1 pickup never reached it.
+  const range = mode === "collect" || spot.structure ? 1 : 2;
   if (creep.pos.getRangeTo(spot.pos) > range) {
     creep.moveTo(spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
     return 0;

--- a/test/unit/corps/workSpot.test.ts
+++ b/test/unit/corps/workSpot.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import { workSpot, EnergySpot } from "../../../src/corps/nodeEnergy";
+
+// Minimal Screeps globals workSpot touches.
+(global as any).RESOURCE_ENERGY = "energy";
+(global as any).FIND_DROPPED_RESOURCES = 106;
+
+interface Pile {
+  resourceType: string;
+  amount: number;
+  pos: { x: number; y: number };
+}
+
+const cheby = (a: { x: number; y: number }, b: { x: number; y: number }): number =>
+  Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+
+/** A mock hauler at (x,y) standing in a field of dropped energy piles. */
+function makeCreep(x: number, y: number, piles: Pile[]) {
+  const calls = { moveTo: 0, pickup: 0, lastMoveRange: undefined as number | undefined };
+  const self = { x, y };
+  const pos = {
+    getRangeTo: (t: { x: number; y: number }) => cheby(self, t),
+    findInRange: (_type: number, range: number, opts?: { filter?: (p: Pile) => boolean }) =>
+      piles.filter(p => cheby(self, p.pos) <= range && (!opts?.filter || opts.filter(p)))
+  };
+  const creep = {
+    pos,
+    store: { energy: 0 } as Record<string, number>,
+    moveTo: (_t: unknown, o?: { range?: number }) => {
+      calls.moveTo += 1;
+      calls.lastMoveRange = o?.range;
+    },
+    pickup: (_p: Pile) => {
+      calls.pickup += 1;
+      return 0;
+    },
+    calls
+  };
+  return creep;
+}
+
+const pile = (x: number, y: number): Pile => ({ resourceType: "energy", amount: 200, pos: { x, y } });
+
+describe("workSpot (hauler energy access)", () => {
+  it("moves closer when collecting from a bare pile two tiles away (does not pick up)", () => {
+    const p = pile(25, 25);
+    const creep = makeCreep(25, 27, [p]); // range 2 from the pile
+    const spot: EnergySpot = { pos: p.pos as any };
+
+    workSpot(creep as any, spot, "collect");
+
+    expect(creep.calls.pickup).to.equal(0);
+    expect(creep.calls.moveTo).to.equal(1);
+    // It must close to range 1 - the bug was approaching only to range 2.
+    expect(creep.calls.lastMoveRange).to.equal(1);
+  });
+
+  it("picks up the pile once adjacent (range 1)", () => {
+    const p = pile(25, 25);
+    const creep = makeCreep(25, 26, [p]); // range 1 from the pile
+    const spot: EnergySpot = { pos: p.pos as any };
+
+    workSpot(creep as any, spot, "collect");
+
+    expect(creep.calls.moveTo).to.equal(0);
+    expect(creep.calls.pickup).to.equal(1);
+  });
+});


### PR DESCRIPTION
Haulers collecting from a bare drop pile approached only to range 2, but `pickup`/`withdraw` reach range 1 — so the hauler parked a tile short and never collected. Remote sources (no container, just a drop pile) hit this path; local sources hid it behind their container. Fix: collect (and any structure touch) closes to range 1; only a bare drop may happen from range 2. Adds unit tests.

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_