### PR TITLE
Spawn-time as an energy-priced budget + effective-energy analysis tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sim:planspawn": "ts-node -P tsconfig.test.json scripts/plan-vs-spawn.ts",
     "sim:multiroom": "ts-node -P tsconfig.test.json scripts/sim-multiroom.ts",
     "sim:variance": "ts-node -P tsconfig.test.json scripts/sim-variance.ts",
+    "sim:ab": "ts-node -P tsconfig.test.json scripts/ab-cold-start.ts",
     "snapshot": "ts-node -P tsconfig.test.json scripts/snapshot.ts",
     "plan:budget": "ts-node -P tsconfig.test.json scripts/plan-budget.ts",
     "plan:placement": "ts-node -P tsconfig.test.json scripts/probe-spawn-placement.ts",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "sim:multiroom": "ts-node -P tsconfig.test.json scripts/sim-multiroom.ts",
     "sim:variance": "ts-node -P tsconfig.test.json scripts/sim-variance.ts",
     "sim:ab": "ts-node -P tsconfig.test.json scripts/ab-cold-start.ts",
+    "sim:energy": "ts-node -P tsconfig.test.json scripts/effective-energy.ts",
     "snapshot": "ts-node -P tsconfig.test.json scripts/snapshot.ts",
     "plan:budget": "ts-node -P tsconfig.test.json scripts/plan-budget.ts",
     "plan:placement": "ts-node -P tsconfig.test.json scripts/probe-spawn-placement.ts",

--- a/scripts/ab-cold-start.ts
+++ b/scripts/ab-cold-start.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env ts-node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * ab-cold-start - measure how much a colony grows from a cold start.
+ *
+ * An A/B harness for "are the economy changes actually making the colony
+ * better?". It stands up the same proven cold-start colony (walled two-chamber
+ * room, two sources, RCL 2 + 5 extensions) on the real engine - NO free-economy
+ * mod, so growth reflects real throughput - runs it for a fixed number of ticks,
+ * and reports the colony's cumulative control points (the canonical "how far has
+ * it grown" number) plus the producing fleet.
+ *
+ * The bot under test is whatever dist/main.js currently is, so the same harness
+ * measures any commit: build the bot at commit A, run this; build at commit B,
+ * run this; compare the control points. The scenario/harness stays constant, so
+ * the delta is the bot's behavior change alone.
+ *
+ * Usage:
+ *   npm run build && npx ts-node -P tsconfig.test.json scripts/ab-cold-start.ts [ticks]
+ */
+import { readFileSync, mkdirSync } from "fs";
+import * as path from "path";
+import { loadLayout, padNeighborTerrain, setRoomLevel } from "../test/integration/loadLayout";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ScreepsServer } = require("screeps-server-mockup");
+
+const RCL_TOTALS = [0, 200, 45200, 180200, 585200, 1395200, 3405200, 10405200];
+const controlPoints = (level: number, progress: number): number => (RCL_TOTALS[level - 1] ?? 0) + progress;
+
+async function main(): Promise<void> {
+  const ticks = Number(process.argv[2] ?? 1500);
+  const port = 26000 + Math.floor(Math.random() * 1000);
+  const serverPath = path.resolve("server", `ab-${port}`);
+  mkdirSync(path.join(serverPath, "logs"), { recursive: true });
+  const server = new ScreepsServer({ port, path: serverPath, logdir: path.join(serverPath, "logs") });
+
+  await server.world.reset();
+
+  const terrain = Array.from({ length: 50 }, (_v, y) =>
+    ".".repeat(25) + (y >= 23 && y <= 27 ? "." : "#") + ".".repeat(24)
+  );
+  await loadLayout(server.world, {
+    room: "W0N0",
+    terrain,
+    objects: [
+      { type: "controller", x: 38, y: 25 },
+      { type: "source", x: 10, y: 10 },
+      { type: "source", x: 40, y: 40 }
+    ]
+  });
+  await padNeighborTerrain(server.world, ["W0N0"]);
+  const player = await server.world.addBot({
+    username: "player", room: "W0N0", x: 12, y: 25,
+    modules: { main: readFileSync("dist/main.js").toString() }
+  });
+  await setRoomLevel(server.world, "W0N0", 2, [
+    { x: 13, y: 24 }, { x: 11, y: 24 }, { x: 13, y: 26 }, { x: 11, y: 26 }, { x: 14, y: 25 }
+  ]);
+
+  await server.start();
+
+  const sample = Number(process.argv[3] ?? 250);
+  for (let t = 1; t <= ticks; t += 1) {
+    await server.tick();
+    if (t % sample === 0) {
+      const o = await server.world.roomObjects("W0N0");
+      const c = o.find((x: any) => x.type === "controller");
+      console.log(`  t=${String(t).padStart(4)} cp=${controlPoints(c?.level ?? 0, c?.progress ?? 0)}`);
+    }
+  }
+
+  const objs = await server.world.roomObjects("W0N0");
+  const ctrl = objs.find((o: any) => o.type === "controller");
+  const cp = controlPoints(ctrl?.level ?? 0, ctrl?.progress ?? 0);
+
+  let mem: any = {};
+  try { mem = JSON.parse((await player.memory) || "{}"); } catch { /* ignore */ }
+  const byType: Record<string, number> = {};
+  for (const name in mem.creeps || {}) {
+    const wt = mem.creeps[name].workType || "bootstrap";
+    byType[wt] = (byType[wt] || 0) + 1;
+  }
+  const variance = (mem.corpVariance || []).map((r: any) => `${r.type} ${r.actual}/${r.budget}`).join(", ");
+
+  console.log(`ticks=${ticks} RCL=${ctrl?.level} controlPoints=${cp}`);
+  console.log(`creeps=${JSON.stringify(byType)}`);
+  console.log(`variance=[${variance}]`);
+
+  await server.stop();
+  process.exit(0);
+}
+
+main().catch(err => { console.error("ab-cold-start failed:", err); process.exit(1); });

