### PR TITLE
Fix miner/hauler coordination: no orphan haulers, miner-first, stand clear

### DIFF
--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -23,6 +23,13 @@ export interface EnergySpot {
   pos: RoomPosition;
   /** If set, transfer-to / withdraw-from this; if absent, drop / pick up at pos. */
   structure?: StoreStructure;
+  /**
+   * True when `pos` is a stand-clear point, not an energy target yet - a bare
+   * source with no drop pile. The hauler should wait NEAR it (not on it) so it
+   * doesn't block the miner's harvest tile, and approach the actual pile once the
+   * miner starts dropping.
+   */
+  waitClear?: boolean;
 }
 
 /**
@@ -42,7 +49,8 @@ export function sourcePickupSpot(sourcePos: RoomPosition): EnergySpot {
     .sort((a, b) => b.amount - a.amount)[0];
   if (pile) return { pos: pile.pos };
 
-  return { pos: sourcePos };
+  // No pile yet: stand clear of the source so we don't block the miner's tile.
+  return { pos: sourcePos, waitClear: true };
 }
 
 /**
@@ -68,12 +76,14 @@ export function controllerDeliverySpot(controller: StructureController): EnergyS
  */
 export function workSpot(creep: Creep, spot: EnergySpot, mode: "collect" | "deposit"): number {
   // pickup/withdraw must be adjacent to the energy (range 1); a structure is
-  // likewise touched at range 1. Only a bare DROP can be done from range 2 - the
-  // energy lands on the creep's own tile, so it just needs to be near the spot.
-  // Collecting from a bare drop pile at range 2 was the bug: the hauler stopped a
-  // tile short of the pile (common in remote mining, where there is no container)
-  // and the range-1 pickup never reached it.
-  const range = mode === "collect" || spot.structure ? 1 : 2;
+  // likewise touched at range 1. A bare DROP only needs range 2 (it lands on the
+  // creep's own tile). A waitClear spot (a bare source with no pile yet) is also
+  // approached only to range 2, so the hauler idles near the source rather than
+  // camping the miner's harvest tile - it closes to range 1 once a real pile
+  // appears (sourcePickupSpot then returns the pile, not the waitClear source).
+  // Collecting a real pile at range 2 was the original bug (the hauler stopped a
+  // tile short, common in remote mining where there is no container).
+  const range = mode === "collect" && !spot.waitClear ? 1 : spot.structure ? 1 : 2;
   if (creep.pos.getRangeTo(spot.pos) > range) {
     creep.moveTo(spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
     return 0;

--- a/src/flow/FlowMaterializer.ts
+++ b/src/flow/FlowMaterializer.ts
@@ -139,6 +139,31 @@ function buildSinkNodeMap(graph: FlowGraph): Map<string, string> {
   return map;
 }
 
+/**
+ * Group hauler assignments by their source, keeping only sources that have a
+ * miner (per `hasMiner`). Sources with haulers but no miner are returned in
+ * `orphaned` so the caller can drop them - a hauler with no miner has nothing to
+ * pick up. Pure, so the gate can be unit tested directly.
+ */
+export function groupHaulersByMinedSource(
+  haulers: HaulerAssignment[],
+  hasMiner: (sourceId: string) => boolean
+): { bySource: Map<string, HaulerAssignment[]>; orphaned: string[] } {
+  const bySource = new Map<string, HaulerAssignment[]>();
+  const orphaned = new Set<string>();
+  for (const hauler of haulers) {
+    const src = hauler.fromId.replace("source-", "");
+    if (!hasMiner(src)) {
+      orphaned.add(src);
+      continue;
+    }
+    const list = bySource.get(src);
+    if (list) list.push(hauler);
+    else bySource.set(src, [hauler]);
+  }
+  return { bySource, orphaned: [...orphaned] };
+}
+
 // =============================================================================
 // NODE FLOW MATERIALIZATION
 // =============================================================================
@@ -173,12 +198,16 @@ function materializeNodeFlow(
   // local "mover": it distributes the source's energy across the local sinks in
   // proportion to the flow solver's allocations, rather than dumping everything
   // into the spawn.
-  const haulersBySource = new Map<string, HaulerAssignment[]>();
-  for (const hauler of nodeFlow.haulers) {
-    const src = hauler.fromId.replace("source-", "");
-    const list = haulersBySource.get(src);
-    if (list) list.push(hauler);
-    else haulersBySource.set(src, [hauler]);
+  // Only field haulers for a source we actually mine. A remote source we
+  // currently have no vision of has its HarvestCorp skipped (the live source
+  // object isn't found), so without this gate we would create a CarryCorp with
+  // no miner - haulers with nothing to pick up, burning spawn capacity.
+  const { bySource: haulersBySource, orphaned } = groupHaulersByMinedSource(
+    nodeFlow.haulers,
+    src => corps.harvestCorps[src] !== undefined
+  );
+  for (const src of orphaned) {
+    result.warnings.push(`No miner for source ${src.slice(-4)}; skipping its haulers`);
   }
   for (const haulers of haulersBySource.values()) {
     materializeCarryCorpForSource(haulers, corps, tick, result);

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -180,7 +180,13 @@ export function effectiveValue(demand: SpawnDemand, tick: number): number {
 export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): ScheduleResult | null {
   if (demands.length === 0) return null;
 
-  const ranked = [...demands].sort((a, b) => effectiveValue(b, ctx.tick) - effectiveValue(a, ctx.tick));
+  // Within a mining unit the miner is a prerequisite for its haulers: while a
+  // source still has an unmet miner demand, hold back that source's haulers so
+  // the miner is staffed first. Otherwise a hauler can outrank its own miner on
+  // raw value and get funded with nothing to pick up.
+  const eligible = withMinerPrecedence(demands);
+
+  const ranked = [...eligible].sort((a, b) => effectiveValue(b, ctx.tick) - effectiveValue(a, ctx.tick));
 
   for (const demand of ranked) {
     if (ctx.energyAvailable >= demand.minCost) {
@@ -204,4 +210,20 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
   }
 
   return null;
+}
+
+/**
+ * Drop hauler demands whose funding group still has an unmet miner demand - the
+ * miner must be staffed before its haulers (a hauler with no miner has nothing to
+ * carry). Other roles, and haulers whose group has no pending miner, pass
+ * through unchanged. Pure, so the precedence rule can be unit tested directly.
+ */
+export function withMinerPrecedence(demands: SpawnDemand[]): SpawnDemand[] {
+  const sourcesAwaitingMiner = new Set(
+    demands.filter(d => d.role === "miner" && d.groupId !== undefined).map(d => d.groupId)
+  );
+  if (sourcesAwaitingMiner.size === 0) return demands;
+  return demands.filter(
+    d => !(d.role === "hauler" && d.groupId !== undefined && sourcesAwaitingMiner.has(d.groupId))
+  );
 }

--- a/test/unit/corps/workSpot.test.ts
+++ b/test/unit/corps/workSpot.test.ts
@@ -65,4 +65,20 @@ describe("workSpot (hauler energy access)", () => {
     expect(creep.calls.moveTo).to.equal(0);
     expect(creep.calls.pickup).to.equal(1);
   });
+
+  it("keeps clear of a bare source (waitClear): approaches only to range 2", () => {
+    // No pile yet - the spot is the source tile, flagged waitClear so the hauler
+    // idles nearby instead of camping the miner's harvest tile.
+    const spot: EnergySpot = { pos: { x: 25, y: 25 } as any, waitClear: true };
+
+    const far = makeCreep(25, 28, []); // range 3 - should move, but only to range 2
+    workSpot(far as any, spot, "collect");
+    expect(far.calls.moveTo).to.equal(1);
+    expect(far.calls.lastMoveRange).to.equal(2);
+
+    const near = makeCreep(25, 27, []); // range 2 - close enough; wait (no pile, no move)
+    workSpot(near as any, spot, "collect");
+    expect(near.calls.moveTo).to.equal(0);
+    expect(near.calls.pickup).to.equal(0);
+  });
 });

--- a/test/unit/flow/groupHaulersByMinedSource.test.ts
+++ b/test/unit/flow/groupHaulersByMinedSource.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import { groupHaulersByMinedSource } from "../../../src/flow/FlowMaterializer";
+import { HaulerAssignment } from "../../../src/flow/FlowTypes";
+
+function hauler(fromId: string, toId: string): HaulerAssignment {
+  return {
+    edgeId: `${fromId}|${toId}`,
+    fromId,
+    toId,
+    distance: 10,
+    carryParts: 2,
+    flowRate: 10,
+    spawnCostPerTick: 0.1,
+    spawnId: "spawn-abc"
+  };
+}
+
+describe("groupHaulersByMinedSource", () => {
+  it("keeps haulers for a source that has a miner", () => {
+    const haulers = [hauler("source-A", "spawn-x"), hauler("source-A", "controller-x")];
+    const { bySource, orphaned } = groupHaulersByMinedSource(haulers, () => true);
+
+    expect(orphaned).to.have.length(0);
+    expect([...bySource.keys()]).to.deep.equal(["A"]);
+    expect(bySource.get("A")).to.have.length(2);
+  });
+
+  it("drops haulers for a source with no miner (the orphan-hauler bug)", () => {
+    // source-B has a miner; source-A (e.g. a remote source we can't see) does not.
+    const haulers = [hauler("source-A", "controller-x"), hauler("source-B", "controller-x")];
+    const hasMiner = (src: string): boolean => src === "B";
+
+    const { bySource, orphaned } = groupHaulersByMinedSource(haulers, hasMiner);
+
+    expect([...bySource.keys()]).to.deep.equal(["B"]);
+    expect(orphaned).to.deep.equal(["A"]);
+  });
+
+  it("reports an orphaned source only once even with several routes", () => {
+    const haulers = [hauler("source-A", "spawn-x"), hauler("source-A", "controller-x")];
+    const { bySource, orphaned } = groupHaulersByMinedSource(haulers, () => false);
+
+    expect(bySource.size).to.equal(0);
+    expect(orphaned).to.deep.equal(["A"]);
+  });
+});

--- a/test/unit/spawn/minerPrecedence.test.ts
+++ b/test/unit/spawn/minerPrecedence.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import { withMinerPrecedence } from "../../../src/spawn/SpawnScheduler";
+import { SpawnDemand, SpawnRole } from "../../../src/spawn/SpawnScheduler";
+
+function demand(role: SpawnRole, groupId: string | undefined, value = 100): SpawnDemand {
+  return {
+    buyerCorpId: `${role}-${groupId}`,
+    role,
+    value,
+    blocking: false,
+    producesIncome: role === "miner" || role === "hauler",
+    groupId,
+    desiredCost: 300,
+    minCost: 150,
+    since: 0
+  };
+}
+
+describe("withMinerPrecedence", () => {
+  it("drops a source's haulers while its miner is still unmet", () => {
+    const demands = [demand("miner", "srcA"), demand("hauler", "srcA", 110)];
+    const out = withMinerPrecedence(demands);
+
+    expect(out.map(d => d.role)).to.deep.equal(["miner"]);
+  });
+
+  it("keeps haulers once their source has no pending miner demand", () => {
+    // srcA's miner is fully staffed (no miner demand), so its haulers proceed.
+    const demands = [demand("hauler", "srcA"), demand("upgrader", "roomX")];
+    const out = withMinerPrecedence(demands);
+
+    expect(out).to.have.length(2);
+  });
+
+  it("only holds back haulers of the same source, not other sources", () => {
+    const demands = [
+      demand("miner", "srcA"),
+      demand("hauler", "srcA"),
+      demand("hauler", "srcB") // srcB has no pending miner -> allowed
+    ];
+    const out = withMinerPrecedence(demands);
+
+    expect(out.map(d => d.buyerCorpId)).to.deep.equal(["miner-srcA", "hauler-srcB"]);
+  });
+
+  it("leaves non-mining demands untouched", () => {
+    const demands = [demand("upgrader", "roomX"), demand("builder", "roomX"), demand("scout", undefined)];
+    expect(withMinerPrecedence(demands)).to.have.length(3);
+  });
+});


### PR DESCRIPTION
Three related miner/hauler coordination fixes:

- **Orphan haulers** — a remote source we can't currently see has its `HarvestCorp` skipped, but its `CarryCorp` was still created. `groupHaulersByMinedSource` gates hauler materialization on a miner existing for that source.
- **Miner precedence** — a source's hauler could outrank its own miner on value and be funded first. `withMinerPrecedence` holds back a source's haulers while its miner demand is unmet.
- **Stand clear** — at a bare source with no pile yet, the hauler camped the miner's harvest tile. `sourcePickupSpot` flags it `waitClear`; `workSpot` keeps the hauler at range 2 until a real pile appears, then closes to range 1.

Pure helpers unit-tested; 377 unit + 7 integration green.

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_