### PR TITLE
Rebalance the economy around an active build (scale upgraders, drain dedicated-source surplus)

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -43,6 +43,17 @@ export type LocalSink = "spawn" | "controller";
 const SPAWN_PRIORITY_FREE_CAPACITY = 50;
 
 /**
+ * Fill fraction at which a dedicated build source's container is judged to be
+ * "backing up": the builder isn't draining the source's full output (a runt
+ * builder, or no active build), so the surplus would otherwise pile up until the
+ * container is full and the miner stalls. Above this the source's haulers resume
+ * and drain the surplus to the core, so the miner keeps producing and the energy
+ * isn't wasted - the economy rebalances around whatever the builder actually
+ * consumes. Half-full leaves ample headroom before the container caps out.
+ */
+const DEDICATED_SOURCE_DRAIN_FILL = 0.5;
+
+/**
  * Choose which local sink to commit a load to. The spawn network has strict
  * priority: whenever it has real free capacity, fill it first regardless of the
  * proportional allocation (the spawn is critical but small, so it tops up fast
@@ -726,11 +737,35 @@ export class CarryCorp extends Corp {
    * down (field no haulers, and existing ones stop drawing from it) so the
    * construction tankers get the source's full output. The reservation is set by
    * ConstructionCorp in room memory while a build is active.
+   *
+   * The reservation holds only while the builder keeps the source's container
+   * drained. If energy backs up past DEDICATED_SOURCE_DRAIN_FILL the builder can't
+   * consume the source's full output (a runt builder, or no active consumption),
+   * so we resume hauling the surplus to the core: the miner never stalls on a full
+   * container and the excess isn't wasted. The builder, sized to the whole source,
+   * holds the container near-empty in the normal case, so haulers stay stood down.
    */
   private yieldsToBuild(): boolean {
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
     const dedicated = spawn?.room.memory.dedicatedBuildSourceId;
-    return !!dedicated && this.mySourceId() === dedicated;
+    if (!dedicated || this.mySourceId() !== dedicated) return false;
+
+    const source = Game.getObjectById(dedicated as Id<Source>);
+    const container = source ? this.sourceContainerAt(source) : null;
+    if (container) {
+      const energy = container.store[RESOURCE_ENERGY];
+      const capacity = container.store.getCapacity(RESOURCE_ENERGY) || 2000;
+      if (energy >= capacity * DEDICATED_SOURCE_DRAIN_FILL) return false; // surplus - drain it
+    }
+    return true;
+  }
+
+  /** The static container on a source's tile, if any (where the miner deposits). */
+  private sourceContainerAt(source: Source): StructureContainer | null {
+    const containers = source.pos.findInRange(FIND_STRUCTURES, 1, {
+      filter: s => s.structureType === STRUCTURE_CONTAINER
+    }) as StructureContainer[];
+    return containers[0] ?? null;
   }
 
   /**

--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -7,6 +7,7 @@
  */
 
 import { Corp, SerializedCorp } from "./Corp";
+import { driveRecycle } from "./recycle";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { UpgraderStrategy, buildUpgraderBody } from "../spawn/BodyBuilder";
 import { CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD } from "./CorpConstants";
@@ -122,8 +123,13 @@ export class UpgradingCorp extends Corp {
     if (!controller) return;
 
     const creeps = this.getActiveCreeps();
+    this.flagExcessForRecycling(creeps, spawn);
     for (const creep of creeps) {
-      this.runUpgrader(creep, room, controller);
+      if (creep.memory.recycling) {
+        driveRecycle(creep, spawn);
+      } else {
+        this.runUpgrader(creep, room, controller);
+      }
     }
   }
 
