### PR TITLE
Add hauler-fleet sizing harness and regression tests

### DIFF
--- a/test/unit/harness/haulerFleet.test.ts
+++ b/test/unit/harness/haulerFleet.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { simulateHaulerFleet } from "./haulerHarness";
+
+/**
+ * Pins down what hauler fleet the live spawn pipeline actually builds for a
+ * source's carry route, using the real CarryCorp + scheduler +
+ * SpawningCorp.buildBodyForRole. The sibling of minerFleet.test - same purpose:
+ * make the emergent sizing legible, and lock current behavior in so a change
+ * (the hauler-sizing work happening on another branch) shows up here as an
+ * explicit, reviewable diff rather than a silent shift.
+ *
+ * Capacities: RCL2 pre-extensions = 300, RCL2 full = 550, RCL3 full = 800.
+ * `carryParts` is the route's total CARRY need from the flow solution.
+ */
+describe("hauler fleet (spawn harness)", () => {
+  it("full-capacity room, modest route: ONE right-sized hauler", () => {
+    // 4 CARRY fits in a single body at 550+ (400 energy), so the route fields
+    // exactly one hauler sized to it - no split.
+    expect(simulateHaulerFleet({ energyCapacity: 550, carryParts: 4 }).carryParts).to.deep.equal([4]);
+    expect(simulateHaulerFleet({ energyCapacity: 800, carryParts: 4 }).carryParts).to.deep.equal([4]);
+  });
+
+  it("a route beyond one body splits across haulers sized to the remaining need", () => {
+    // 12 CARRY at 800 capacity caps each body at 8 CARRY (1:1, 800/100), so it
+    // takes one 8-CARRY hauler plus a 4-CARRY hauler for the remainder.
+    const fleet = simulateHaulerFleet({ energyCapacity: 800, carryParts: 12 });
+    expect(fleet.shape, fleet.shape).to.equal("8 CARRY + 4 CARRY");
+    expect(fleet.carryParts).to.deep.equal([8, 4]);
+  });
+
+  it("a clean split sizes both haulers usefully (no runt)", () => {
+    // 8 CARRY at 550 (max 5/body) splits 5 + 3 - both >= the 3-CARRY floor.
+    expect(simulateHaulerFleet({ energyCapacity: 550, carryParts: 8 }).carryParts).to.deep.equal([5, 3]);
+  });
+
+  it("small routes are not inflated to the 3-CARRY floor", () => {
+    // The floor is min(desiredCarry, 3): a route that only needs 1-2 CARRY gets
+    // a 1-2 CARRY hauler, not a padded 3-CARRY one.
+    expect(simulateHaulerFleet({ energyCapacity: 550, carryParts: 2 }).carryParts).to.deep.equal([2]);
+    expect(simulateHaulerFleet({ energyCapacity: 800, carryParts: 1 }).carryParts).to.deep.equal([1]);
+  });
+
+  it("hauler ratio is plumbed through: 1:2 (swamp) trades CARRY for MOVE", () => {
+    // Same route + budget, different ratio: the swamp body spends more of each
+    // 100 energy on MOVE, so it carries fewer CARRY parts per hauler than 1:1.
+    const plains = simulateHaulerFleet({ energyCapacity: 550, carryParts: 8, haulerRatio: "1:1" });
+    const swamp = simulateHaulerFleet({ energyCapacity: 550, carryParts: 8, haulerRatio: "1:2" });
+    const roads = simulateHaulerFleet({ energyCapacity: 550, carryParts: 8, haulerRatio: "2:1" });
+    expect(swamp.carryParts[0], "swamp lead hauler carries less than plains").to.be.lessThan(plains.carryParts[0]);
+    expect(roads.carryParts[0], "road lead hauler carries more than plains").to.be.greaterThan(plains.carryParts[0]);
+  });
+
+  describe("the cold-start runt tail (hauler analog of the 2x2 miner split)", () => {
+    it("a 300-energy spawn leaves a 1-CARRY runt on the tail hauler", () => {
+      // At 300 capacity a body caps at 3 CARRY, so a 4-CARRY route takes two
+      // haulers - and the tail covers just the 1 remaining CARRY. The 3-CARRY
+      // floor only floors a hauler at min(desiredCarry, 3), so when the REMAINDER
+      // is 1 the tail is a 1-CARRY runt: it moves 50 energy a round trip yet
+      // holds a fleet slot for its whole life. This is the hauler counterpart of
+      // the miner 2x2 cold-start split (see miner-fleet harness); freezing it
+      // here makes the fix (on the hauler-sizing branch) a visible diff.
+      const fleet = simulateHaulerFleet({ energyCapacity: 300, carryParts: 4 });
+      expect(fleet.shape, fleet.shape).to.equal("3 CARRY + 1 CARRY");
+      expect(fleet.carryParts).to.deep.equal([3, 1]);
+    });
+  });
+});

