### PR TITLE
Fix bootstrap->flow hand-off + add flow-handoff probe

### DIFF
--- a/src/corps/HarvestCorp.ts
+++ b/src/corps/HarvestCorp.ts
@@ -366,8 +366,15 @@ export class HarvestCorp extends Corp {
    * additional source's miner is expansion rather than a blocking bootstrap need.
    */
   private colonyHasMiner(): boolean {
+    // Count only real FLOW miners (a HarvestCorp's creep, corpId "mining-..."),
+    // NOT bootstrap jacks - which also carry workType "harvest" but corpId
+    // "bootstrap-...". Counting jacks here made every flow miner non-blocking
+    // while jacks were alive, so the blocking upgrader/haulers always outranked
+    // it and no flow miner ever spawned: the colony could never hand off from
+    // bootstrap to the flow economy.
     for (const name in Game.creeps) {
-      if (Game.creeps[name].memory.workType === "harvest") return true;
+      const memory = Game.creeps[name].memory;
+      if (memory.workType === "harvest" && memory.corpId?.startsWith("mining-")) return true;
     }
     return false;
   }

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -213,17 +213,20 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
 }
 
 /**
- * Drop hauler demands whose funding group still has an unmet miner demand - the
- * miner must be staffed before its haulers (a hauler with no miner has nothing to
- * carry). Other roles, and haulers whose group has no pending miner, pass
- * through unchanged. Pure, so the precedence rule can be unit tested directly.
+ * Drop hauler demands whose source has NO miner in the field yet - the first
+ * miner must be staffed before its haulers (a hauler with no miner has nothing
+ * to carry). Gated on `groupStarted` (a miner is already mining), NOT on the
+ * mere presence of a miner demand: once the first miner exists, its haulers may
+ * proceed even while a bigger/second miner is still wanted - otherwise an
+ * under-target miner starves its own haulers forever and the source's energy
+ * strands unhauled. Other roles pass through. Pure, so it can be unit tested.
  */
 export function withMinerPrecedence(demands: SpawnDemand[]): SpawnDemand[] {
-  const sourcesAwaitingMiner = new Set(
-    demands.filter(d => d.role === "miner" && d.groupId !== undefined).map(d => d.groupId)
+  const sourcesWithoutMiner = new Set(
+    demands.filter(d => d.role === "miner" && !d.groupStarted && d.groupId !== undefined).map(d => d.groupId)
   );
-  if (sourcesAwaitingMiner.size === 0) return demands;
+  if (sourcesWithoutMiner.size === 0) return demands;
   return demands.filter(
-    d => !(d.role === "hauler" && d.groupId !== undefined && sourcesAwaitingMiner.has(d.groupId))
+    d => !(d.role === "hauler" && d.groupId !== undefined && sourcesWithoutMiner.has(d.groupId))
   );
 }

--- a/test/integration/flow-handoff.test.ts
+++ b/test/integration/flow-handoff.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { assert } from "chai";
+import { helper, hookConsole } from "./helper";
+import { loadLayout, padNeighborTerrain } from "./loadLayout";
+
+before(() => hookConsole());
+afterEach(async () => helper.afterEach());
+
+/**
+ * Flow hand-off / budget-vs-actual probe.
+ *
+ * Runs a bootstrap room on the reliable integration harness (which persists the
+ * bot's Memory, unlike ad-hoc ts-node scripts) and samples, over time:
+ *   - the creep population by workType (does it move off bootstrap onto flow
+ *     miners/haulers/upgraders?), from Memory.creeps;
+ *   - controller progress;
+ *   - Memory.corpVariance (each budgeted corp's budget vs measured actual).
+ *
+ * It prints a per-sample line so we can read trustworthy numbers, and only
+ * soft-asserts that the colony stays alive, so the diagnostic always reports.
+ */
+describe("flow hand-off probe", () => {
+  it("reports bootstrap->flow transition and corp budget vs actual over 600 ticks", async function () {
+    this.timeout(300000);
+
+    // Two chambers split by a vertical wall at x=25 (gap at y=23..27), so peak
+    // detection has distinct open areas to find - unlike an all-plain room.
+    const terrain = Array.from({ length: 50 }, (_v, y) =>
+      ".".repeat(25) + (y >= 23 && y <= 27 ? "." : "#") + ".".repeat(24)
+    );
+    await helper.beforeEach(async (world) => {
+      await loadLayout(world, {
+        room: "W0N0",
+        terrain,
+        objects: [
+          { type: "controller", x: 38, y: 25 },
+          { type: "source", x: 10, y: 10 },
+          { type: "source", x: 40, y: 40 }
+        ]
+      });
+      await padNeighborTerrain(world, ["W0N0"]);
+      await helper.addBot({ room: "W0N0", x: 12, y: 25 });
+    });
+
+    const samples: string[] = [];
+    for (let t = 1; t <= 400; t += 1) {
+      await helper.server.tick();
+      if (t % 100 !== 0) continue;
+
+      const mem = JSON.parse((await helper.player.memory) || "{}");
+      const creeps = mem.creeps || {};
+      const byType: Record<string, number> = {};
+      for (const name in creeps) {
+        const wt = (creeps[name] as any).workType || "bootstrap";
+        byType[wt] = (byType[wt] || 0) + 1;
+      }
+      const objects = await helper.server.world.roomObjects("W0N0");
+      const ctrl = objects.find((o: any) => o.type === "controller");
+      const variance = (mem.corpVariance || [])
+        .map((r: any) => `${r.type} ${r.actual}/${r.budget}`)
+        .join(", ");
+      const hc = mem.harvestCorps || {};
+      const minersWithAssignment = Object.values(hc).filter((c: any) => c.minerAssignment).length;
+      const corps =
+        `nodes ${Object.keys(mem.nodes || {}).length} ` +
+        `harvest ${Object.keys(hc).length}(${minersWithAssignment} assigned) ` +
+        `haul ${Object.keys(mem.haulingCorps || {}).length} ` +
+        `upgrade ${Object.keys(mem.upgradingCorps || {}).length} ` +
+        `bootstrap ${Object.keys(mem.bootstrapCorps || {}).length}`;
+      samples.push(
+        `tick ${t}: RCL ${ctrl?.level ?? 0} prog ${ctrl?.progress ?? 0} | creeps ${JSON.stringify(byType)} | ${corps} | variance [${variance}]`
+      );
+    }
+
+    console.log("\n=== flow hand-off probe ===");
+    for (const line of samples) console.log(line);
+
+    const lastObjects = await helper.server.world.roomObjects("W0N0");
+    const liveCreeps = lastObjects.filter((o: any) => o.type === "creep").length;
+    assert.isAbove(liveCreeps, 0, "colony should keep at least one creep alive");
+  });
+});

--- a/test/integration/flow-handoff.test.ts
+++ b/test/integration/flow-handoff.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { assert } from "chai";
 import { helper, hookConsole } from "./helper";
-import { loadLayout, padNeighborTerrain } from "./loadLayout";
+import { loadLayout, padNeighborTerrain, setRoomLevel } from "./loadLayout";
 
 before(() => hookConsole());
 afterEach(async () => helper.afterEach());
@@ -40,10 +40,15 @@ describe("flow hand-off probe", () => {
       });
       await padNeighborTerrain(world, ["W0N0"]);
       await helper.addBot({ room: "W0N0", x: 12, y: 25 });
+      // Start at RCL 2 (with 5 extensions) so the flow economy's gate is open
+      // from tick 1 - no need to grind bootstrap up from RCL 1.
+      await setRoomLevel(world, "W0N0", 2, [
+        { x: 13, y: 24 }, { x: 11, y: 24 }, { x: 13, y: 26 }, { x: 11, y: 26 }, { x: 14, y: 25 }
+      ]);
     });
 
     const samples: string[] = [];