--- a/scripts/effective-energy.ts
+++ b/scripts/effective-energy.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env ts-node
+/* eslint-disable no-console */
+/**
+ * effective-energy - what does a source TRULY net, after creep overhead?
+ *
+ * Models the net energy/tick a source delivers once you subtract the spawn cost
+ * of the creeps needed to harvest and haul it - and, crucially, accounts for
+ * travel TIME-TO-LIVE: a static miner walks `d` tiles out and then dies at the
+ * source, so it only mines for (LIFETIME - d) ticks and must be respawned that
+ * much more often. That raises BOTH its amortized energy cost (more bodies per
+ * unit time) and the spawn-time it consumes. The same initial walk-out shortens
+ * a hauler's productive life too.
+ *
+ * Constants mirror src/flow/FlowTypes.ts so this tracks the live economy.
+ *
+ * Usage: npx ts-node -P tsconfig.test.json scripts/effective-energy.ts
+ */
+
+const LIFETIME = 1500;
+const COST = { WORK: 100, CARRY: 50, MOVE: 50 };
+const MINER_COST = 5 * COST.WORK + 3 * COST.MOVE; // 650, a 5W3M miner
+const MINER_PARTS = 8; // 5 WORK + 3 MOVE
+
+/** Round trip ticks for a one-way distance d (matches calculateRoundTrip). */
+const roundTrip = (d: number): number => 2 * d + 2;
+/** CARRY parts to sustain `rate` e/tick over distance d (matches calculateCarryParts). */
+const carryFor = (rate: number, d: number): number => (rate * roundTrip(d)) / 50;
+/** Productive life of a creep that must first walk `d` tiles out. */
+const usefulLife = (d: number): number => Math.max(1, LIFETIME - d);
+
+interface Row {
+  carry: number;
+  totalParts: number;
+  minerOH: number;
+  haulerOH: number;
+  net: number;
+  eff: number;
+  spawnLoad: number;
+}
+
+function row(rate: number, d: number, ttl: boolean): Row {
+  const life = ttl ? usefulLife(d) : LIFETIME;
+  const carry = Math.ceil(carryFor(rate, d));
+  const totalParts = MINER_PARTS + 2 * carry; // hauler = 1 CARRY + 1 MOVE per unit
+  const minerOH = MINER_COST / life;
+  const haulerOH = (carry * (COST.CARRY + COST.MOVE)) / life;
+  const net = rate - minerOH - haulerOH;
+  return {
+    carry,
+    totalParts,
+    minerOH,
+    haulerOH,
+    net,
+    eff: (net / rate) * 100,
+    // fraction of ONE spawn's uptime this source's fleet consumes:
+    // parts*3 ticks to build, divided by how long each fleet lives.
+    spawnLoad: (totalParts * 3) / life
+  };
+}
+
+function breakeven(rate: number, ttl: boolean): number {
+  for (let d = 0; d <= 1000; d++) if (row(rate, d, ttl).net < 0) return d - 1;
+  return 1000;
+}
+
+function printTable(label: string, rate: number): void {
+  console.log(`\n=== ${label} (gross ${rate} e/tick) ===`);
+  console.log(" dist | carry | bodyParts | minerOH haulerOH |  netE  eff% | spawnLoad");
+  for (const d of [0, 25, 50, 75, 100, 150, 200, 250, 300]) {
+    const r = row(rate, d, true);
+    console.log(
+      `  ${String(d).padStart(3)} | ${String(r.carry).padStart(5)} | ${String(r.totalParts).padStart(9)} | ` +
+        `${r.minerOH.toFixed(2).padStart(6)} ${r.haulerOH.toFixed(2).padStart(7)} | ` +
+        `${r.net.toFixed(2).padStart(5)} ${r.eff.toFixed(0).padStart(3)} | ${r.spawnLoad.toFixed(3)}`
+    );
+  }
+  console.log(`  break-even net=0:  flat (no TTL) ${breakeven(rate, false)} tiles  ->  TTL-adjusted ${breakeven(rate, true)} tiles`);
+}
+
+printTable("owned / reserved", 10);
+printTable("unreserved", 5);
+console.log("\nminerOH = 650/(1500-d)  (static miner dies at source);  haulerOH = carry*100/(1500-d)");
+console.log("bodyParts = 8 (miner) + 2*carry (haulers);  spawnLoad = bodyParts*3/(1500-d) = fraction of one spawn's uptime");