--- a/test/unit/harness/haulerHarness.ts
+++ b/test/unit/harness/haulerHarness.ts
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview Hauler-fleet harness - observe the hauler fleet the REAL spawn
+ * pipeline builds for a source's carry route.
+ *
+ * The sibling of the miner-fleet harness (spawnHarness). Hauler sizing is the
+ * same kind of emergent result of three real pieces talking to each other:
+ *   - CarryCorp.getSpawnDemand (how many haulers, each sized to the remaining
+ *     carry need, with the 3-CARRY runt floor),
+ *   - the scheduler (what it picks + how much energy it grants), and
+ *   - SpawningCorp.buildBodyForRole (how the granted energy + ratio map to
+ *     CARRY/MOVE parts).
+ *
+ * It drives the actual production code end-to-end: collectDemands (so the
+ * director's grouping is real), scheduleSpawn, and SpawningCorp.executeSpawn -
+ * the last via a captured fake spawn, so the body is built by the real
+ * buildBodyForRole with no re-implementation. So whatever it reports is exactly
+ * what the live colony would build for the same route - a diagnostic AND a
+ * regression guard for hauler sizing while that logic is iterated on.
+ *
+ * @module test/unit/harness/haulerHarness
+ */
+
+import { setupGlobals, Game } from "../mock";
+import { HarvestCorp } from "../../../src/corps/HarvestCorp";
+import { CarryCorp } from "../../../src/corps/CarryCorp";
+import { SpawningCorp } from "../../../src/corps/SpawningCorp";
+import { MinerAssignment, HaulerAssignment } from "../../../src/flow/FlowTypes";
+import { createCorpRegistry } from "../../../src/execution/CorpRunner";
+import { collectDemands } from "../../../src/execution/SpawnDirector";
+import { scheduleSpawn } from "../../../src/spawn/SpawnScheduler";
+
+const SPAWN_ID = "spawn1";
+const ROOM = "W1N1";
+const SOURCE = "source-aaaa";
+
+/** Inputs that define one hauling situation. */
+export interface HaulerScenario {
+  /** room.energyCapacityAvailable - the body the room *could* build. */
+  energyCapacity: number;
+  /** Spawn energy on hand each spawn. Defaults to a full spawn (energyCapacity). */
+  energyAvailable?: number;
+  /** Total CARRY parts the route needs (HaulerAssignment.carryParts). */
+  carryParts: number;
+  /** CARRY:MOVE ratio for the route (terrain hint). Default "1:1". */
+  haulerRatio?: "2:1" | "1:1" | "1:2";
+  /** Safety cap so a logic bug can't loop forever. */
+  maxSpawns?: number;
+}
+
+/** What the scenario actually built. */
+export interface HaulerFleet {
+  /** CARRY parts of each hauler, spawn order, largest first. e.g. [5, 3]. */
+  carryParts: number[];
+  /** A label like "2 x 5 CARRY" / "5 CARRY + 3 CARRY". */
+  shape: string;
+}
+
+interface FakeCreep {
+  name: string;
+  spawning: boolean;
+  memory: { corpId: string; workType: string };
+  getActiveBodyparts: (part: string) => number;
+  store: { getCapacity: () => number };
+}
+
+/**
+ * Spawn a route's hauler fleet out to completion and return what it built.
+ *
+ * Mirrors the director's per-tick step (collect demands -> schedule -> spawn) in
+ * a loop until the CarryCorp stops asking. A miner is placed in the field first
+ * so the source counts as "started" and withMinerPrecedence does not hold the
+ * haulers back - this harness isolates the hauler-sizing question, not the
+ * miner-before-hauler ordering (that is covered by the decision harness).
+ */
+export function simulateHaulerFleet(scenario: HaulerScenario): HaulerFleet {
+  const {
+    energyCapacity,
+    energyAvailable = energyCapacity,
+    carryParts,
+    haulerRatio = "1:1",
+    maxSpawns = 20
+  } = scenario;
+
+  setupGlobals();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const game = Game as any;
+  const savedCreeps = game.creeps;
+  const savedGetObjectById = game.getObjectById;
+  game.creeps = {} as { [name: string]: FakeCreep };
+
+  // SpawningCorp.executeSpawn logs each spawn; silence it so the harness stays
+  // quiet (it is driving the real production path, not exercising logging).
+  const savedLog = console.log;
+  console.log = () => {};
+
+  // A captured fake spawn: executeSpawn looks it up by id, checks energy, and
+  // calls spawnCreep - which we intercept to record the body the real
+  // buildBodyForRole produced (rather than actually spawning).
+  let lastBody: string[] = [];
+  let lastMemory: { corpId: string; workType: string } | null = null;
+  const fakeSpawn = {
+    id: SPAWN_ID,
+    spawning: false,
+    room: { energyAvailable, energyCapacityAvailable: energyCapacity, memory: {} },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnCreep: (body: string[], _name: string, opts: any) => {
+      lastBody = body;
+      lastMemory = opts?.memory;
+      return OK;
+    }
+  };
+  game.getObjectById = (id: string) => (id === SPAWN_ID ? fakeSpawn : null);
+
+  try {
+    const registry = createCorpRegistry();
+
+    // Source's miner: already in the field (so the source is "started"), and the
+    // HarvestCorp is satisfied (target met) so it emits no miner demand.
+    const harvest = new HarvestCorp(`${ROOM}-harvest-${SOURCE}`, SPAWN_ID, SOURCE, 5, `mining-${SOURCE}`);
+    harvest.setMinerAssignment({
+      sourceId: SOURCE, spawnId: `spawn-${SPAWN_ID}`, harvestRate: 10, maxMiners: 1, efficiency: 80
+    } as MinerAssignment);
+    registry.harvestCorps[SOURCE] = harvest;
+    game.creeps["miner-0"] = {
+      name: "miner-0", spawning: false,
+      memory: { corpId: `mining-${SOURCE}`, workType: "harvest" },
+      getActiveBodyparts: (p: string) => (p === WORK ? 5 : 0),
+      store: { getCapacity: () => 0 }
+    } as FakeCreep;
+
+    // The route's hauling corp.
+    const carry = new CarryCorp(`${ROOM}-hauling-${SOURCE}`, SPAWN_ID, `hauling-${SOURCE}`);
+    carry.setHaulerAssignments([
+      { fromId: SOURCE, toId: "controller-x", carryParts, spawnId: `spawn-${SPAWN_ID}`, haulerRatio } as HaulerAssignment
+    ]);
+    registry.haulingCorps[SOURCE] = carry;
+
+    const spawning = new SpawningCorp(`${ROOM}-spawning`, SPAWN_ID, energyCapacity);
+
+    for (let i = 0; i < maxSpawns; i++) {
+      const demands = collectDemands(registry, SPAWN_ID, { energyCapacity, tick: 100 + i });
+      if (demands.length === 0) break; // corps satisfied - fleet complete
+      const result = scheduleSpawn(demands, { energyAvailable, energyCapacity, energyIncome: 10, tick: 100 + i });
+      if (!result) break; // scheduler chose to wait
+
+      const ok = spawning.executeSpawn(
+        result.demand.role,
+        result.demand.buyerCorpId,
+        result.energyBudget,
+        100 + i,
+        result.demand.bodyParam,
+        result.demand.haulerRatio,
+        result.demand.bodyStrategy
+      );
+      if (!ok || lastMemory === null) break;
+
+      const carryCount = lastBody.filter(p => p === CARRY).length;
+      const memory = lastMemory;
+      const body = lastBody;
+      game.creeps[`hauler-${i}`] = {
+        name: `hauler-${i}`,
+        spawning: false,
+        memory,
+        getActiveBodyparts: (p: string) => body.filter(b => b === p).length,
+        store: { getCapacity: () => carryCount * 50 }
+      } as FakeCreep;
+    }
+
+    const fleet = Object.values(game.creeps as { [n: string]: FakeCreep })
+      .filter(c => c.memory.workType === "haul")
+      .map(c => c.getActiveBodyparts(CARRY))
+      .sort((a, b) => b - a);
+    return { carryParts: fleet, shape: summarize(fleet) };
+  } finally {
+    game.creeps = savedCreeps;
+    game.getObjectById = savedGetObjectById;
+    console.log = savedLog;
+  }
+}
+
+/** "2 x 5 CARRY", "1 x 3 CARRY", or "5 CARRY + 3 CARRY" for mixed fleets. */
+function summarize(carry: number[]): string {
+  if (carry.length === 0) return "no haulers";
+  const allSame = carry.every(c => c === carry[0]);
+  if (allSame) return `${carry.length} x ${carry[0]} CARRY`;
+  return carry.map(c => `${c} CARRY`).join(" + ");
+}


### PR DESCRIPTION
Sibling of the miner-fleet harness: observe the hauler fleet the REAL spawn
pipeline builds for a source's carry route.

It drives production code end-to-end - `CarryCorp.getSpawnDemand` ->
`collectDemands` grouping -> `scheduleSpawn` -> `SpawningCorp.executeSpawn` -
with `executeSpawn` driven through a captured fake spawn, so the body is built by
the real `buildBodyForRole`. No re-implementation and **no production change**,
so it does not collide with the hauler-sizing work happening on another branch.

Six tests pin current hauler sizing so that in-flight change shows up as a
reviewable diff rather than a silent shift:
- full-capacity route: one right-sized hauler
- a route beyond one body splits across haulers sized to the remainder (8 + 4)
- a clean split sizes both usefully (5 + 3, no runt)
- small routes are not inflated to the 3-CARRY floor
- hauler ratio is plumbed through (swamp 1:2 carries less, road 2:1 more)
- cold-start runt tail: a 300-energy spawn leaves a 1-CARRY runt on the tail
  hauler — the hauler analog of the miner 2x2 split, frozen here so the fix is
  a visible diff

393 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_