### PR TITLE
Hold the spawn for a blocking producer instead of bleeding it dry

### DIFF
--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -167,15 +167,20 @@ export function effectiveValue(demand: SpawnDemand, tick: number): number {
  *     fresh one; see {@link COMPLETION_BOOST}).
  *  2. Walk from highest value:
  *     - If we can afford the demand's minimum body, spawn it now, spending up
- *       to its desired cost (capped by available energy).
- *     - Otherwise, if it is a *blocking* demand that the room can eventually
- *       afford AND energy is actually flowing in (income > 0), wait: hold the
- *       spawn so energy accumulates for it, rather than spending on a
- *       lower-value creep. This is what lets the upgrader win against a steady
- *       trickle of mining orders.
- *     - Otherwise skip it and consider the next demand. In particular, when no
- *       energy is coming in yet (income == 0) we never wait - we fall through to
- *       spawn whatever affordable income producer gets the economy moving.
+ *       to its desired cost (capped by available energy) - UNLESS we are holding
+ *       the spawn for a higher-ranked blocking demand we cannot yet afford, in
+ *       which case we only spend on another *blocking* demand (never on a lower
+ *       non-blocking creep) so energy keeps accumulating for the blocking one.
+ *     - If a *blocking* demand the room can eventually afford is unaffordable
+ *       right now, hold the spawn for it: directly when energy is flowing
+ *       (income > 0), or - even at income == 0 - by refusing to spend the dribble
+ *       on lower-priority non-blocking creeps. The latter is what breaks the
+ *       first-hauler deadlock: a freshly-mining source's blocking hauler costs
+ *       more than a near-empty spawn holds, and if we kept funding extra miners /
+ *       upgraders the spawn would never accumulate the hauler's body. Cold-start
+ *       income is supplied by the bootstrap corp (which spawns its jacks
+ *       directly, ahead of this scheduler), so holding here cannot deadlock the
+ *       very first creep.
  */
 export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): ScheduleResult | null {
   if (demands.length === 0) return null;
@@ -188,8 +193,25 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
 
   const ranked = [...eligible].sort((a, b) => effectiveValue(b, ctx.tick) - effectiveValue(a, ctx.tick));
 
+  // Set once we pass a blocking demand we cannot afford yet but the room can
+  // eventually build. From then on we decline to spend the dribble on
+  // lower-priority creeps, letting the spawn fill for the blocking demand.
+  let holdForBlocking = false;
+  // Strict hold: the blocking demand we are waiting on is itself an income
+  // PRODUCER (a hauler), which means energy is already being mined and just
+  // needs moving - spawning more producers would not help, so even an affordable
+  // income producer must wait. When the blocking demand is a consumer (upgrader)
+  // we are NOT strict: an affordable income producer still spawns, because we
+  // need income flowing before the consumer can ever be afforded (cold start).
+  let holdStrict = false;
+
   for (const demand of ranked) {
     if (ctx.energyAvailable >= demand.minCost) {
+      // While holding for an unaffordable blocking demand, decline lower-priority
+      // creeps that would bleed the spawn back below the body we are accumulating
+      // for. A blocking demand always spends; a non-blocking income producer
+      // spends only when the hold is not strict (see holdStrict).
+      if (holdForBlocking && !demand.blocking && (holdStrict || !demand.producesIncome)) continue;
       const energyBudget = Math.min(demand.desiredCost, ctx.energyAvailable);
       return {
         demand,
@@ -200,11 +222,18 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
 
     // Cannot afford even the minimum body for this demand.
     const canEverAfford = ctx.energyCapacity >= demand.minCost;
-    const worthWaiting = demand.blocking && canEverAfford && ctx.energyIncome > 0;
-    if (worthWaiting) {
-      // Hold the spawn for this high-value blocking demand instead of spending
-      // energy on something less important.
-      return null;
+    if (demand.blocking && canEverAfford) {
+      if (ctx.energyIncome > 0) {
+        // Energy is flowing in - just hold the spawn for this blocking demand
+        // instead of spending on something less important.
+        return null;
+      }
+      // No income yet: don't spend the dribble on lower-priority creeps. Keep
+      // scanning in case a lower-ranked demand we DO allow is affordable (a
+      // blocking demand always; an income producer when the hold is not strict),
+      // which still makes progress; otherwise we fall through to the final hold.
+      holdForBlocking = true;
+      if (demand.producesIncome) holdStrict = true;
     }
     // Otherwise, let a lower-value but affordable demand have a turn.
   }

--- a/test/unit/spawn/SpawnScheduler.test.ts
+++ b/test/unit/spawn/SpawnScheduler.test.ts
@@ -101,6 +101,43 @@ describe("SpawnScheduler", () => {
         expect(result?.demand.buyerCorpId).to.equal("miner");
       });
 
+      it("holds for a blocking income PRODUCER at income==0 instead of funding more producers", () => {
+        // The first hauler deadlock: a freshly-mining source's blocking hauler
+        // costs more than the drained spawn holds, and income is 0 (bootstrap
+        // delivers separately). Spawning the affordable extra miner would bleed
+        // the spawn and the hauler's body would never accumulate - energy is
+        // already being mined, it just needs moving. So we hold (spawn nothing).
+        const hauler = demand({
+          buyerCorpId: "hauler", role: "hauler", value: 100, blocking: true,
+          producesIncome: true, minCost: 300, desiredCost: 500,
+        });
+        const extraMiner = demand({
+          buyerCorpId: "miner2", role: "miner", value: 30, producesIncome: true,
+          minCost: 150, desiredCost: 250,
+        });
+        const result = scheduleSpawn([hauler, extraMiner], ctx({
+          energyAvailable: 200, energyCapacity: 550, energyIncome: 0,
+        }));
+        expect(result).to.equal(null);
+      });
+
+      it("still spawns a lower-ranked blocking demand while holding for an unaffordable one", () => {
+        // Holding for one blocking producer must not block ANOTHER source's
+        // affordable first miner - that makes real progress (more income).
+        const hauler = demand({
+          buyerCorpId: "hauler", role: "hauler", value: 100, blocking: true,
+          producesIncome: true, minCost: 300, desiredCost: 500,
+        });
+        const firstMiner = demand({
+          buyerCorpId: "minerB", role: "miner", value: 90, blocking: true,
+          producesIncome: true, minCost: 150, desiredCost: 250,
+        });
+        const result = scheduleSpawn([hauler, firstMiner], ctx({
+          energyAvailable: 200, energyCapacity: 550, energyIncome: 0,
+        }));
+        expect(result?.demand.buyerCorpId).to.equal("minerB");
+      });
+
       it("does NOT wait for a blocking demand the room can never afford", () => {
         const tooBig = demand({
           buyerCorpId: "toobig", role: "upgrader", value: 80, blocking: true,


### PR DESCRIPTION
## Summary

Continues the bootstrap→flow hand-off work (`4c42e87`) and the CarryCorp-from-plan fix (#55). Those got the flow miner + its CarryCorp to exist; this gets the **first hauler to actually spawn**, so the mining+hauling unit completes instead of stalling with energy mined but never moved.

**Root cause:** `scheduleSpawn` refused to wait for an unaffordable *blocking* demand when `income == 0`, falling through to spend the dribble on whatever was affordable. For a freshly-mining source that meant the spawn kept getting drained on extra miners/upgraders, so the source's blocking **first hauler** — which costs more than a drained spawn holds — could never accumulate its body. Energy was mined and dropped but never hauled.

**Fix:** an unaffordable-but-eventually-affordable blocking demand now **holds** the spawn even at `income == 0`, by declining to fund lower-priority creeps so energy accumulates for it. The hold is:
- **strict** when the blocking demand is itself an income *producer* (a hauler) — energy is already being mined and only needs moving, so spawning more producers can't help; even an affordable extra miner waits.
- **loose** when it's a *consumer* (upgrader) — an affordable income producer still spawns, since cold-start income must flow before the consumer can ever be afforded.
- A lower-ranked **blocking** demand (e.g. another source's first miner) always spawns — that's real progress.

Cold-start income comes from the bootstrap corp, which spawns ahead of this scheduler, so the hold cannot deadlock the very first creep.

## Effect (plan-vs-spawn harness)
- **singleSource**: `haul 0 → 5` — real haulers now spawn and the mining+hauling unit completes (previously only tankers covered the short route; a multi-CARRY haul route never got staffed). Upgrade shifts lower because energy now completes the supply unit + construction first — the intended supply-first ordering.

## Verification
- Build clean (57 modules). 380 unit tests passing (added 2 covering the strict/loose hold and the lower-ranked-blocking exception).

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_