### PR TITLE
Size hauler fleets by CARRY capacity, not creep count, to escape a runt stall

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -583,6 +583,15 @@ export class CarryCorp extends Corp {
   }
 
   /**
+   * Total CARRY parts the fleet currently fields. Used to size the fleet by actual
+   * capacity rather than creep count, so a fleet of runts (spawned small under
+   * energy pressure) is recognised as under-capacity and topped up.
+   */
+  private fieldedCarry(): number {
+    return this.getAssignedCreeps().reduce((sum, c) => sum + c.getActiveBodyparts(CARRY), 0);
+  }
+
+  /**
    * Get the spawn ID this corp spawns from.
    */
   public getSpawnId(): string {
@@ -638,20 +647,37 @@ export class CarryCorp extends Corp {
     const targetHaulers = Math.max(1, Math.ceil(carryNeeded / maxCarryPerHauler));
 
     const current = this.getCreepCount();
-    if (current >= targetHaulers) return [];
+    const fieldedCarry = this.fieldedCarry();
 
-    // Size this hauler to an EVEN share of the route's carry across the haulers it
-    // needs - not a greedy "max out each body and leave whatever is left for the
-    // last one". The greedy split leaves a runt tail whenever the route doesn't
-    // divide into full bodies: a 4-CARRY route at a 3-CARRY-body cap builds 3 + 1,
-    // and that 1-CARRY runt moves only 50 energy a round trip yet holds a fleet slot
-    // for its whole 1500-tick life. The even split fields the same hauler count and
-    // total CARRY with no runt (3 + 1 -> 2 + 2). Each hauler index gets the floor
-    // share, and the first `remainder` haulers get one more - deterministic from the
-    // spawn order alone, so it needs no per-creep body inspection.
-    const base = Math.floor(carryNeeded / targetHaulers);
-    const remainder = carryNeeded % targetHaulers;
-    const desiredCarry = Math.max(1, Math.min(maxCarryPerHauler, base + (current < remainder ? 1 : 0)));
+    // Stop once the fleet has BOTH the planned count and enough total CARRY. The
+    // count alone is not enough: under energy pressure haulers spawn at the runt
+    // floor (see minCost below), so the planned count can be reached while the
+    // fielded CARRY still falls short of the route. A source left under-hauled piles
+    // its energy up, which keeps the spawn starved and the next hauler a runt too -
+    // a self-sustaining stall. Keep adding haulers until the CARRY is actually
+    // covered, capped at twice the planned count so a pathologically starved room
+    // can't spawn an unbounded swarm.
+    if (current >= targetHaulers && fieldedCarry >= carryNeeded) return [];
+    if (current >= targetHaulers * 2) return [];
+
+    // Size while FILLING the planned fleet by an EVEN share of the route's carry -
+    // not a greedy "max out each body and leave whatever is left for the last one",
+    // which leaves a runt tail whenever the route doesn't divide into full bodies
+    // (a 4-CARRY route at a 3-CARRY-body cap builds 3 + 1, and that 1-CARRY runt
+    // moves only 50 energy a round trip yet holds a fleet slot for its whole life;
+    // the even split makes it 2 + 2). Each index gets the floor share and the first
+    // `remainder` get one more - deterministic from spawn order. Once PAST the
+    // planned count we are topping up a runt shortfall, so size to just the missing
+    // CARRY rather than another full share.
+    let desiredCarry: number;
+    if (current < targetHaulers) {
+      const base = Math.floor(carryNeeded / targetHaulers);
+      const remainder = carryNeeded % targetHaulers;
+      desiredCarry = base + (current < remainder ? 1 : 0);
+    } else {
+      desiredCarry = carryNeeded - fieldedCarry;
+    }
+    desiredCarry = Math.max(1, Math.min(maxCarryPerHauler, desiredCarry));
     const desiredCost = desiredCarry * PART_PAIR_COST;
 
     // Don't let the scheduler spawn a 1-CARRY runt under energy pressure: it

--- a/test/unit/corps/CarryCorp.behavior.test.ts
+++ b/test/unit/corps/CarryCorp.behavior.test.ts
@@ -29,6 +29,7 @@ function fakeHauler(corpId: string): unknown {
     memory: { corpId, workType: "haul" },
     spawning: false,
     store: { getCapacity: () => 250 },
+    getActiveBodyparts: (part: string) => (part === "carry" ? 5 : 0), // a full 5-CARRY hauler
   };
 }
 


### PR DESCRIPTION
## Summary

Breaks a **runt-starvation stall** by sizing hauler fleets on CARRY capacity instead of creep count.

`CarryCorp.getSpawnDemand` stopped fielding haulers once the planned *count* was met (`current >= targetHaulers`). But under energy pressure haulers spawn at the runt floor, so two 3-CARRY haulers (6 total) satisfied a route needing 8 and the demand path went quiet. The under-hauled source then piles its energy up → the spawn stays starved → the next hauler is a runt too — a self-sustaining stall that the idle-gated runt recycler never reaches (the spawn is never idle under this pressure).

Now the stop is **capacity-aware**: keep adding haulers until the fielded CARRY actually covers the route (capped at 2× the planned count so a pathologically starved room can't spawn an unbounded swarm). Haulers past the planned count are sized to just the remaining shortfall, not another full even-share. A healthy room fields full-size bodies that meet the need at the planned count, so it is unaffected — the top-up only fires for a fleet left under-capacity by runts.

## Validation
- **plan-vs-spawn twoSourceRcl3:** hauled CARRY `6 → 9`.
- **plan-vs-spawn singleSource:** unchanged (`haul 5/6`, no bloat — confirms a healthy room doesn't over-spawn).
- **404 unit tests pass** (incl. the behavior-test mock gaining `getActiveBodyparts` so the new `fieldedCarry` is exercised).

## Context
This is the first of the colony-wide runt-starvation fix. The remaining `twoSourceRcl3` gap is the **dedicated build source**: its energy is served by tankers, not haulers, because the builder is over-sized (2 WORK, eating the whole ~10/tick source) versus the plan's 1 WORK — a separate follow-up.

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_