### PR TITLE
Add upgrader-fleet harness and tests (completes the triad)

### DIFF
--- a/test/unit/harness/upgraderFleet.test.ts
+++ b/test/unit/harness/upgraderFleet.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { simulateUpgraderFleet } from "./upgraderHarness";
+
+/**
+ * Pins what upgrader fleet the live spawn pipeline staffs for a controller's
+ * energy allocation, using the real UpgradingCorp + scheduler +
+ * SpawningCorp.buildBodyForRole. The third sibling of the miner- and hauler-fleet
+ * harnesses. It locks in the two subtle, recently-added behaviors that are easy
+ * to regress: the #59 supply-before-demand gate (no flow upgrader until a hauler
+ * is delivering) and the #62 scale-down of upgrading while a source is dedicated
+ * to an active build.
+ *
+ * Capacities: RCL2 full = 550, RCL3 full = 800. `allocated` is the controller
+ * energy/tick the plan routed to upgrading (1 e/tick consumed per WORK part).
+ */
+describe("upgrader fleet (spawn harness)", () => {
+  it("staffs total WORK equal to the controller's allocation", () => {
+    // The fleet exists to consume the allocation: 1 WORK per e/tick allocated.
+    expect(simulateUpgraderFleet({ energyCapacity: 550, allocated: 2 }).totalWork).to.equal(2);
+    expect(simulateUpgraderFleet({ energyCapacity: 550, allocated: 10 }).totalWork).to.equal(10);
+    expect(simulateUpgraderFleet({ energyCapacity: 800, allocated: 20 }).totalWork).to.equal(20);
+  });
+
+  it("fields fewer, bigger upgraders as capacity rises (same allocation)", () => {
+    // A bigger room builds bigger bodies, so the same 10 e/tick allocation is
+    // covered by fewer upgraders - 5 x 2 WORK at 550, but 3 (4+4+2) at 800.
+    const small = simulateUpgraderFleet({ energyCapacity: 550, allocated: 10 });
+    const big = simulateUpgraderFleet({ energyCapacity: 800, allocated: 10 });
+    expect(small.workParts).to.deep.equal([2, 2, 2, 2, 2]);
+    expect(big.count).to.be.lessThan(small.count);
+    expect(big.totalWork, "still consumes the whole allocation").to.equal(10);
+  });
+
+  it("does not over-spawn for a tiny allocation", () => {
+    // A 2 e/tick allocation gets a single 2-WORK upgrader, not a swarm.
+    const fleet = simulateUpgraderFleet({ energyCapacity: 550, allocated: 2 });
+    expect(fleet.count).to.equal(1);
+    expect(fleet.workParts).to.deep.equal([2]);
+  });
+
+  describe("the #59 supply-before-demand gate", () => {
+    it("stands the upgraders DOWN until a hauler is delivering", () => {
+      // No flow hauler in the room -> the gate emits no demand, so the controller
+      // allocation staffs zero upgraders (the energy is reserved for the hauler
+      // that closes the delivery loop). With a hauler present it staffs normally.
+      expect(simulateUpgraderFleet({ energyCapacity: 550, allocated: 10, hauler: false }).count).to.equal(0);
+      expect(simulateUpgraderFleet({ energyCapacity: 550, allocated: 10, hauler: true }).count).to.be.greaterThan(0);
+    });
+  });
+
+  describe("the #62 active-build rebalance", () => {
+    it("scales the upgrader fleet DOWN while a source is dedicated to a build", () => {
+      // With one of two sources dedicated to an active build, the upgrader
+      // allocation drops to the share of the sources still feeding the core
+      // ((total-1)/total = 1/2 here), so upgrading is throttled to ~half while the
+      // build runs - the build gets its source's energy instead of the controller.
+      const normal = simulateUpgraderFleet({ energyCapacity: 550, allocated: 10, sources: 2 });
+      const building = simulateUpgraderFleet({ energyCapacity: 550, allocated: 10, sources: 2, dedicatedBuild: true });
+      expect(normal.totalWork).to.equal(10);
+      expect(building.totalWork).to.equal(5);
+      expect(building.totalWork).to.be.lessThan(normal.totalWork);
+    });
+
+    it("keeps a minimal upgrader alive even when the only source is dedicated to the build", () => {
+      // A single-source room dedicating its one source to a build scales the
+      // allocation to 0 - but the controller must not be abandoned, so a minimal
+      // 1-WORK upgrader is still fielded to hold off downgrade.
+      const fleet = simulateUpgraderFleet({ energyCapacity: 550, allocated: 10, sources: 1, dedicatedBuild: true });
+      expect(fleet.count).to.equal(1);
+      expect(fleet.totalWork).to.equal(1);
+    });
+  });
+});