-    for (let t = 1; t <= 400; t += 1) {
+    for (let t = 1; t <= 500; t += 1) {
       await helper.server.tick();
       if (t % 100 !== 0) continue;
 
@@ -75,8 +80,16 @@ describe("flow hand-off probe", () => {
     console.log("\n=== flow hand-off probe ===");
     for (const line of samples) console.log(line);
 
-    const lastObjects = await helper.server.world.roomObjects("W0N0");
-    const liveCreeps = lastObjects.filter((o: any) => o.type === "creep").length;
-    assert.isAbove(liveCreeps, 0, "colony should keep at least one creep alive");
+    // Regression guard for the bootstrap->flow hand-off: starting at RCL 2 the
+    // colony must actually staff its FLOW corps - a flow miner producing real
+    // energy (corpVariance actual > 0) and a hauler moving it. Before the
+    // colonyHasMiner / withMinerPrecedence fixes this stayed 0 forever while the
+    // colony ran only on bootstrap jacks.
+    const mem = JSON.parse((await helper.player.memory) || "{}");
+    const rows = (mem.corpVariance || []) as Array<{ type: string; actual: number }>;
+    const minerProducing = rows.some(r => r.type === "mining" && r.actual > 0);
+    const haulerProducing = rows.some(r => r.type === "hauling" && r.actual > 0);
+    assert.isTrue(minerProducing, "a flow miner should be producing energy (hand-off)");
+    assert.isTrue(haulerProducing, "a flow hauler should be moving energy (hand-off)");
   });
 });

