### PR TITLE
Fast spawn-decision regression tests + per-geometry economy suite

### DIFF
--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -111,8 +111,11 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
  * from then on its remaining demands (its haulers, any second miner) are flagged
  * groupStarted so the scheduler finishes funding that source before opening a
  * fresh one - the "fund one corp fully, then move on" strategy.
+ *
+ * Exported so the spawn-decision harness can drive the real grouping logic (not
+ * a re-implementation) when freezing "what spawns next" regression moments.
  */
-function collectDemands(registry: CorpRegistry, spawnId: string, ctx: SpawnDemandContext): SpawnDemand[] {
+export function collectDemands(registry: CorpRegistry, spawnId: string, ctx: SpawnDemandContext): SpawnDemand[] {
   const demands: SpawnDemand[] = [];
 
   for (const id in registry.harvestCorps) {

--- a/test/integration/helper.ts
+++ b/test/integration/helper.ts
@@ -35,6 +35,7 @@ export interface AddBotOptions {
 export class IntegrationTestHelper {
   private _server: any;
   private _player: any;
+  private _serverPath = "";
 
   get server() {
     return this._server;
@@ -42,6 +43,17 @@ export class IntegrationTestHelper {
 
   get player() {
     return this._player;
+  }
+
+  /**
+   * Filesystem path of the current server instance. The engine reads its
+   * `db.json` here as its MODFILE, so tests that want to load engine mods (e.g.
+   * the free-economy mod) call `enableMods(helper.serverPath, [...])` from
+   * inside the `buildWorld` callback - after the world is built (db.json exists)
+   * and before the server starts.
+   */
+  get serverPath() {
+    return this._serverPath;
   }
 
   /**
@@ -54,6 +66,7 @@ export class IntegrationTestHelper {
     const port = nextPort;
     nextPort += 1;
     const serverPath = path.resolve("server", String(port));
+    this._serverPath = serverPath;
     const logdir = path.join(serverPath, "logs");
     // The mockup's own mkdir is non-recursive, so ensure the tree exists first.
     mkdirSync(logdir, { recursive: true });

--- a/test/integration/scenario-economy.test.ts
+++ b/test/integration/scenario-economy.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { assert } from "chai";
+import { readFileSync } from "fs";
+import { helper, hookConsole } from "./helper";
+import { enableMods, FREE_ECONOMY_MOD } from "./loadLayout";
+import { loadScenario, Scenario } from "./scenario/Scenario";
+import * as scenarios from "./scenario/library";
+
+const MAIN = "dist/main.js";
+
+before(() => hookConsole());
+afterEach(async () => helper.afterEach());
+
+/**
+ * Scenario economy-health regression suite (per-geometry coverage).
+ *
+ * Runs library scenarios end-to-end on the integration harness (the path that
+ * reliably persists the bot's Memory) and asserts the income-side invariants
+ * that must hold across *any* room geometry, so a planner/scheduler change that
+ * quietly breaks one shape is caught here:
+ *
+ *   - EVERY source is mined (a flow miner producing real energy for each), and
+ *   - that energy is hauled home (a hauler producing).
+ *
+ * The point is breadth: challenge the economy with different room shapes - a
+ * symmetric pair of sources, and a near + far-corner pair - and catch the
+ * outlier where one source never gets staffed or its energy strands unhauled.
+ * The far-corner case is the one that stresses travel-cost / marginal-value
+ * accounting (a long haul, a miner that spends much of its life walking out);
+ * the symmetric case is the baseline.
+ *
+ * The downstream mine->haul->UPGRADE->controller chain (controller actually
+ * making progress) is guarded separately, unmodded, by `flow-handoff.test.ts` -
+ * it is deliberately not re-asserted here, where the free-economy mod (below)
+ * speeds the income ramp but distorts the upgrade/controller economics.
+ *
+ * Each case runs under the free-economy mod (build + upgrade sinks zeroed) so
+ * the colony reaches its income steady-state in a few hundred ticks instead of
+ * grinding through an energy-starved bootstrap - letting the suite cover several
+ * geometries in a reasonable wall-clock budget.
+ */
+interface EconomyCase {
+  /** Library factory name (for the test title). */
+  name: string;
+  scenario: () => Scenario;
+  /** How many sources the room has - each must end up mined. */
+  sources: number;
+}
+
+const CASES: EconomyCase[] = [
+  // Symmetric baseline: two equidistant sources should both be staffed.
+  { name: "twoSourceRcl3", scenario: scenarios.twoSourceRcl3, sources: 2 },
+  // Distance-stressed: a near source and a far-corner source. The far source's
+  // longer haul / lower useful miner TTL must NOT cause the colony to abandon it.
+  { name: "asymmetricTwoSource", scenario: scenarios.asymmetricTwoSource, sources: 2 },
+];
+
+describe("scenario economy health", () => {
+  for (const c of CASES) {
+    it(`${c.name}: every source mined, energy hauled home`, async function () {
+      this.timeout(600000);
+
+      const main = readFileSync(MAIN).toString();
+      const scenario = c.scenario();
+      const room = scenario.bot.room;
+      let bot: any;
+
+      await helper.beforeEach(async () => {
+        bot = (await loadScenario(helper.server, scenario, main)).bot;
+        // Zero the build/upgrade energy sinks so the income economy ramps fast
+        // enough to cover several geometries per suite run.
+        enableMods(helper.serverPath, [FREE_ECONOMY_MOD]);
+      });
+
+      for (let t = 1; t <= 600; t += 1) {
+        await helper.server.tick();
+      }
+
+      const mem = JSON.parse((await bot.memory) || "{}");
+      const rows = (mem.corpVariance || []) as Array<{ type: string; actual: number }>;
+      const minersProducing = rows.filter(r => r.type === "mining" && r.actual > 0).length;
+      const haulersProducing = rows.filter(r => r.type === "hauling" && r.actual > 0).length;
+
+      // One compact diagnostic line, in the style of the flow-handoff probe, so a
+      // failure is readable without a re-run.
+      const ctrl = (await helper.server.world.roomObjects(room)).find((o: any) => o.type === "controller");
+      console.log(
+        `[${c.name}] RCL ${ctrl?.level} prog ${ctrl?.progress} | ` +
+          `variance ${(mem.corpVariance || []).map((r: any) => `${r.type} ${r.actual}/${r.budget}`).join(", ")}`
+      );
+
+      assert.isAtLeast(
+        minersProducing,
+        c.sources,
+        `every source should be mined (saw ${minersProducing} producing of ${c.sources})`
+      );
+      assert.isAtLeast(haulersProducing, 1, "at least one hauler should be moving energy home");
+    });
+  }
+});

--- a/test/integration/scenario/library.ts
+++ b/test/integration/scenario/library.ts
@@ -31,6 +31,39 @@ export function twoSource(opts: { room?: string } = {}): Scenario {
 }
 
 /**
+ * An open room whose two sources sit at very different distances from the spawn:
+ * one adjacent to the centre, one in the far corner. The symmetric {@link
+ * twoSource} masks distance-sensitive bugs (both sources cost the same to mine
+ * and haul); this asymmetry is the one that stresses them - the far source has a
+ * much longer haul and a miner that spends a big chunk of its life just walking
+ * out (less useful TTL), so it exercises travel-cost / marginal-value accounting
+ * and the question "does the colony still bother to mine the far source?".
+ * Pre-advanced to RCL 3 with a full RCL-2 extension set so the home economy has
+ * the spare hauler capacity to reach the corner.
+ */
+export function asymmetricTwoSource(opts: { room?: string } = {}): Scenario {
+  const room = opts.room ?? "W0N0";
+  const builder = new RoomBuilder(room)
+    .border()
+    .controller(25, 8)
+    .source(22, 22) // near: ~3 tiles from the central spawn
+    .source(45, 45); // far: opposite corner, a long haul home
+  const exts = [
+    { x: 22, y: 24 }, { x: 28, y: 24 }, { x: 22, y: 26 }, { x: 28, y: 26 }, { x: 24, y: 22 },
+  ];
+  return {
+    name: "asymmetric-two-source",
+    description: "Open room, one near + one far-corner source, spawn at centre. RCL 3 + 5 extensions.",
+    rooms: [builder.toRoom()],
+    bot: { room, ...SPAWN },
+    state: {
+      controller: { level: 3, progress: 0 },
+      structures: exts.map((e) => ({ room, type: "extension", x: e.x, y: e.y, energy: 50 })),
+    },
+  };
+}
+
+/**
  * A single open room with one source at the given depth, a central spawn and a
  * controller near the top. `sourceY` controls how far the source is from the
  * spawn - the classic near/far mining comparison.

--- a/test/integration/scenario/library.ts
+++ b/test/integration/scenario/library.ts
@@ -64,6 +64,38 @@ export function asymmetricTwoSource(opts: { room?: string } = {}): Scenario {
 }
 
 /**
+ * A single source gated behind a full-width swamp band, so the only route from
+ * spawn to source crosses ~10 tiles of swamp (5x move cost). This stresses the
+ * travel-cost / useful-TTL math from a different angle than {@link
+ * asymmetricTwoSource}: the straight-line distance is modest but the *effective*
+ * walk is long, so a miner spends much of its life in transit and a hauler's
+ * round trip is slow - the body sizing and hauler count must account for the
+ * terrain, not just the tile distance. Pre-advanced to RCL 3 with a full RCL-2
+ * extension set.
+ */
+export function swampSource(opts: { room?: string } = {}): Scenario {
+  const room = opts.room ?? "W0N0";
+  const builder = new RoomBuilder(room)
+    .border()
+    .rect(1, 31, 48, 40, "swamp") // a swamp band spanning the room
+    .controller(25, 8) // north of the spawn, on clear ground
+    .source(25, 46); // south, reachable only across the swamp band
+  const exts = [
+    { x: 22, y: 24 }, { x: 28, y: 24 }, { x: 22, y: 26 }, { x: 28, y: 26 }, { x: 24, y: 22 },
+  ];
+  return {
+    name: "swamp-source",
+    description: "Open room, one source gated behind a full-width swamp band. RCL 3 + 5 extensions.",
+    rooms: [builder.toRoom()],
+    bot: { room, ...SPAWN },
+    state: {
+      controller: { level: 3, progress: 0 },
+      structures: exts.map((e) => ({ room, type: "extension", x: e.x, y: e.y, energy: 50 })),
+    },
+  };
+}
+
+/**
  * A single open room with one source at the given depth, a central spawn and a
  * controller near the top. `sourceY` controls how far the source is from the
  * spawn - the classic near/far mining comparison.

--- a/test/unit/harness/spawnDecision.ts
+++ b/test/unit/harness/spawnDecision.ts
@@ -1,0 +1,170 @@
+/**
+ * @fileoverview Spawn-decision harness - freeze "what does the colony spawn
+ * NEXT?" as a fast, server-free assertion.
+ *
+ * The choice of the next creep is an emergent result of three real pieces:
+ *   - each corp's getSpawnDemand (count, sizing, value, blocking flags),
+ *   - the director's collectDemands grouping (groupId / groupStarted, the
+ *     "fund one income unit fully" bookkeeping), and
+ *   - the scheduler (withMinerPrecedence + effectiveValue ranking + the
+ *     wait-for-blocking / affordability decision).
+ *
+ * Bugs hide in the *seams* between them - e.g. a miner that stopped counting as
+ * "blocking" while a bootstrap jack was alive, so the upgrader out-ranked it and
+ * the colony never handed off from bootstrap to the flow economy. A pure
+ * scheduler test can't catch that: it feeds the scheduler synthetic demands and
+ * so bypasses the demand-generation logic where the bug lived.
+ *
+ * This harness wires the REAL pieces together (HarvestCorp, CarryCorp,
+ * UpgradingCorp, the exported collectDemands, scheduleSpawn) over a tiny
+ * declarative situation and reports the single creep the live director would
+ * spawn next - so a test can assert "next = miner of source A" in milliseconds.
+ *
+ * @module test/unit/harness/spawnDecision
+ */
+
+import { setupGlobals, Game } from "../mock";
+import { HarvestCorp } from "../../../src/corps/HarvestCorp";
+import { CarryCorp } from "../../../src/corps/CarryCorp";
+import { UpgradingCorp } from "../../../src/corps/UpgradingCorp";
+import { MinerAssignment, HaulerAssignment, SinkAllocation } from "../../../src/flow/FlowTypes";
+import { createCorpRegistry } from "../../../src/execution/CorpRunner";
+import { collectDemands } from "../../../src/execution/SpawnDirector";
+import { scheduleSpawn } from "../../../src/spawn/SpawnScheduler";
+
+/** The one spawn every corp in a situation spawns from. */
+const SPAWN_ID = "spawn1";
+const ROOM = "W1N1";
+
+/** A live creep to place in Game.creeps for the situation. */
+export interface SituationCreep {
+  /** corpId tying the creep to its corp (e.g. "mining-A", "hauling-A", "bootstrap-W1N1"). */
+  corpId: string;
+  /** "harvest" | "haul" | ... - the workType the corp's creep-count scan matches on. */
+  workType: string;
+  /** WORK parts (miners) - drives size-based logic. */
+  work?: number;
+  /** CARRY parts (haulers) - drives store capacity. */
+  carry?: number;
+}
+
+/** A source that has a flow HarvestCorp (and optionally a CarryCorp). */
+export interface SituationSource {
+  /** Source id; the registry key and the suffix of the corp ids. */
+  id: string;
+  /** Source output e/tick (5 remote, 10 owned). Default 10. */
+  harvestRate?: number;
+  /** Mining spots around the source. Default 1. */
+  maxMiners?: number;
+  /** Flow efficiency (affects miner demand value only). Default 80. */
+  efficiency?: number;
+  /** CARRY parts this source's haulers should staff. Omit for no hauling corp. */
+  haulCarry?: number;
+}
+
+/** A declarative spawn moment. */
+export interface SpawnSituation {
+  /** Spawn energy on hand right now. */
+  energyAvailable: number;
+  /** Room energy capacity (spawn + extensions). Default = energyAvailable. */
+  energyCapacity?: number;
+  /** Estimated income e/tick (gates wait-for-blocking). Default 10. */
+  energyIncome?: number;
+  /** Sources with a flow mining (and optional hauling) corp. */
+  sources?: SituationSource[];
+  /** Whether the room has an upgrading corp wanting energy. Default false. */
+  upgrader?: boolean;
+  /** Live creeps already in the field. Default none. */
+  creeps?: SituationCreep[];
+  /** Current tick (for aging). Default 100. */
+  tick?: number;
+}
+
+/** The director's decision for the situation. */
+export interface SpawnDecision {
+  /** Role of the next creep, or null if the director would spawn nothing. */
+  role: string | null;
+  /** Owning corp id of the next creep. */
+  buyerCorpId: string | null;
+  /** Scheduler's human-readable reason (or null when nothing is spawned). */
+  reason: string | null;
+}
+
+function fakeCreep(c: SituationCreep, idx: number): any {
+  const work = c.work ?? 0;
+  const carry = c.carry ?? 0;
+  return {
+    name: `${c.corpId}-${idx}`,
+    spawning: false,
+    memory: { corpId: c.corpId, workType: c.workType },
+    getActiveBodyparts: (part: string) => (part === WORK ? work : part === CARRY ? carry : 0),
+    store: { getCapacity: () => carry * 50 }
+  };
+}
+
+/**
+ * Resolve the single creep the live SpawnDirector would spawn next for the
+ * situation, by running the real collectDemands + scheduleSpawn over a registry
+ * of real corps. Pure apart from the shared global Game.creeps, which it saves
+ * and restores.
+ */
+export function decideNextSpawn(situation: SpawnSituation): SpawnDecision {
+  setupGlobals();
+
+  const energyCapacity = situation.energyCapacity ?? situation.energyAvailable;
+  const tick = situation.tick ?? 100;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const game = Game as any;
+  const savedCreeps = game.creeps;
+  game.creeps = {};
+  (situation.creeps ?? []).forEach((c, i) => {
+    const creep = fakeCreep(c, i);
+    game.creeps[creep.name] = creep;
+  });
+
+  try {
+    const registry = createCorpRegistry();
+
+    for (const src of situation.sources ?? []) {
+      const harvest = new HarvestCorp(`${ROOM}-harvest-${src.id}`, SPAWN_ID, src.id, 5, `mining-${src.id}`);
+      harvest.setMinerAssignment({
+        sourceId: src.id,
+        spawnId: `spawn-${SPAWN_ID}`,
+        harvestRate: src.harvestRate ?? 10,
+        maxMiners: src.maxMiners ?? 1,
+        efficiency: src.efficiency ?? 80
+      } as MinerAssignment);
+      registry.harvestCorps[src.id] = harvest;
+
+      if (src.haulCarry !== undefined) {
+        const carry = new CarryCorp(`${ROOM}-hauling-${src.id}`, SPAWN_ID, `hauling-${src.id}`);
+        carry.setHaulerAssignments([
+          { fromId: src.id, carryParts: src.haulCarry, spawnId: `spawn-${SPAWN_ID}`, haulerRatio: "1:1" } as HaulerAssignment
+        ]);
+        registry.haulingCorps[src.id] = carry;
+      }
+    }
+
+    if (situation.upgrader) {
+      const up = new UpgradingCorp(`${ROOM}-upgrading`, SPAWN_ID);
+      up.setSinkAllocation({
+        sinkId: "controller-x", sinkType: "controller", allocated: 5, demand: 5, unmet: 0, priority: 65
+      } as SinkAllocation);
+      registry.upgradingCorps[ROOM] = up;
+    }
+
+    const demands = collectDemands(registry, SPAWN_ID, { energyCapacity, tick });
+    const result = scheduleSpawn(demands, {
+      energyAvailable: situation.energyAvailable,
+      energyCapacity,
+      energyIncome: situation.energyIncome ?? 10,
+      tick
+    });
+
+    if (!result) return { role: null, buyerCorpId: null, reason: null };
+    return { role: result.demand.role, buyerCorpId: result.demand.buyerCorpId, reason: result.reason };
+  } finally {
+    game.creeps = savedCreeps;
+  }
+}

--- a/test/unit/harness/spawnDecision.ts
+++ b/test/unit/harness/spawnDecision.ts
@@ -147,7 +147,7 @@ export function decideNextSpawn(situation: SpawnSituation): SpawnDecision {
     }
 
     if (situation.upgrader) {
-      const up = new UpgradingCorp(`${ROOM}-upgrading`, SPAWN_ID);
+      const up = new UpgradingCorp(`${ROOM}-upgrading`, SPAWN_ID, `upgrading-${ROOM}`);
       up.setSinkAllocation({
         sinkId: "controller-x", sinkType: "controller", allocated: 5, demand: 5, unmet: 0, priority: 65
       } as SinkAllocation);

--- a/test/unit/spawn/nextSpawn.test.ts
+++ b/test/unit/spawn/nextSpawn.test.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+import "../../../src/types/Memory"; // load the CreepMemory/Memory type augmentation
+import { decideNextSpawn } from "../harness/spawnDecision";
+
+/**
+ * "What does the colony spawn NEXT?" - key economic moments frozen as fast
+ * regression tests.
+ *
+ * Each case is a real decision point we have actually hit (and in two cases,
+ * actually broken) in the sims, captured at the millisecond level: a tiny
+ * declarative situation run through the REAL collectDemands + scheduleSpawn
+ * pipeline (see spawnDecision harness). They give clear signal at near-zero cost
+ * and let us iterate on the spawn logic without standing up a server.
+ */
+describe("next spawn decision (key moments)", () => {
+  it("cold start: spawns the source's MINER before the upgrader", () => {
+    // Empty colony at RCL 2 (bare 300 spawn): a source needing its first miner,
+    // and an upgrader. Both demands are blocking, but the income producer must
+    // come first - there is no energy to upgrade with until a source is mined.
+    const decision = decideNextSpawn({
+      energyAvailable: 300,
+      energyCapacity: 300,
+      energyIncome: 0,
+      sources: [{ id: "A" }],
+      upgrader: true
+    });
+
+    expect(decision.role).to.equal("miner");
+    expect(decision.buyerCorpId).to.equal("mining-A");
+  });
+
+  it("bootstrap hand-off: a flow miner stays blocking while only a bootstrap jack is alive", () => {
+    // The bug this guards: colonyHasMiner once counted bootstrap jacks (also
+    // workType "harvest"), so the flow miner read as non-blocking and the
+    // blocking upgrader out-ranked it forever - the colony never moved off
+    // bootstrap. A live jack must NOT demote the flow miner: it is still the
+    // colony's first real income producer and must out-rank the upgrader.
+    const decision = decideNextSpawn({
+      energyAvailable: 300,
+      energyCapacity: 300,
+      energyIncome: 0,
+      sources: [{ id: "A" }],
+      upgrader: true,
+      creeps: [{ corpId: "bootstrap-W1N1", workType: "harvest", work: 2 }]
+    });
+
+    expect(decision.role).to.equal("miner");
+    expect(decision.buyerCorpId).to.equal("mining-A");
+  });
+
+  it("miner precedence: a source's hauler is held until its first miner exists", () => {
+    // Source A has neither a miner nor a hauler yet. The hauler must NOT be
+    // spawned first - it would have nothing to carry. withMinerPrecedence holds
+    // A's hauler back until A has a miner in the field.
+    const decision = decideNextSpawn({
+      energyAvailable: 550,
+      energyCapacity: 550,
+      sources: [{ id: "A", haulCarry: 4 }]
+    });
+
+    expect(decision.role).to.equal("miner");
+    expect(decision.buyerCorpId).to.equal("mining-A");
+  });
+
+  it("fund one corp fully: completes a started source's haulers before opening a fresh source", () => {
+    // Source A is already underway (a miner + one hauler in the field) and wants
+    // a second hauler; source B is fresh and wants its (non-blocking, since the
+    // colony already mines A) first miner. Neither demand is blocking and B's
+    // miner has the higher BASE value - but the completion boost must carry A's
+    // hauler so the colony finishes hauling A's energy home before opening B,
+    // instead of stranding A's energy to start a source it won't finish.
+    const decision = decideNextSpawn({
+      energyAvailable: 550,
+      energyCapacity: 550,
+      sources: [
+        { id: "A", haulCarry: 8 }, // wants 2 haulers; one already exists
+        { id: "B" } // fresh source, first miner pending
+      ],
+      creeps: [
+        { corpId: "mining-A", workType: "harvest", work: 5 }, // A's miner: A is "started"
+        { corpId: "hauling-A", workType: "haul", carry: 5 } // A's first hauler
+      ]
+    });
+
+    expect(decision.role).to.equal("hauler");
+    expect(decision.buyerCorpId).to.equal("hauling-A");
+  });
+
+  it("opens the next source once the started one is fully staffed", () => {
+    // Counterpart to the previous case: A is now fully staffed (miner + enough
+    // hauler CARRY for its whole rate), so there is nothing left to complete -
+    // the colony should open source B's miner.
+    const decision = decideNextSpawn({
+      energyAvailable: 550,
+      energyCapacity: 550,
+      sources: [
+        { id: "A", haulCarry: 4 }, // one hauler is enough
+        { id: "B" }
+      ],
+      creeps: [
+        { corpId: "mining-A", workType: "harvest", work: 5 },
+        { corpId: "hauling-A", workType: "haul", carry: 5 }
+      ]
+    });
+
+    expect(decision.role).to.equal("miner");
+    expect(decision.buyerCorpId).to.equal("mining-B");
+  });
+});

--- a/test/unit/spawn/nextSpawn.test.ts
+++ b/test/unit/spawn/nextSpawn.test.ts
@@ -106,4 +106,45 @@ describe("next spawn decision (key moments)", () => {
     expect(decision.role).to.equal("miner");
     expect(decision.buyerCorpId).to.equal("mining-B");
   });
+
+  it("funds the upgrader before opening a fresh source once income is staffed", () => {
+    // Source A is fully staffed and its energy is coming home, but the colony has
+    // not upgraded yet (no upgrader in the field, so the upgrader demand is
+    // blocking). A fresh source B wants its first (non-blocking) miner. The
+    // colony must drive RCL - fund the blocking upgrader - rather than open yet
+    // another source while the controller goes un-upgraded.
+    const decision = decideNextSpawn({
+      energyAvailable: 550,
+      energyCapacity: 550,
+      sources: [
+        { id: "A", haulCarry: 4 }, // fully staffed below
+        { id: "B" } // fresh: first miner pending, non-blocking
+      ],
+      upgrader: true,
+      creeps: [
+        { corpId: "mining-A", workType: "harvest", work: 5 },
+        { corpId: "hauling-A", workType: "haul", carry: 5 }
+      ]
+    });
+
+    expect(decision.role).to.equal("upgrader");
+    expect(decision.buyerCorpId).to.equal("upgrading-W1N1");
+  });
+
+  it("holds the spawn rather than spawning a 1-WORK miner runt at a drained spawn", () => {
+    // Cold start with the spawn drained to 200: a 1-WORK miner (150) is
+    // affordable right now, but a 1-WORK miner harvests just 2/tick against a
+    // ~10/tick source - a runt that occupies the source's spot for its whole
+    // life. The first miner is floored at 2 WORK (250), which is not affordable
+    // yet; since it is blocking and income is flowing, the director must HOLD the
+    // spawn to accumulate energy for the real miner, not spend it on the runt.
+    const decision = decideNextSpawn({
+      energyAvailable: 200,
+      energyCapacity: 550,
+      energyIncome: 10,
+      sources: [{ id: "A" }]
+    });
+
+    expect(decision.role).to.equal(null); // spawn nothing this tick - wait for the floored miner
+  });
 });


### PR DESCRIPTION
Builds out the test harness toward high-signal, low-cost tests that freeze key
economic decisions, plus a per-geometry integration guard.

## Fast spawn-decision tests (~10ms)
A server-free decision harness (`test/unit/harness/spawnDecision.ts`) runs the
REAL pipeline - each corp's `getSpawnDemand` -> the director's `collectDemands`
grouping -> `scheduleSpawn` - over a tiny declarative situation and reports the
single creep the live director would spawn next. Bugs hide in the seams between
those pieces, which pure-scheduler tests (synthetic demands) structurally can't
reach. `collectDemands` is exported so the harness drives production code, not a
re-implementation.

Seven frozen "what spawns next?" moments (`test/unit/spawn/nextSpawn.test.ts`):
- cold start: miner before upgrader
- bootstrap hand-off: a flow miner stays blocking while only a jack is alive
  (the `colonyHasMiner` regression - mutation-verified)
- miner precedence: hold a source's hauler until its first miner exists
- fund one corp fully: complete a started source's haulers before opening a fresh
  source (isolates `COMPLETION_BOOST`)
- open the next source once the started one is fully staffed
- fund the upgrader before opening a fresh source once income is staffed
- hold the spawn rather than spawn a 1-WORK runt at a drained spawn
  (mutation-verified against removing the 2-WORK floor)

## Per-geometry economy-health integration suite
`test/integration/scenario-economy.test.ts` runs library geometries under the
free-economy mod and asserts the income invariants that must hold for any room
shape: every source is mined and its energy is hauled home. Adds the
`asymmetricTwoSource` (near + far-corner) and `swampSource` (source behind a
swamp band) scenarios, and exposes `helper.serverPath` so integration tests can
enable engine mods.

Verification: 387 unit tests passing; both integration geometries green; the two
bug-guard tests mutation-verified to fail when their fix is removed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_