### PR TITLE
Even-split hauler fleets so a route never leaves a runt tail

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -45,11 +45,12 @@ const SPAWN_PRIORITY_FREE_CAPACITY = 50;
 /**
  * Fill fraction at which a dedicated build source's container is judged to be
  * "backing up": the builder isn't draining the source's full output (a runt
- * builder, or no active build), so the surplus would otherwise pile up until the
- * container is full and the miner stalls. Above this the source's haulers resume
- * and drain the surplus to the core, so the miner keeps producing and the energy
- * isn't wasted - the economy rebalances around whatever the builder actually
- * consumes. Half-full leaves ample headroom before the container caps out.
+ * builder, or no active consumption), so the energy just accumulates in the
+ * container and, once it caps out, overflows onto the ground and decays - wasted.
+ * Above this the source's haulers resume and move the surplus to the core instead,
+ * so the economy rebalances around whatever the builder actually consumes rather
+ * than stranding the rest at the source. Half-full leaves ample headroom before
+ * the container caps out.
  */
 const DEDICATED_SOURCE_DRAIN_FILL = 0.5;
 
@@ -639,10 +640,18 @@ export class CarryCorp extends Corp {
     const current = this.getCreepCount();
     if (current >= targetHaulers) return [];
 
-    // Size this hauler to its share of the remaining carry need (capped by what
-    // the room can afford in one body).
-    const remainingCarry = carryNeeded - current * maxCarryPerHauler;
-    const desiredCarry = Math.max(1, Math.min(maxCarryPerHauler, remainingCarry));
+    // Size this hauler to an EVEN share of the route's carry across the haulers it
+    // needs - not a greedy "max out each body and leave whatever is left for the
+    // last one". The greedy split leaves a runt tail whenever the route doesn't
+    // divide into full bodies: a 4-CARRY route at a 3-CARRY-body cap builds 3 + 1,
+    // and that 1-CARRY runt moves only 50 energy a round trip yet holds a fleet slot
+    // for its whole 1500-tick life. The even split fields the same hauler count and
+    // total CARRY with no runt (3 + 1 -> 2 + 2). Each hauler index gets the floor
+    // share, and the first `remainder` haulers get one more - deterministic from the
+    // spawn order alone, so it needs no per-creep body inspection.
+    const base = Math.floor(carryNeeded / targetHaulers);
+    const remainder = carryNeeded % targetHaulers;
+    const desiredCarry = Math.max(1, Math.min(maxCarryPerHauler, base + (current < remainder ? 1 : 0)));
     const desiredCost = desiredCarry * PART_PAIR_COST;
 
     // Don't let the scheduler spawn a 1-CARRY runt under energy pressure: it
@@ -741,9 +750,10 @@ export class CarryCorp extends Corp {
    * The reservation holds only while the builder keeps the source's container
    * drained. If energy backs up past DEDICATED_SOURCE_DRAIN_FILL the builder can't
    * consume the source's full output (a runt builder, or no active consumption),
-   * so we resume hauling the surplus to the core: the miner never stalls on a full
-   * container and the excess isn't wasted. The builder, sized to the whole source,
-   * holds the container near-empty in the normal case, so haulers stay stood down.
+   * so we resume hauling the surplus to the core: the accumulated energy goes home
+   * instead of overflowing the container and decaying on the ground. The builder,
+   * sized to the whole source, holds the container near-empty in the normal case,
+   * so haulers stay stood down.
    */
   private yieldsToBuild(): boolean {
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);

--- a/test/unit/corps/runtRecycling.test.ts
+++ b/test/unit/corps/runtRecycling.test.ts
@@ -39,14 +39,16 @@ describe("runt recycling: which runts heal?", () => {
     expect(pickRuntToRecycle(fleet.workParts, needWork, maxWorkWarm)).to.equal(null);
   });
 
-  it("does NOT recycle the cold-start [3,1] hauler runt tail (stuck even once the room grows)", () => {
+  it("splits the cold-start hauler fleet evenly, so there is no runt tail to recycle", () => {
+    // Unlike the miner 2x2 wart above, hauler sizing now even-splits the route, so
+    // the old 3 + 1 cold-start tail never forms - there is no runt to heal.
     const fleet = simulateHaulerFleet({ energyCapacity: 300, carryParts: 4 });
-    expect(fleet.carryParts, fleet.shape).to.deep.equal([3, 1]); // the cold-start runt tail
+    expect(fleet.carryParts, fleet.shape).to.deep.equal([2, 2]); // even split, no runt
 
     const needCarry = 4; // the route's total CARRY need
     const maxCarryWarm = 8; // a warmed-up room (800) could build an 8-CARRY hauler
-    // total (4) already >= need (4): the 1-CARRY runt is never retired, so it
-    // holds a fleet slot moving 50 energy per round trip for its whole life.
+    // Two equal haulers already cover the need with no sub-max runt, so there is
+    // nothing for the recycler to retire.
     expect(pickRuntToRecycle(fleet.carryParts, needCarry, maxCarryWarm)).to.equal(null);
   });
 });

--- a/test/unit/harness/haulerFleet.test.ts
+++ b/test/unit/harness/haulerFleet.test.ts
@@ -21,17 +21,18 @@ describe("hauler fleet (spawn harness)", () => {
     expect(simulateHaulerFleet({ energyCapacity: 800, carryParts: 4 }).carryParts).to.deep.equal([4]);
   });
 
-  it("a route beyond one body splits across haulers sized to the remaining need", () => {
+  it("a route beyond one body splits EVENLY across the haulers it needs", () => {
     // 12 CARRY at 800 capacity caps each body at 8 CARRY (1:1, 800/100), so it
-    // takes one 8-CARRY hauler plus a 4-CARRY hauler for the remainder.
+    // takes two haulers - split evenly into 6 + 6 rather than a greedy 8 + 4.
+    // Same hauler count and total CARRY, but balanced (and never a runt tail).
     const fleet = simulateHaulerFleet({ energyCapacity: 800, carryParts: 12 });
-    expect(fleet.shape, fleet.shape).to.equal("8 CARRY + 4 CARRY");
-    expect(fleet.carryParts).to.deep.equal([8, 4]);
+    expect(fleet.shape, fleet.shape).to.equal("2 x 6 CARRY");
+    expect(fleet.carryParts).to.deep.equal([6, 6]);
   });
 
-  it("a clean split sizes both haulers usefully (no runt)", () => {
-    // 8 CARRY at 550 (max 5/body) splits 5 + 3 - both >= the 3-CARRY floor.
-    expect(simulateHaulerFleet({ energyCapacity: 550, carryParts: 8 }).carryParts).to.deep.equal([5, 3]);
+  it("a two-hauler route splits evenly (no runt)", () => {
+    // 8 CARRY at 550 (max 5/body) needs two haulers: an even 4 + 4, not 5 + 3.
+    expect(simulateHaulerFleet({ energyCapacity: 550, carryParts: 8 }).carryParts).to.deep.equal([4, 4]);
   });
 
   it("small routes are not inflated to the 3-CARRY floor", () => {
@@ -42,27 +43,28 @@ describe("hauler fleet (spawn harness)", () => {
   });
 
   it("hauler ratio is plumbed through: 1:2 (swamp) trades CARRY for MOVE", () => {
-    // Same route + budget, different ratio: the swamp body spends more of each
-    // 100 energy on MOVE, so it carries fewer CARRY parts per hauler than 1:1.
-    const plains = simulateHaulerFleet({ energyCapacity: 550, carryParts: 8, haulerRatio: "1:1" });
-    const swamp = simulateHaulerFleet({ energyCapacity: 550, carryParts: 8, haulerRatio: "1:2" });
-    const roads = simulateHaulerFleet({ energyCapacity: 550, carryParts: 8, haulerRatio: "2:1" });
+    // A single right-sized hauler (5-CARRY route fits one body at 550), so the
+    // ratio's effect on CARRY-per-body is visible directly rather than masked by an
+    // even fleet split: the swamp body spends more of each unit on MOVE (and is
+    // budget-capped), carrying fewer CARRY than 1:1, while the road body packs more.
+    const plains = simulateHaulerFleet({ energyCapacity: 550, carryParts: 5, haulerRatio: "1:1" });
+    const swamp = simulateHaulerFleet({ energyCapacity: 550, carryParts: 5, haulerRatio: "1:2" });
+    const roads = simulateHaulerFleet({ energyCapacity: 550, carryParts: 5, haulerRatio: "2:1" });
     expect(swamp.carryParts[0], "swamp lead hauler carries less than plains").to.be.lessThan(plains.carryParts[0]);
     expect(roads.carryParts[0], "road lead hauler carries more than plains").to.be.greaterThan(plains.carryParts[0]);
   });
 
-  describe("the cold-start runt tail (hauler analog of the 2x2 miner split)", () => {
-    it("a 300-energy spawn leaves a 1-CARRY runt on the tail hauler", () => {
+  describe("the cold-start runt tail is split away (hauler analog of the 2x2 miner split)", () => {
+    it("a 300-energy spawn splits a 4-CARRY route EVENLY, with no 1-CARRY runt", () => {
       // At 300 capacity a body caps at 3 CARRY, so a 4-CARRY route takes two
-      // haulers - and the tail covers just the 1 remaining CARRY. The 3-CARRY
-      // floor only floors a hauler at min(desiredCarry, 3), so when the REMAINDER
-      // is 1 the tail is a 1-CARRY runt: it moves 50 energy a round trip yet
-      // holds a fleet slot for its whole life. This is the hauler counterpart of
-      // the miner 2x2 cold-start split (see miner-fleet harness); freezing it
-      // here makes the fix (on the hauler-sizing branch) a visible diff.
+      // haulers. A greedy "max each body" split would build 3 + 1 - and that
+      // 1-CARRY tail moves only 50 energy a round trip yet holds a fleet slot for
+      // its whole life. The even split fields the same two haulers as a balanced
+      // 2 + 2 instead, so neither is a runt. (The miner harness still freezes the
+      // analogous 2x2 miner wart; only hauler sizing is fixed here.)
       const fleet = simulateHaulerFleet({ energyCapacity: 300, carryParts: 4 });
-      expect(fleet.shape, fleet.shape).to.equal("3 CARRY + 1 CARRY");
-      expect(fleet.carryParts).to.deep.equal([3, 1]);
+      expect(fleet.shape, fleet.shape).to.equal("2 x 2 CARRY");
+      expect(fleet.carryParts).to.deep.equal([2, 2]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Hauler-corp sizing: **even-split a route's CARRY across the haulers it needs** so it never leaves a runt tail.

`CarryCorp.getSpawnDemand` sized each hauler greedily — max out every body, leave whatever's left for the last one — so any route that didn't divide into full bodies ended with a runt. A 4-CARRY route at a 3-CARRY-body cap built `3 + 1`, and that 1-CARRY tail moves only 50 energy per round trip yet holds a fleet slot for its whole 1500-tick life (the hauler analog of the miner cold-start split the sibling harness pins).

Now the route's carry is distributed evenly: each hauler index gets the floor share and the first few (the remainder) get one more. Same hauler count and the same total CARRY, but balanced and runt-free — `3 + 1 → 2 + 2`, `8 + 4 → 6 + 6`, `5 + 3 → 4 + 4`. It's deterministic from spawn order, so it needs no per-creep body inspection (works with every existing corp mock).

Also corrects the `dedicated-source drain` comment from PR #62: a backed-up source overflows its container and decays the surplus on the ground (energy wasted) — it does not literally stall the miner.

## Validation
- **The hauler-fleet harness** (driving the real CarryCorp + scheduler + `buildBodyForRole`) now pins the even splits; the **runt-recycling** test records that the cold-start hauler tail no longer forms (nothing to recycle); the **ratio** test moves to a single right-sized hauler so the CARRY:MOVE effect is visible rather than masked by an even split.
- **397 unit tests pass.**
- **plan-vs-spawn twoSourceRcl3 unregressed** — aggregates unchanged (`harvest 12`, `build 2`); the split changes hauler *composition*, not totals. (The remaining `haul 6/15` there is starvation/allocation-driven, separate from fleet composition.)

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_