--- a/test/unit/harness/upgraderHarness.ts
+++ b/test/unit/harness/upgraderHarness.ts
@@ -1,0 +1,182 @@
+/**
+ * @fileoverview Upgrader-fleet harness - observe the upgrader fleet the REAL
+ * spawn pipeline builds for a controller's energy allocation.
+ *
+ * The third sibling of the miner- and hauler-fleet harnesses (the spawnHarness
+ * doc anticipates it). Upgrader staffing is an emergent result of the real
+ * pieces: UpgradingCorp.getSpawnDemand (the #59 "no flow upgrader until a hauler
+ * delivers" gate; the count sized to the controller allocation; the #62
+ * scale-down while a source is dedicated to an active build), the scheduler, and
+ * SpawningCorp.buildBodyForRole. It drives that production code end-to-end -
+ * collectDemands, scheduleSpawn, executeSpawn via a captured fake spawn - so the
+ * fleet it reports is exactly what the live colony would staff.
+ *
+ * @module test/unit/harness/upgraderHarness
+ */
+
+import { setupGlobals, Game, FIND_MY_CREEPS, FIND_SOURCES } from "../mock";
+import { UpgradingCorp } from "../../../src/corps/UpgradingCorp";
+import { SpawningCorp } from "../../../src/corps/SpawningCorp";
+import { SinkAllocation } from "../../../src/flow/FlowTypes";
+import { createCorpRegistry } from "../../../src/execution/CorpRunner";
+import { collectDemands } from "../../../src/execution/SpawnDirector";
+import { scheduleSpawn } from "../../../src/spawn/SpawnScheduler";
+
+const SPAWN_ID = "spawn1";
+const ROOM = "W1N1";
+
+/** Inputs that define one upgrading situation. */
+export interface UpgraderScenario {
+  /** room.energyCapacityAvailable - the body the room *could* build. */
+  energyCapacity: number;
+  /** Spawn energy on hand each spawn. Defaults to a full spawn (energyCapacity). */
+  energyAvailable?: number;
+  /** Controller energy/tick the plan allocated to upgrading (SinkAllocation.allocated). */
+  allocated: number;
+  /** Number of sources in the room (matters only with an active build). Default 1. */
+  sources?: number;
+  /** Is a source dedicated to an active build? Scales the upgrader allocation (#62). */
+  dedicatedBuild?: boolean;
+  /** Is a real flow hauler delivering? The #59 gate stands upgraders down without one. Default true. */
+  hauler?: boolean;
+  /** Safety cap so a logic bug can't loop forever. */
+  maxSpawns?: number;
+}
+
+/** What the scenario actually built. */
+export interface UpgraderFleet {
+  /** WORK parts of each upgrader, spawn order, largest first. */
+  workParts: number[];
+  /** Total WORK across the fleet (the controller-consuming capacity it staffs). */
+  totalWork: number;
+  /** Number of upgraders. */
+  count: number;
+  /** A label like "2 x 4 WORK" / "4 WORK + 2 WORK" / "no upgraders". */
+  shape: string;
+}
+
+interface FakeCreep {
+  name: string;
+  spawning: boolean;
+  memory: { corpId: string; workType: string };
+  getActiveBodyparts: (part: string) => number;
+}
+
+/**
+ * Spawn a controller's upgrader fleet out to completion and return what it built.
+ * Mirrors the director's per-tick step (collect -> schedule -> spawn) in a loop
+ * until the UpgradingCorp stops asking.
+ */
+export function simulateUpgraderFleet(scenario: UpgraderScenario): UpgraderFleet {
+  const {
+    energyCapacity,
+    energyAvailable = energyCapacity,
+    allocated,
+    sources = 1,
+    dedicatedBuild = false,
+    hauler = true,
+    maxSpawns = 20
+  } = scenario;
+
+  setupGlobals();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const game = Game as any;
+  const savedCreeps = game.creeps;
+  const savedGetObjectById = game.getObjectById;
+  const savedLog = console.log;
+  game.creeps = {} as { [name: string]: FakeCreep };
+  console.log = () => {};
+
+  // A real hauler in the field opens the #59 supply-before-demand gate.
+  if (hauler) {
+    game.creeps["hauler-0"] = {
+      name: "hauler-0", spawning: false,
+      memory: { corpId: "hauling-src", workType: "haul" },
+      getActiveBodyparts: () => 0
+    } as FakeCreep;
+  }
+
+  let lastBody: string[] = [];
+  let lastMemory: { corpId: string; workType: string } | null = null;
+  const fakeSpawn = {
+    id: SPAWN_ID,
+    spawning: false,
+    room: {
+      name: ROOM,
+      energyAvailable,
+      energyCapacityAvailable: energyCapacity,
+      // No controller -> the corp uses its mobile (no-buffer) strategy.
+      controller: undefined,
+      memory: dedicatedBuild ? { dedicatedBuildSourceId: "src-build" } : {},
+      find: (type: number) => {
+        if (type === FIND_MY_CREEPS) return Object.values(game.creeps);
+        if (type === FIND_SOURCES) return Array.from({ length: sources }, () => ({}));
+        return [];
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnCreep: (body: string[], _name: string, opts: any) => {
+      lastBody = body;
+      lastMemory = opts?.memory;
+      return OK;
+    }
+  };
+  game.getObjectById = (id: string) => (id === SPAWN_ID ? fakeSpawn : null);
+
+  try {
+    const registry = createCorpRegistry();
+    const corp = new UpgradingCorp(`${ROOM}-upgrading`, SPAWN_ID, `upgrading-${ROOM}`);
+    corp.setSinkAllocation({
+      sinkId: "controller-x", sinkType: "controller", allocated, demand: allocated, unmet: 0, priority: 65
+    } as SinkAllocation);
+    registry.upgradingCorps[ROOM] = corp;
+
+    const spawning = new SpawningCorp(`${ROOM}-spawning`, SPAWN_ID, energyCapacity);
+
+    for (let i = 0; i < maxSpawns; i++) {
+      const demands = collectDemands(registry, SPAWN_ID, { energyCapacity, tick: 100 + i });
+      if (demands.length === 0) break; // corp satisfied (or gated) - fleet complete
+      const result = scheduleSpawn(demands, { energyAvailable, energyCapacity, energyIncome: 10, tick: 100 + i });
+      if (!result) break;
+
+      const ok = spawning.executeSpawn(
+        result.demand.role,
+        result.demand.buyerCorpId,
+        result.energyBudget,
+        100 + i,
+        result.demand.bodyParam,
+        result.demand.haulerRatio,
+        result.demand.bodyStrategy
+      );
+      if (!ok || lastMemory === null) break;
+
+      const workCount = lastBody.filter(p => p === WORK).length;
+      const memory = lastMemory;
+      const body = lastBody;
+      game.creeps[`upgrader-${i}`] = {
+        name: `upgrader-${i}`,
+        spawning: false,
+        memory,
+        getActiveBodyparts: (p: string) => body.filter(b => b === p).length
+      } as FakeCreep;
+    }
+
+    const work = Object.values(game.creeps as { [n: string]: FakeCreep })
+      .filter(c => c.memory.workType === "upgrade")
+      .map(c => c.getActiveBodyparts(WORK))
+      .sort((a, b) => b - a);
+    return { workParts: work, totalWork: work.reduce((s, w) => s + w, 0), count: work.length, shape: summarize(work) };
+  } finally {
+    game.creeps = savedCreeps;
+    game.getObjectById = savedGetObjectById;
+    console.log = savedLog;
+  }
+}
+
+/** "2 x 4 WORK", "1 x 5 WORK", or "4 WORK + 2 WORK" for mixed fleets. */
+function summarize(work: number[]): string {
+  if (work.length === 0) return "no upgraders";
+  const allSame = work.every(w => w === work[0]);
+  if (allSame) return `${work.length} x ${work[0]} WORK`;
+  return work.map(w => `${w} WORK`).join(" + ");
+}


### PR DESCRIPTION
The third sibling of the miner- and hauler-fleet harnesses (the spawnHarness doc
anticipates it): observe the upgrader fleet the REAL spawn pipeline staffs for a
controller's energy allocation, driving production code end-to-end
(`collectDemands` -> `scheduleSpawn` -> `SpawningCorp.executeSpawn` via a captured
fake spawn). Locks in the subtle, recently-added behaviors that are easy to
regress:

- total upgrader WORK tracks the controller allocation; higher capacity fields
  fewer, bigger upgraders for the same allocation; a tiny allocation is not
  over-spawned.
- the **#59** supply-before-demand gate: no flow upgrader is staffed until a
  hauler is delivering (mutation-verified).
- the **#62** active-build rebalance: a source dedicated to a build scales the
  upgrader fleet down to the share still feeding the core (two sources -> half),
  while keeping a minimal upgrader alive when the only source is dedicated
  (mutation-verified).

404 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_