### PR TITLE
Pin runt-recycling and spawn over-planning behavior

### DIFF
--- a/test/unit/corps/runtRecycling.test.ts
+++ b/test/unit/corps/runtRecycling.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { pickRuntToRecycle } from "../../../src/corps/recycle";
+import { simulateMinerFleet } from "../harness/spawnHarness";
+import { simulateHaulerFleet } from "../harness/haulerHarness";
+
+/**
+ * Which stuck runts actually get recycled?
+ *
+ * Runt recycling (HarvestCorp.flagMinerRuntForRecycling /
+ * CarryCorp.flagRuntForRecycling) retires the smallest sub-max creep so its corp
+ * respawns it full size - but only via pickRuntToRecycle, which fires *only when
+ * the fleet's total useful parts are below what the plan needs*. That heals a
+ * genuinely under-capacity fleet, but it leaves an OVER-SPLIT yet adequate fleet
+ * alone: the cold-start splits the spawn harnesses build (a 2x2 miner, a [3,1]
+ * hauler) already meet their total need, so they are never recycled. Combined
+ * with the demand path (which also won't touch an at-target fleet, see the
+ * miner-fleet harness), that means the cold-start over-split is *permanently
+ * stuck* - it never heals, even after the room grows. These tests pin that.
+ */
+describe("runt recycling: which runts heal?", () => {
+  it("recycles a genuinely UNDER-capacity fleet (heals)", () => {
+    // One 2-WORK miner on a source that needs 5 WORK: total 2 < 5 -> recycle it,
+    // and the corp respawns a full 5-WORK miner.
+    expect(pickRuntToRecycle([2], 5, 5)).to.equal(0);
+    // One 3-CARRY hauler on a route that needs 8 CARRY: total 3 < 8 -> recycle.
+    expect(pickRuntToRecycle([3], 8, 8)).to.equal(0);
+  });
+
+  it("does NOT recycle the cold-start 2x2 miner split (stuck even once the room grows)", () => {
+    const fleet = simulateMinerFleet({ energyCapacity: 300, harvestRate: 5, maxMiners: 2 });
+    expect(fleet.workParts, fleet.shape).to.deep.equal([2, 2]); // the cold-start over-split
+
+    const needWork = 3; // ceil(5 e/tick / 2): a 3-WORK miner saturates this remote source
+    const maxWorkWarm = 3; // after the room fills its extensions it could build a 3-WORK miner
+    // total (4) already >= need (3), so the fleet is left alone - the over-split
+    // never heals even though one 3-WORK miner would free a mining spot and cost
+    // less upkeep than two 2-WORK bodies.
+    expect(pickRuntToRecycle(fleet.workParts, needWork, maxWorkWarm)).to.equal(null);
+  });
+
+  it("does NOT recycle the cold-start [3,1] hauler runt tail (stuck even once the room grows)", () => {
+    const fleet = simulateHaulerFleet({ energyCapacity: 300, carryParts: 4 });
+    expect(fleet.carryParts, fleet.shape).to.deep.equal([3, 1]); // the cold-start runt tail
+
+    const needCarry = 4; // the route's total CARRY need
+    const maxCarryWarm = 8; // a warmed-up room (800) could build an 8-CARRY hauler
+    // total (4) already >= need (4): the 1-CARRY runt is never retired, so it
+    // holds a fleet slot moving 50 energy per round trip for its whole life.
+    expect(pickRuntToRecycle(fleet.carryParts, needCarry, maxCarryWarm)).to.equal(null);
+  });
+});

--- a/test/unit/flow/EconomyPlanner.test.ts
+++ b/test/unit/flow/EconomyPlanner.test.ts
@@ -131,6 +131,28 @@ describe("EconomyPlanner", () => {
     assert.isAtLeast(work(corps, "build"), 1, "construction still gets the rest");
   });
 
+  it("scales mining to consumable capacity - lots of sources does NOT over-plan", () => {
+    // Four sources (40 supply) but a small controller (capacity 10) and no other
+    // sink: the colony cannot USE more than ~its overhead + 10/tick, so the
+    // planner mines only that much. A miner is commissioned only for a source
+    // whose energy is actually routed (see "one initiative per worked source,
+    // sized to its routed output"), so most sources are left in the ground rather
+    // than opening a miner + hauler the spawn would have to keep alive for energy
+    // that has nowhere to go. The same planner, given capacity to consume it,
+    // opens every source - so the cap is driven by demand, not an arbitrary limit.
+    const sources = [source("s0", 5), source("s1", 15), source("s2", 35), source("s3", 45)];
+    const small = plan(sources, [sink("spawn", "spawn", 100, 0, 25), sink("ctrl", "controller", 50, 10, 25)]);
+    const big = plan(sources, [sink("spawn", "spawn", 100, 0, 25), sink("ctrl", "controller", 50, 1000, 25)]);
+
+    const smallMiners = corp(small.corps, "mine").length;
+    const bigMiners = corp(big.corps, "mine").length;
+
+    assert.isBelow(smallMiners, sources.length, "a capped colony does NOT open a miner per source");
+    assert.isAbove(small.unrouted, 0, "the supply it cannot consume is left unmined");
+    assert.equal(bigMiners, sources.length, "with capacity to consume it, every source IS opened");
+    assert.isAbove(small.unrouted, big.unrouted, "the small-sink colony leaves far more in the ground");
+  });
+
   it("closes the energy loop: a far source self-consistently leaves less for its project", () => {
     // Same supply and same value/capacity, only the haul distance differs. The
     // far economy must staff bigger haulers, so its overhead is higher and its


### PR DESCRIPTION
Two standing questions, answered with regression tests built on the spawn
harnesses and the economy planner.

**Are stuck runts recycled? Only undersized ones.** `pickRuntToRecycle` fires
only when a fleet's total parts are below the plan's need, so:
- a genuinely under-capacity fleet heals (its runt is retired + respawned full)
- but the cold-start OVER-SPLIT fleets the harnesses actually build (a 2x2 miner,
  a `[3,1]` hauler) already meet their total need, so they're never recycled —
  and the demand path won't touch an at-target fleet either. The over-split is
  therefore permanently stuck, even after the room grows. Pinned via the real
  harness fleets.

**Does a spawn with lots of sources over-plan? No.** The planner commissions a
miner only for a source whose energy is actually routed to a sink, sized to the
routed output. With limited sink capacity most sources are left in the ground
rather than opening miners/haulers the spawn would keep alive for energy with
nowhere to go; given capacity to consume it, the same planner opens every source.
The cap is demand-driven, not arbitrary.

397 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_