--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -614,6 +614,7 @@ export class CarryCorp extends Corp {
   public project(scene: ChainScene): CorpEconomics {
     let costPerTick = 0;
     let throughput = 0;
+    let spawnPartsPerTick = 0;
     for (const a of this.haulerAssignments) {
       const body = buildHaulerBody(a.flowRate, a.distance, scene.energyCapacity);
       if (body.cost === 0 || body.carryCapacity === 0) continue;
@@ -626,9 +627,13 @@ export class CarryCorp extends Corp {
       const travel = pickup ? scene.dist(scene.spawnPos, pickup.pos) * travelTicksPerTile(scene.energyCapacity) : 0;
       const usefulLife = Math.max(1, CREEP_LIFETIME - travel);
       costPerTick += (haulers * body.cost) / usefulLife;
+      // The hauler fleet is the part-hungry one: more haulers, each a bigger
+      // body, the farther the route - this is the term that makes a far source
+      // exhaust the spawn's build-rate budget.
+      spawnPartsPerTick += (haulers * body.body.length) / usefulLife;
       throughput += a.flowRate;
     }
-    return { costPerTick, throughput };
+    return { costPerTick, throughput, spawnPartsPerTick };
   }
 
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {

--- a/src/corps/Corp.ts
+++ b/src/corps/Corp.ts
@@ -365,7 +365,7 @@ export abstract class Corp {
    * update.
    */
   project(_scene: ChainScene): CorpEconomics {
-    return { costPerTick: 0, throughput: 0 };
+    return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
   }
 
   /**

--- a/src/corps/HarvestCorp.ts
+++ b/src/corps/HarvestCorp.ts
@@ -303,17 +303,23 @@ export class HarvestCorp extends Corp {
    */
   public project(scene: ChainScene): CorpEconomics {
     const source = scene.resource(this.sourceId);
-    if (!source) return { costPerTick: 0, throughput: 0 };
+    if (!source) return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
 
     const capacity = source.capacity ?? SOURCE_ENERGY_CAPACITY;
     const supply = capacity / SOURCE_REGEN_TIME;
     const body = buildMinerBody(calculateOptimalWorkParts(capacity), scene.energyCapacity);
-    if (body.cost === 0) return { costPerTick: 0, throughput: 0 };
+    if (body.cost === 0) return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
 
     const harvestRate = Math.min(supply, HARVEST_RATE * body.workParts);
     const travel = scene.dist(scene.spawnPos, source.pos) * travelTicksPerTile(scene.energyCapacity);
     const usefulLife = Math.max(1, CREEP_LIFETIME - travel);
-    return { costPerTick: body.cost / usefulLife, throughput: harvestRate };
+    // A static miner walks out once and dies at the source, so it both costs
+    // energy and consumes spawn build-time over its (shortened) useful life.
+    return {
+      costPerTick: body.cost / usefulLife,
+      throughput: harvestRate,
+      spawnPartsPerTick: body.body.length / usefulLife
+    };
   }
 
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {

--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -367,16 +367,16 @@ export class UpgradingCorp extends Corp {
    */
   public project(scene: ChainScene): CorpEconomics {
     const allocated = this.sinkAllocation?.allocated ?? 0;
-    if (allocated <= 0 || !scene.controllerPos) return { costPerTick: 0, throughput: 0 };
+    if (allocated <= 0 || !scene.controllerPos) return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
 
     // Virtual mode has no vision of buffers, so assume the mobile (no-container)
     // strategy - the conservative, CARRY-heavier body.
     const body = buildUpgraderBody(scene.energyCapacity, Math.max(1, Math.ceil(allocated)), "mobile");
-    if (body.cost === 0) return { costPerTick: 0, throughput: 0 };
+    if (body.cost === 0) return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
 
     const travel = scene.dist(scene.spawnPos, scene.controllerPos) * travelTicksPerTile(scene.energyCapacity);
     const usefulLife = Math.max(1, CREEP_LIFETIME - travel);
-    return { costPerTick: body.cost / usefulLife, throughput: 0 };
+    return { costPerTick: body.cost / usefulLife, throughput: 0, spawnPartsPerTick: body.body.length / usefulLife };
   }
 
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {

--- a/src/corps/economics.ts
+++ b/src/corps/economics.ts
@@ -34,6 +34,39 @@ export interface ChainScene {
   resource(id: string): SceneResource | undefined;
 }
 
+/**
+ * Body parts a single spawn can build per tick. A spawn produces one part every
+ * SPAWN_TIME_PER_PART (3) ticks, so this is 1/3 - i.e. 500 parts over a creep's
+ * 1500-tick life. It is the spawn's *time* budget, separate from and often
+ * tighter than its energy budget: a far source can stay net-energy-positive yet
+ * demand more hauler parts than the spawn can physically build. Corps compete for
+ * this budget the same way they compete for energy, so a source that is too far
+ * loses the competition and falls out - no hard distance limit required.
+ */
+export const SPAWN_PARTS_PER_TICK = 1 / 3;
+
+/**
+ * Rough energy/tick a single spawn can keep harvested + delivered. Used only to
+ * PRICE spawn build-time in energy terms, not as a hard cap. Pricing the spawn's
+ * 0.333 parts/tick against this gives {@link SPAWN_PART_ENERGY_VALUE}, the energy
+ * a unit of spawn throughput is "worth" - so a part-hungry corp can be penalized
+ * in pure energy and ranked against everything else. A conservative mid estimate
+ * (a couple of well-staffed sources); tune against real colonies.
+ */
+export const SPAWN_SUPPORTED_HARVEST = 60;
+
+/**
+ * Energy value of one unit of spawn throughput (energy per part/tick): how much
+ * harvested energy the spawn could support if that build-time went to its best
+ * use. = SPAWN_SUPPORTED_HARVEST / SPAWN_PARTS_PER_TICK. Multiply a corp's
+ * {@link CorpEconomics.spawnPartsPerTick} by this to get its build-time cost in
+ * energy, then subtract it from net energy (see {@link effectiveNet}). This is
+ * what makes the spawn-time wall fall out of a pure-energy ranking: a far source
+ * whose haulers eat the build budget is penalized enough to lose to a near one,
+ * with no hard distance limit.
+ */
+export const SPAWN_PART_ENERGY_VALUE = SPAWN_SUPPORTED_HARVEST / SPAWN_PARTS_PER_TICK;
+
 /** What a corp projects it would cost and move, per tick, in a given scene. */
 export interface CorpEconomics {
   /**
@@ -44,6 +77,27 @@ export interface CorpEconomics {
   costPerTick: number;
   /** Energy/tick this corp delivers toward the goal (0 for pure consumers). */
   throughput: number;
+  /**
+   * Body parts/tick this corp draws from spawn throughput: its claim on the
+   * spawn's finite build rate (see {@link SPAWN_PARTS_PER_TICK}). Computed on the
+   * same creep-count and useful-life basis as {@link costPerTick}, so the two
+   * budgets stay in step. This is what makes the spawn-time wall fall out of
+   * planning: sum it across the corps a spawn supports and a far, part-hungry
+   * roster exceeds the spawn's build rate long before it exhausts the energy.
+   */
+  spawnPartsPerTick: number;
+}
+
+/**
+ * Net energy/tick of a corp (or a summed chain) in a single currency: its energy
+ * delivery, minus its energy upkeep, minus its spawn build-time priced in energy
+ * (see {@link SPAWN_PART_ENERGY_VALUE}). This is the number to RANK by - a corp
+ * that delivers energy but hogs the spawn's build rate (a far hauler fleet, a
+ * reserver) is demoted just as if it cost that much energy, so the spawn-time
+ * constraint falls out of the same comparison that already weighs energy.
+ */
+export function effectiveNet(econ: CorpEconomics): number {
+  return econ.throughput - econ.costPerTick - econ.spawnPartsPerTick * SPAWN_PART_ENERGY_VALUE;
 }
 
 /**

--- a/test/unit/corps/spawnPartsEconomics.test.ts
+++ b/test/unit/corps/spawnPartsEconomics.test.ts
@@ -1,0 +1,70 @@
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { HarvestCorp } from "../../../src/corps/HarvestCorp";
+import { CarryCorp } from "../../../src/corps/CarryCorp";
+import { ChainScene, effectiveNet, SPAWN_PART_ENERGY_VALUE } from "../../../src/corps/economics";
+import { chebyshevDistance } from "../../../src/types/Position";
+import { HaulerAssignment } from "../../../src/flow/FlowTypes";
+
+const SPAWN = { x: 0, y: 0, roomName: "W1N1" };
+function scene(): ChainScene {
+  return {
+    spawnPos: SPAWN,
+    energyCapacity: 800,
+    controllerPos: SPAWN,
+    dist: chebyshevDistance,
+    resource: (id: string) => {
+      const m = /^src@(\d+)$/.exec(id);
+      if (m) return { pos: { x: Number(m[1]), y: 0, roomName: "W1N1" }, capacity: 3000 };
+      return undefined;
+    }
+  };
+}
+
+function haulRoute(fromId: string, distance: number, flowRate = 10): HaulerAssignment {
+  return { edgeId: `${fromId}|c`, fromId, toId: "c", distance, carryParts: 0, flowRate, spawnCostPerTick: 0, spawnId: "v" };
+}
+
+describe("spawn-part economics", () => {
+  it("a miner reports a spawn-part cost = body parts / useful life", () => {
+    const corp = new HarvestCorp("v", "v", "src@5");
+    const e = corp.project(scene());
+    expect(e.spawnPartsPerTick).to.be.greaterThan(0);
+    // A 5W3M miner (8 parts) at d=5 lives ~1500-15 ticks: 8/~1485 ~ 0.0054.
+    expect(e.spawnPartsPerTick).to.be.closeTo(0.0054, 0.002);
+  });
+
+  it("a farther hauling route draws MORE spawn parts (the part-hungry term)", () => {
+    const near = new CarryCorp("v", "v");
+    near.setHaulerAssignments([haulRoute("src@5", 5)]);
+    const far = new CarryCorp("v", "v");
+    far.setHaulerAssignments([haulRoute("src@200", 200)]);
+    const nearParts = near.project(scene()).spawnPartsPerTick;
+    const farParts = far.project(scene()).spawnPartsPerTick;
+    expect(farParts).to.be.greaterThan(nearParts);
+  });
+
+  it("the spawn-part penalty demotes a far source below a near one in pure energy", () => {
+    // Same gross flow (10/tick) mined + hauled; only the distance differs. The far
+    // route's part-hungry hauler fleet makes its effective (penalty-adjusted) net
+    // lower, so it ranks below the near source - the spawn-time wall falling out of
+    // a single energy comparison, not a hard distance limit.
+    const build = (d: number) => {
+      const miner = new HarvestCorp("v", "v", `src@${d}`).project(scene());
+      const hauler = new CarryCorp("v", "v");
+      hauler.setHaulerAssignments([haulRoute(`src@${d}`, d)]);
+      const haul = hauler.project(scene());
+      return effectiveNet({
+        costPerTick: miner.costPerTick + haul.costPerTick,
+        throughput: miner.throughput,
+        spawnPartsPerTick: miner.spawnPartsPerTick + haul.spawnPartsPerTick
+      });
+    };
+    expect(build(200)).to.be.lessThan(build(5));
+  });
+
+  it("prices spawn build-time at SPAWN_PART_ENERGY_VALUE per part/tick", () => {
+    const econ = { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0.1 };
+    expect(effectiveNet(econ)).to.be.closeTo(-0.1 * SPAWN_PART_ENERGY_VALUE, 1e-9);
+  });
+});


### PR DESCRIPTION
Three pieces toward understanding (and eventually planning by) the spawn's TRUE
effective energy rate.

**Model: price spawn build-time in energy.** A spawn has two budgets - energy and
build-time (1 part / 3 ticks = 500 parts over a 1500-tick life). For a far source
the build-time is the tighter one: its hauler fleet can stay net-energy-positive
yet need more parts than the spawn can physically build. So `CorpEconomics` now
carries `spawnPartsPerTick` (every `project()` reports body parts * count /
useful life - capturing a static miner's shortened TTL and a far hauler fleet's
extra bodies), and `effectiveNet` prices that build-time in energy
(`SPAWN_PART_ENERGY_VALUE`). Ranking by `effectiveNet` demotes a part-hungry far
source below a near one in a single currency, so the spawn-time wall falls out of
the same comparison that weighs energy - no hard distance cutoff. Tunable.

**`sim:ab`** - cold-start A/B harness: same scenario, any commit, compare control
points (used to measure the pre-#56 baseline vs current master).

**`sim:energy`** - TTL-aware effective-energy table: net e/tick after miner+hauler
overhead, with the travel-TTL the flat model omits (miner `650/(1500-d)`), total
body parts, and spawn-time load per source.

408 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_