@@ -395,8 +401,12 @@ export class UpgradingCorp extends Corp {
 
     // Energy/tick the controller is allocated; that is the WORK the upgraders
     // must total to consume it (1 energy/tick per WORK part). Without an
-    // allocation, ask for a minimal upgrader to keep the controller alive.
-    const allocated = this.sinkAllocation && this.sinkAllocation.allocated > 0 ? this.sinkAllocation.allocated : 2;
+    // allocation, ask for a minimal upgrader to keep the controller alive. While
+    // a source is reserved for the builder, the allocation is scaled to the
+    // sources still feeding the core (see effectiveAllocated) so we don't field
+    // upgraders the remaining supply can't feed.
+    const base = this.sinkAllocation && this.sinkAllocation.allocated > 0 ? this.sinkAllocation.allocated : 2;
+    const allocated = spawn ? this.effectiveAllocated(spawn.room, base) : base;
 
     // One upgrader can only afford so many WORK parts at the current capacity;
     // a single small upgrader cannot consume a whole source. Size the COUNT to
@@ -452,6 +462,54 @@ export class UpgradingCorp extends Corp {
   // ===========================================================================
   // FLOW INTEGRATION
   // ===========================================================================
+
+  /**
+   * Scale the raw energy allocation down to the sources still feeding the core
+   * economy. While the builder has a whole source reserved (its haulers stand
+   * down - see CarryCorp.yieldsToBuild), only the remaining sources deliver to
+   * the spawn/controller. Sizing upgrading to the full allocation then fields
+   * more upgraders than that reduced supply can feed: they sit starved at the
+   * controller while the spawn (fed by the same shrunken supply) can't refill,
+   * which in turn keeps the lone remaining miner a runt that can't regrow.
+   * Scaling the target to the core's source share lets the spawn keep its fill,
+   * the miner regrow, and the single source become "plenty" - the economy
+   * rebalances around the build instead of starving for it.
+   */
+  private effectiveAllocated(room: Room, base: number): number {
+    if (!room.memory.dedicatedBuildSourceId) return base;
+    const total = room.find(FIND_SOURCES).length || 1;
+    return (base * Math.max(0, total - 1)) / total;
+  }
+
+  /**
+   * Shed the smallest upgrader when the fleet's total WORK over-shoots what the
+   * (build-aware) allocation can actually feed - the "recycle if needed" half of
+   * the rebalance. Only sheds when retiring the runt still leaves us at or above
+   * the target, so a correctly-sized fleet is never disturbed and we can't thrash
+   * below target. The retired creep walks to the spawn and recycles, returning
+   * its body energy to the economy that now needs it.
+   */
+  private flagExcessForRecycling(creeps: Creep[], spawn: StructureSpawn): void {
+    if (spawn.spawning) return; // don't compete with an in-progress spawn
+    if (creeps.some(c => c.memory.recycling)) return; // one at a time
+    if (creeps.length === 0) return;
+
+    const base = this.sinkAllocation && this.sinkAllocation.allocated > 0 ? this.sinkAllocation.allocated : 2;
+    const target = this.effectiveAllocated(spawn.room, base);
+
+    let smallest: Creep | null = null;
+    let smallestWork = Infinity;
+    let totalWork = 0;
+    for (const c of creeps) {
+      const w = c.getActiveBodyparts(WORK);
+      totalWork += w;
+      if (w < smallestWork) {
+        smallestWork = w;
+        smallest = c;
+      }
+    }
+    if (smallest && totalWork - smallestWork >= target) smallest.memory.recycling = true;
+  }
 
   /**
    * Set the sink allocation from FlowEconomy.

--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -488,8 +488,15 @@ export class UpgradingCorp extends Corp {
    * the target, so a correctly-sized fleet is never disturbed and we can't thrash
    * below target. The retired creep walks to the spawn and recycles, returning
    * its body energy to the economy that now needs it.
+   *
+   * Scoped to the dedicated-build rebalance only: without a reserved build source
+   * the upgrade target equals the full allocation (effectiveAllocated is a no-op),
+   * so this is exactly the situation the recycle is for. Firing it more broadly
+   * churned upgraders against the normal fallback target and stole spawn ticks
+   * from a second source's miner during the cold ramp.
    */
   private flagExcessForRecycling(creeps: Creep[], spawn: StructureSpawn): void {
+    if (!spawn.room.memory.dedicatedBuildSourceId) return; // only rebalance during a dedicated build
     if (spawn.spawning) return; // don't compete with an in-progress spawn
     if (creeps.some(c => c.memory.recycling)) return; // one at a time
     if (creeps.length === 0) return;


### PR DESCRIPTION
## Summary

Two complementary changes that let the colony **rebalance around an active build** instead of starving for it, keeping the dedicate-a-source framework intact.

### 1. Scale upgraders down (and recycle excess) when a source is reserved for the builder
When the builder reserves a whole source (`dedicatedBuildSourceId`, set with ≥2 sources during construction), only the remaining sources feed the spawn/controller. Upgrading still sized itself to the full allocation, so it fielded more upgraders than the shrunken supply could feed: they sat starved at the controller while the spawn couldn't refill, which kept the lone remaining miner a 3-WORK runt that (in a starved room) couldn't regrow — holding the whole room down.

`UpgradingCorp.effectiveAllocated` now scales the upgrade target to the sources still feeding the core, and `flagExcessForRecycling` sheds the smallest excess upgrader (only while the fleet stays at/above target, and only in the dedicated-build scenario, so a correct fleet is never disturbed). The spawn keeps its fill, the miner regrows, and the single source becomes plenty.

### 2. Drain a dedicated source's surplus so its miner never stalls
A reserved source stands its haulers down so the tankers get its full output — but when the builder can't consume it all (a runt builder, or no active consumption), the container fills, the miner stalls, and energy is wasted. `CarryCorp.yieldsToBuild` now holds the reservation **only while the builder keeps the container drained**: once it backs up past half-full, the source's haulers resume and move the surplus to the core. In the normal case (builder sized to the whole source) the container stays near-empty, so haulers stay stood down and behavior is unchanged. The dedicate-a-source primitive (valuable for future build-rate boosts) is preserved without its stall failure mode.

## Validation
- **plan-vs-spawn twoSourceRcl3:** the runt miner regrows once the spawn is fed — `harvest 9→12` — and upgraders scale `6→3` to match the available supply. singleSource unchanged (no dedicated source → the rebalance path never fires).
- **397 unit tests pass**, including the parallel session's new `runtRecycling` / `EconomyPlanner` / `haulerFleet` tests.
- **Integration `scenario economy health` passes:** both `twoSourceRcl3` and `asymmetricTwoSource` — every source mined, energy hauled home. (An earlier version of change 1 alone regressed this by routing freed energy to construction, dedicating a source whose miner then stranded under the test's free-economy build; change 2 fixes that at the root.)

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_