### PR TITLE
Exercise and pin the upgrader supply-before-demand gate

### DIFF
--- a/test/unit/harness/spawnDecision.ts
+++ b/test/unit/harness/spawnDecision.ts
@@ -23,7 +23,7 @@
  * @module test/unit/harness/spawnDecision
  */
 
-import { setupGlobals, Game } from "../mock";
+import { setupGlobals, Game, FIND_MY_CREEPS } from "../mock";
 import { HarvestCorp } from "../../../src/corps/HarvestCorp";
 import { CarryCorp } from "../../../src/corps/CarryCorp";
 import { UpgradingCorp } from "../../../src/corps/UpgradingCorp";
@@ -117,11 +117,33 @@ export function decideNextSpawn(situation: SpawnSituation): SpawnDecision {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const game = Game as any;
   const savedCreeps = game.creeps;
+  const savedGetObjectById = game.getObjectById;
   game.creeps = {};
   (situation.creeps ?? []).forEach((c, i) => {
     const creep = fakeCreep(c, i);
     game.creeps[creep.name] = creep;
   });
+
+  // A fake spawn so corps that consult Game.getObjectById(spawnId) run their real
+  // room-aware logic - notably the upgrader's "no flow upgrader until a hauler is
+  // delivering" gate (roomHasHauler scans room.find(FIND_MY_CREEPS)) and the
+  // hauler's yieldsToBuild (reads room.memory). Without it those paths were
+  // silently skipped and the gate never exercised. No controller is provided, so
+  // the upgrader uses its mobile strategy.
+  const fakeSpawn = {
+    id: SPAWN_ID,
+    spawning: false,
+    room: {
+      name: ROOM,
+      energyAvailable: situation.energyAvailable,
+      energyCapacityAvailable: energyCapacity,
+      memory: {},
+      controller: undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      find: (type: number) => (type === FIND_MY_CREEPS ? Object.values(game.creeps) : [])
+    }
+  };
+  game.getObjectById = (id: string) => (id === SPAWN_ID ? fakeSpawn : null);
 
   try {
     const registry = createCorpRegistry();
@@ -166,5 +188,6 @@ export function decideNextSpawn(situation: SpawnSituation): SpawnDecision {
     return { role: result.demand.role, buyerCorpId: result.demand.buyerCorpId, reason: result.reason };
   } finally {
     game.creeps = savedCreeps;
+    game.getObjectById = savedGetObjectById;
   }
 }

--- a/test/unit/spawn/nextSpawn.test.ts
+++ b/test/unit/spawn/nextSpawn.test.ts
@@ -107,6 +107,31 @@ describe("next spawn decision (key moments)", () => {
     expect(decision.buyerCorpId).to.equal("mining-B");
   });
 
+  it("an upgrader stands down until a hauler is delivering (supply before demand)", () => {
+    // The controller wants energy and the spawn is full, but there is no hauler in
+    // the room. The upgrader must stand down - that energy is reserved for the
+    // hauler that closes the delivery loop. Funding the upgrader here is the
+    // cold-start deadlock the gate prevents: the spawn drains on upgraders and can
+    // never afford the hauler that would refill it. With no other eligible demand,
+    // the director spawns nothing this tick.
+    const noHauler = decideNextSpawn({
+      energyAvailable: 550,
+      energyCapacity: 550,
+      upgrader: true // controller wants energy, but no hauler is configured
+    });
+    expect(noHauler.role).to.equal(null);
+
+    // The moment a hauler is delivering (corpId "hauling-*"), the same upgrader is
+    // eligible and funded. The contrast IS the gate.
+    const withHauler = decideNextSpawn({
+      energyAvailable: 550,
+      energyCapacity: 550,
+      upgrader: true,
+      creeps: [{ corpId: "hauling-A", workType: "haul", carry: 4 }]
+    });
+    expect(withHauler.role).to.equal("upgrader");
+  });
+
   it("funds the upgrader before opening a fresh source once income is staffed", () => {
     // Source A is fully staffed and its energy is coming home, but the colony has
     // not upgraded yet (no upgrader in the field, so the upgrader demand is


### PR DESCRIPTION
The decision harness left `Game.getObjectById` returning null, so corps that
consult the spawn's room (the upgrader's "no flow upgrader until a hauler is
delivering" gate from #59, the hauler's `yieldsToBuild`) silently skipped that
logic — the gate was never exercised and the upgrader tests passed for the wrong
reason.

Give the harness a fake spawn whose `room.find(FIND_MY_CREEPS)` returns the
situation's creeps and whose `memory` is present, so those room-aware paths run
for real. Add a key moment that isolates the gate: with the controller wanting
energy but no hauler in the room the upgrader stands down (the director spawns
nothing); add a delivering hauler and the same upgrader is funded. The contrast
is the gate, and it is mutation-verified — removing the gate fails exactly this
test and nothing else.

398 unit tests passing (rebased onto #63's even-split hauler sizing).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_