### PR TITLE
Gate flow upgraders until the room's delivery loop exists

### DIFF
--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -311,6 +311,20 @@ export class UpgradingCorp extends Corp {
   }
 
   /**
+   * True if the room already has a real flow hauler in the field (corpId
+   * "hauling-..."), i.e. the mining->spawn delivery loop is closed. Bootstrap
+   * jacks (which also move energy) are deliberately excluded - see the
+   * supply-before-demand gate in getSpawnDemand.
+   */
+  private roomHasHauler(room: Room): boolean {
+    for (const creep of room.find(FIND_MY_CREEPS)) {
+      const memory = creep.memory;
+      if (memory.workType === "haul" && memory.corpId?.startsWith("hauling-")) return true;
+    }
+    return false;
+  }
+
+  /**
    * Declare this corp's spawn demand for the scheduler.
    *
    * The upgrader is what drives RCL progress, so its demand is blocking when no
@@ -364,6 +378,20 @@ export class UpgradingCorp extends Corp {
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
     const controller = spawn?.room.controller;
     const strategy: UpgraderStrategy = controller ? this.getUpgraderStrategy(controller) : "mobile";
+
+    // SUPPLY BEFORE DEMAND: don't fund flow upgraders until the room's delivery
+    // loop exists (a real hauler in the field). At cold start the first miner
+    // spawns and then travels to its source; while it is not yet mining,
+    // withMinerPrecedence holds that source's haulers back, leaving the blocking
+    // first upgrader (and its non-blocking siblings) as the top *eligible* demand.
+    // They then drain the spawn's starting energy before the hauler is ever
+    // eligible, and the room freezes: the spawn empties with no hauler to refill
+    // it and no way to afford one (the cold-start delivery deadlock). Gating
+    // upgraders on an established hauler reserves that energy for the hauler that
+    // closes the supply loop; the controller is kept alive meanwhile by the
+    // bootstrap corp's anti-downgrade upgrading. Bootstrap jacks do NOT count -
+    // we want their deliveries to fund the first hauler, not be spent upgrading.
+    if (spawn && !this.roomHasHauler(spawn.room)) return [];
 
     // Energy/tick the controller is allocated; that is the WORK the upgraders
     // must total to consume it (1 energy/tick per WORK part). Without an


### PR DESCRIPTION
## Summary

Fixes the cold-start **delivery deadlock** behind twoSourceRcl3's stall (and, in doing so, lets the runt-regrow fix from #57 finally engage live).

A room that starts healthy — RCL3, ~550 banked energy, no creeps — drained its spawn on **upgraders before any hauler existed**, then froze: spawn empty, no hauler to refill it, no energy to afford one.

**Mechanism:** the first miner spawns and travels to its source; while it isn't mining yet, `withMinerPrecedence` holds that source's haulers back, so the *blocking* first upgrader (and its non-blocking siblings) are the top **eligible** demand and spend the starting energy. By the time the miner mines and the hauler becomes blocking, the spawn is empty and the room is stuck.

**Fix:** don't emit upgrader demand until the room has a real flow hauler in the field (`corpId "hauling-..."`), reserving the cold-start energy for the hauler that closes the mining→spawn loop. Haulers don't depend on upgraders, so there's no circular wait; the controller is kept alive meanwhile by the bootstrap corp's anti-downgrade upgrading. Bootstrap jacks are deliberately excluded so their deliveries fund the first hauler rather than upgrading.

## Validation
- **plan-vs-spawn harness — twoSourceRcl3:** `harvest 3→9/10`, `haul 0→6/15`, `upgrade 4→6/12` — the loop closes and the miners then grow to full size (the #57 regrow gate engages once delivery works).
- **singleSource unregressed:** haul 5/6 OK, upgrade slightly better.
- **387 unit tests pass**, including the parallel session's new spawn-decision regression tests (upgrader-priority, runt-hold).
- **Integration `scenario economy health` suite passes:** both `twoSourceRcl3` and `asymmetricTwoSource` — every source mined, energy hauled home.

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_