--- a/test/integration/loadLayout.ts
+++ b/test/integration/loadLayout.ts
@@ -177,6 +177,39 @@ export function enableMods(serverPath: string, modPaths: string[]): void {
 /** Absolute path to the bundled free-economy mod (zeroes build/upgrade sinks). */
 export const FREE_ECONOMY_MOD = path.resolve(__dirname, "mods", "freeEconomy.js");
 
+/**
+ * Set an owned room's controller level (and optional extension count), so a sim
+ * can START at a given RCL instead of grinding through bootstrap to reach it.
+ * Call after the bot is added (its controller exists). Extensions are dropped
+ * around the spawn so energyCapacityAvailable reflects the level.
+ */
+export async function setRoomLevel(
+  world: any,
+  room: string,
+  level: number,
+  extensions: Array<{ x: number; y: number }> = []
+): Promise<void> {
+  const { C, db } = await world.load();
+  await db["rooms.objects"].update(
+    { room, type: "controller" },
+    { $set: { level, progress: 0, downgradeTime: null } }
+  );
+  for (const e of extensions) {
+    await db["rooms.objects"].insert({
+      room,
+      type: "extension",
+      x: e.x,
+      y: e.y,
+      user: (await db["rooms.objects"].findOne({ room, type: "controller" })).user,
+      store: { energy: 0 },
+      storeCapacityResource: { energy: C.EXTENSION_ENERGY_CAPACITY[level] ?? 50 },
+      hits: C.EXTENSION_HITS,
+      hitsMax: C.EXTENSION_HITS,
+      notifyWhenAttacked: true
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Neighbour-room padding
 // ---------------------------------------------------------------------------

--- a/test/unit/spawn/minerPrecedence.test.ts
+++ b/test/unit/spawn/minerPrecedence.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { withMinerPrecedence } from "../../../src/spawn/SpawnScheduler";
 import { SpawnDemand, SpawnRole } from "../../../src/spawn/SpawnScheduler";
 
-function demand(role: SpawnRole, groupId: string | undefined, value = 100): SpawnDemand {
+function demand(role: SpawnRole, groupId: string | undefined, value = 100, groupStarted = false): SpawnDemand {
   return {
     buyerCorpId: `${role}-${groupId}`,
     role,
@@ -10,6 +10,7 @@ function demand(role: SpawnRole, groupId: string | undefined, value = 100): Spaw
     blocking: false,
     producesIncome: role === "miner" || role === "hauler",
     groupId,
+    groupStarted,
     desiredCost: 300,
     minCost: 150,
     since: 0
@@ -30,6 +31,15 @@ describe("withMinerPrecedence", () => {
     const out = withMinerPrecedence(demands);
 
     expect(out).to.have.length(2);
+  });
+
+  it("keeps a source's haulers once its first miner is in the field (groupStarted)", () => {
+    // srcA still wants a bigger/second miner, but one is already mining
+    // (groupStarted) - so its haulers must NOT be held back.
+    const demands = [demand("miner", "srcA", 100, true), demand("hauler", "srcA")];
+    const out = withMinerPrecedence(demands);
+
+    expect(out.map(d => d.role)).to.deep.equal(["miner", "hauler"]);
   });
 
   it("only holds back haulers of the same source, not other sources", () => {


### PR DESCRIPTION
Fixes the bootstrap→flow hand-off (the flow economy never engaged) plus a reliable integration probe.

- `colonyHasMiner()` counted bootstrap jacks (same `workType: "harvest"`), so the first flow miner was never `blocking` and never won the spawn against the blocking upgrader/haulers. Now counts only real flow miners (`corpId` `mining-…`).
- `withMinerPrecedence` held a source's haulers back while *any* miner demand existed → an under-target small miner starved its own haulers. Now gated on `groupStarted` (first miner in the field).
- Adds `flow-handoff` integration probe (runs on the reliable mocha harness, can read Memory) that asserts a flow miner + hauler actually produce.

Result: flow miner and hauler spawn and produce (real `corpVariance` actuals). 378 unit + bootstrap green.

Known remaining (separate): the miner spawns small so income is thin and upgraders are still starved (controller progress 0) — a sizing/distribution tuning issue, not the deadlock.

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_