### PR TITLE
Regrow undersized miners without waiting for a fully-maxed room

### DIFF
--- a/src/corps/HarvestCorp.ts
+++ b/src/corps/HarvestCorp.ts
@@ -11,7 +11,7 @@ import { CREEP_LIFETIME, HARVEST_RATE, SOURCE_ENERGY_CAPACITY, SOURCE_REGEN_TIME
 import { Corp, SerializedCorp } from "./Corp";
 import { ChainScene, CorpEconomics, travelTicksPerTile } from "./economics";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
-import { driveRecycle, pickRuntToRecycle, spawnIdleAndMaxed } from "./recycle";
+import { driveRecycle, pickRuntToRecycle } from "./recycle";
 import { MinerAssignment } from "../flow/FlowTypes";
 import { Position } from "../types/Position";
 import { buildMinerBody } from "../spawn/BodyBuilder";
@@ -194,26 +194,38 @@ export class HarvestCorp extends Corp {
   }
 
   /**
-   * Retire an undersized bootstrap miner once the room is flush. The first miner
-   * is floored small so the cold economy can afford it; if it is still mining at
-   * less than the source's full WORK when the room is maxed out and the spawn
-   * would idle, recycle it so its corp respawns it at the full size the room can
-   * now build (e.g. a 2-WORK cold-start miner becomes a 5-WORK miner). Pure gate
-   * + pure pick, so it never fires in a constrained room.
+   * Retire an undersized bootstrap miner so its corp respawns it at full size.
+   * The first miner is floored small so the cold economy can afford it; left
+   * alone it caps the source's output for its whole 1500-tick life.
+   *
+   * We recycle a runt once the room can IMMEDIATELY rebuild it one size larger
+   * (energyAvailable covers a bigger body): the replacement is a guaranteed
+   * upgrade and spawns with minimal unmined gap. The old gate required the room
+   * to be fully maxed (energyAvailable >= energyCapacityAvailable), but a runt
+   * under-mines the source that fills the room - so a thin room never reached
+   * "maxed" and the runt was immortal, holding the whole economy down (the
+   * runt catch-22). The affordability check still keeps us from disrupting a
+   * miner in a room that genuinely cannot build a bigger one.
    */
   private flagMinerRuntForRecycling(creeps: Creep[], spawn: StructureSpawn): void {
     if (!this.minerAssignment) return;
-    if (!spawnIdleAndMaxed(spawn.room, spawn)) return;
+    if (spawn.spawning) return; // don't compete with an in-progress spawn
     if (creeps.some(c => c.memory.recycling)) return; // one at a time
 
+    const room = spawn.room;
     const totalWork = Math.max(1, Math.ceil(this.minerAssignment.harvestRate / 2));
-    const maxWorkPerMiner = Math.max(1, buildMinerBody(totalWork, spawn.room.energyCapacityAvailable).workParts);
-    const idx = pickRuntToRecycle(
-      creeps.map(c => c.getActiveBodyparts(WORK)),
-      totalWork,
-      maxWorkPerMiner
-    );
-    if (idx !== null) creeps[idx].memory.recycling = true;
+    const maxWorkPerMiner = Math.max(1, buildMinerBody(totalWork, room.energyCapacityAvailable).workParts);
+    const workCounts = creeps.map(c => c.getActiveBodyparts(WORK));
+    const idx = pickRuntToRecycle(workCounts, totalWork, maxWorkPerMiner);
+    if (idx === null) return;
+
+    // Only recycle once we can afford to rebuild this runt at least one WORK
+    // larger right now - guarantees a real upgrade and no long unmined gap.
+    const upgradeWork = Math.min(maxWorkPerMiner, workCounts[idx] + 1);
+    const upgradeCost = buildMinerBody(upgradeWork, room.energyCapacityAvailable).cost;
+    if (room.energyAvailable < upgradeCost) return;
+
+    creeps[idx].memory.recycling = true;
   }
 
   /**
@@ -330,13 +342,17 @@ export class HarvestCorp extends Corp {
     // pressure. A 1-WORK miner harvests just 2/tick against a ~10/tick source, so
     // the source stays under-mined, the spawn it feeds stays starved, and every
     // OTHER corp then runts out too - the whole economy collapses to one-useful-
-    // part creeps. Even a bare spawn (300) affords a 2-WORK miner (250). The first
-    // miner is the bootstrap income, so it may spawn as small as that floor when
-    // energy is tight; later miners hold out for the full desired body, since the
-    // income already flows and a source has only so many spots - each one should
-    // be as large as the room can build.
+    // part creeps. Even a bare spawn (300) affords a 2-WORK miner (250). The runt
+    // floor is ONLY for the colony's very first miner, which is the bootstrap
+    // income and must spawn fast even if tiny. Once income flows (this colony
+    // already has a miner elsewhere - e.g. a second source, or a regrow after a
+    // runt was recycled), hold out for the full desired body: the income already
+    // covers the wait, and a source has only so many spots so each should be as
+    // large as the room can build. This also prevents a single-source regrow from
+    // respawning as a runt again (thrash).
     const desired = buildMinerBody(desiredWork, ctx.energyCapacity);
-    const minWork = current === 0 ? Math.min(desiredWork, 2) : desiredWork;
+    const colonyColdStart = current === 0 && !this.colonyHasMiner();
+    const minWork = colonyColdStart ? Math.min(desiredWork, 2) : desiredWork;
     const min = buildMinerBody(minWork, ctx.energyCapacity);
     if (min.cost === 0) return []; // room cannot afford even a minimal miner
 

--- a/test/unit/corps/HarvestCorp.planning.test.ts
+++ b/test/unit/corps/HarvestCorp.planning.test.ts
@@ -117,9 +117,10 @@ describe("HarvestCorp mining planning (spots x capacity)", () => {
     expect(harvestOf(fieldFleet(3, 300).work)).to.equal(10);
   });
 
-  describe("miner recycling (once the room is flush)", () => {
-    // The corp's maxed+idle gate is exercised in the live loop; here we pin the
-    // WORK-based decision shared with hauler recycling.
+  describe("miner recycling (regrow undersized miners)", () => {
+    // The corp's recycle gate (recycle a runt once the room can afford to rebuild
+    // it one size larger) is exercised in the live loop; here we pin the
+    // WORK-based pick decision shared with hauler recycling.
     it("retires a cold-start 2-WORK miner once the room can build a 5-WORK one", () => {
       // source needs 5 WORK, room now builds up to 5, lone miner is 2 -> recycle it
       expect(pickRuntToRecycle([2], 5, 5)).to.equal(0);


### PR DESCRIPTION
## Summary

Removes the immortal-runt catch-22 in miner sizing (the "miner spawns small so income is thin" item flagged in `4c42e87`).

A cold-start miner is intentionally floored small (2 WORK) so the bare economy can afford it. The regrow path that should later replace it at full size was gated on the room being **fully maxed** (`energyAvailable >= energyCapacityAvailable`). But a runt under-mines the very source that fills the room — so a thin room never reaches "maxed" and the runt is immortal, capping output for its whole 1500-tick life. Self-sustaining deadlock.

**Two coordinated changes:**
- **Regrow gate:** recycle a runt once the room can *immediately* rebuild it one WORK larger (`energyAvailable` covers the bigger body), instead of requiring a maxed room. The replacement is a guaranteed upgrade with minimal unmined gap; the affordability check still prevents disrupting a miner in a room that genuinely can't build bigger.
- **Floor scope:** the runt floor now applies only to the colony's **true first miner** (no income anywhere yet). A second source's first miner, or a regrow after a runt was recycled, holds out for the full desired body — income already covers the wait, and it prevents a single-source regrow from respawning as a runt again (thrash).

## Verification
- 380 unit tests green.
- **singleSource** (cap 300): miners stay `[2,2]` — max for a 300-cap room, so the gate correctly never fires (no churn, no regression).
- In a fully-drained room (`energyAvailable ≈ 0`) the gate stays shut, so the change is **neutral-safe** there.

## Note on twoSourceRcl3
The live harvest benefit lands in rooms with extension capacity but small miners (e.g. twoSourceRcl3, cap 550, 3-WORK miner). That scenario is currently blocked *upstream* by a separate cold-start **delivery deadlock** (consumers drain the spawn before a mining+hauling delivery unit exists; bootstrap then can't recover from a drained spawn → `spawnE=0` permanently), so the regrow gate can't engage there yet. This change is correct and ready for when that deadlock is resolved.

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_