### PR TITLE
Calibrate spawn-part energy price + document the effective-energy model

### DIFF
--- a/docs/ECONOMIC_FRAMEWORK.md
+++ b/docs/ECONOMIC_FRAMEWORK.md
@@ -211,6 +211,85 @@ interface FlowSolution {
 // Efficiency: 97.3%
 ```
 
+## Effective Energy: What a Source TRULY Nets
+
+The net-energy example above is the *co-located* best case. The real value of a
+source is its **effective energy/tick** after every overhead it actually incurs,
+and that is what should drive "is this source worth mining, and from where?".
+Three effects, all distance-driven, pull it down — and a fourth currency makes
+the cutoff fall out without a hard limit.
+
+Tools: `npm run sim:energy` prints the effective-energy table;
+`scripts/effective-energy.ts` is the model. Each corp reports its own numbers via
+`Corp.project()` → `CorpEconomics`, and `effectiveNet()` collapses them to one
+number to rank by (`src/corps/economics.ts`).
+
+### 1. The hauler dominates, and grows with distance
+
+The miner is a flat, small cost (a 5W3M body, ~0.43 e/tick amortized). The
+**hauler** is the cost that explodes: CARRY scales with the round trip, so
+`haulerOverhead ≈ rate·(2d+2)/750`. For an owned source (10 e/tick gross):
+
+| one-way dist | net e/tick | efficiency | total body parts |
+|---|---|---|---|
+| 0   | 9.5 | 95% | 10  |
+| 50  | 8.1 | 81% | 50  |
+| 100 | 6.6 | 66% | 90  |
+| 200 | 3.3 | 33% | 170 |
+| 300 | −0.6 | −6% | 250 |
+
+### 2. Travel TTL shortens the miner's life
+
+A static miner walks `d` tiles out and then **dies at the source**, so it only
+mines for `1500 − d` ticks and must be respawned that much more often. Its real
+amortized cost is `650/(1500−d)` (e.g. respawn every 1300 at d=200), not the flat
+`650/1500` the old `FlowSolver` used. The same initial walk-out shortens a
+hauler's productive life too. TTL pulls the *net-zero* break-even in from ~356 to
+~285 tiles (owned) / ~339 to ~270 (unreserved).
+
+### 3. Spawn build-time is a SECOND budget — priced in energy
+
+A spawn has two budgets, not one. Besides energy it has **build-time**: it makes
+one body part every `SPAWN_TIME_PER_PART` (3) ticks = **500 parts over a 1500-tick
+life** (`SPAWN_PARTS_PER_TICK = 1/3`). A far source can stay net-energy-positive
+yet demand more hauler parts than the spawn can physically build — so build-time
+is often the *tighter* wall, and it bites at a closer distance than the energy
+break-even. A single owned source at d≈200 already eats ~40% of one spawn's entire
+part budget; two such sources nearly saturate it before a single upgrader is built.
+
+Rather than a hard part cap, we **price build-time in energy** and fold it into the
+same ranking that already weighs energy:
+
+```
+effectiveNet = throughput − energyUpkeep − spawnPartsPerTick · SPAWN_PART_ENERGY_VALUE
+```
+
+`SPAWN_PART_ENERGY_VALUE ≈ 155` (energy per part/tick) is calibrated from a
+representative source at the average remote distance (~75 tiles): it nets ~7.4
+e/tick on ~70 parts, so a held part is worth ~0.1 e/tick ≈ 155 over its life.
+Ranking by `effectiveNet`, a part-hungry far source is demoted below a near one in
+pure energy — so the spawn-time wall **falls out of planning**, no hard distance
+limit required.
+
+The constant is really a stand-in for the colony's **marginal alternative use of a
+part** (an idle spawn → cheap parts → far sources welcome; abundant near sources →
+expensive parts → far sources excluded). By construction `effNet` crosses zero at
+the calibration distance, so with 155 a single spawn's profitable remote reach is
+about **50–75 tiles**; lower the constant (a poorer marginal alternative) and the
+reach extends. Tune it to the colony, don't hard-code a distance.
+
+### 4. Reserving a remote room is a per-ROOM cost
+
+Reserving lifts a remote source from 5 → 10 e/tick, but a reserver is **expensive
+in both currencies**: a `CLAIM+MOVE` body costs 650 energy, CLAIM creeps live only
+~600 ticks, and it must walk to the room — so amortized it is ~`650/(600−d)` e/tick
+*plus* its parts priced in energy, **per room**. That cost is shared across the
+room's sources, so it amortizes over them: a **two-source** room halves the
+per-source reserver cost, which is why two sources justify reserving (and reaching
+farther) where one source may not. Reserve only while `+5/source` gross beats the
+amortized per-source reserver cost — another decision that falls straight out of
+`effectiveNet`.
+
 ## ROI Tracking
 
 Even with flow-based allocation, we track corps performance:

--- a/scripts/effective-energy.ts
+++ b/scripts/effective-energy.ts
@@ -17,9 +17,24 @@
  */
 
 const LIFETIME = 1500;
-const COST = { WORK: 100, CARRY: 50, MOVE: 50 };
+const COST = { WORK: 100, CARRY: 50, MOVE: 50, CLAIM: 600 };
 const MINER_COST = 5 * COST.WORK + 3 * COST.MOVE; // 650, a 5W3M miner
 const MINER_PARTS = 8; // 5 WORK + 3 MOVE
+
+// Spawn build-time priced in energy (mirrors src/corps/economics.ts).
+const SPAWN_PART_ENERGY_VALUE = 155; // energy per part/tick held
+
+// Reserver: a CLAIM+MOVE creep that holds a remote room at the full 3000 cap.
+// CLAIM creeps live only ~600 ticks; one CLAIM keeps a room reserved.
+const CLAIM_LIFETIME = 600;
+const RESERVER_COST = COST.CLAIM + COST.MOVE; // 650
+const RESERVER_PARTS = 2; // CLAIM + MOVE
+
+/** Per-ROOM reserver cost in energy-equivalent (upkeep + parts priced), at distance d. */
+function reserverCostPerRoom(d: number): number {
+  const life = Math.max(1, CLAIM_LIFETIME - d); // walks out, then reserves
+  return RESERVER_COST / life + (RESERVER_PARTS / life) * SPAWN_PART_ENERGY_VALUE;
+}
 
 /** Round trip ticks for a one-way distance d (matches calculateRoundTrip). */
 const roundTrip = (d: number): number => 2 * d + 2;
@@ -31,11 +46,11 @@ const usefulLife = (d: number): number => Math.max(1, LIFETIME - d);
 interface Row {
   carry: number;
   totalParts: number;
-  minerOH: number;
-  haulerOH: number;
   net: number;
   eff: number;
   spawnLoad: number;
+  partPenalty: number;
+  effNet: number;
 }
 
 function row(rate: number, d: number, ttl: boolean): Row {
@@ -44,17 +59,19 @@ function row(rate: number, d: number, ttl: boolean): Row {
   const totalParts = MINER_PARTS + 2 * carry; // hauler = 1 CARRY + 1 MOVE per unit
   const minerOH = MINER_COST / life;
   const haulerOH = (carry * (COST.CARRY + COST.MOVE)) / life;
-  const net = rate - minerOH - haulerOH;
+  const net = rate - minerOH - haulerOH; // energy profit (after body upkeep)
+  // Spawn build-time priced in energy: the second budget. effNet is the number
+  // to rank by - a far, part-hungry source is demoted in pure energy.
+  const partPenalty = (totalParts / life) * SPAWN_PART_ENERGY_VALUE;
   return {
     carry,
     totalParts,
-    minerOH,
-    haulerOH,
     net,
     eff: (net / rate) * 100,
-    // fraction of ONE spawn's uptime this source's fleet consumes:
-    // parts*3 ticks to build, divided by how long each fleet lives.
-    spawnLoad: (totalParts * 3) / life
+    // fraction of ONE spawn's uptime this source's fleet consumes.
+    spawnLoad: (totalParts * 3) / life,
+    partPenalty,
+    effNet: net - partPenalty
   };
 }
 
@@ -65,19 +82,43 @@ function breakeven(rate: number, ttl: boolean): number {
 
 function printTable(label: string, rate: number): void {
   console.log(`\n=== ${label} (gross ${rate} e/tick) ===`);
-  console.log(" dist | carry | bodyParts | minerOH haulerOH |  netE  eff% | spawnLoad");
+  console.log(" dist | carry | bodyParts |  netE  eff% | spawnLoad | partPenalty | effNet");
   for (const d of [0, 25, 50, 75, 100, 150, 200, 250, 300]) {
     const r = row(rate, d, true);
     console.log(
       `  ${String(d).padStart(3)} | ${String(r.carry).padStart(5)} | ${String(r.totalParts).padStart(9)} | ` +
-        `${r.minerOH.toFixed(2).padStart(6)} ${r.haulerOH.toFixed(2).padStart(7)} | ` +
-        `${r.net.toFixed(2).padStart(5)} ${r.eff.toFixed(0).padStart(3)} | ${r.spawnLoad.toFixed(3)}`
+        `${r.net.toFixed(2).padStart(5)} ${r.eff.toFixed(0).padStart(3)} | ${r.spawnLoad.toFixed(3).padStart(9)} | ` +
+        `${r.partPenalty.toFixed(2).padStart(11)} | ${r.effNet.toFixed(2).padStart(6)}`
     );
   }
-  console.log(`  break-even net=0:  flat (no TTL) ${breakeven(rate, false)} tiles  ->  TTL-adjusted ${breakeven(rate, true)} tiles`);
+  console.log(`  break-even net=0 (energy): flat ${breakeven(rate, false)}t -> TTL ${breakeven(rate, true)}t`);
+}
+
+/**
+ * Reserve a remote room (5 -> 10 e/tick) or not? The reserver is a per-ROOM cost
+ * amortized over the room's sources, so 2 sources halve it. Shows per-source
+ * effNet reserved (with the reserver toll) vs unreserved, for 1 and 2 sources.
+ */
+function printReserver(): void {
+  console.log(`\n=== reserve a remote room? (per-source effNet) ===`);
+  console.log(" dist | unreserved | reserved(1src) | reserved(2src) | reserverTollPerRoom");
+  for (const d of [25, 50, 75, 100, 150, 200]) {
+    const unres = row(5, d, true).effNet;
+    const resBase = row(10, d, true).effNet; // a reserved source's effNet before the reserver toll
+    const toll = reserverCostPerRoom(d);
+    const res1 = resBase - toll; // 1 source bears the whole reserver
+    const res2 = resBase - toll / 2; // 2 sources split it
+    const win = (a: number, b: number) => (a > b ? "reserve" : "leave ");
+    console.log(
+      `  ${String(d).padStart(3)} | ${unres.toFixed(2).padStart(10)} | ` +
+        `${res1.toFixed(2).padStart(8)} ${win(res1, unres)} | ${res2.toFixed(2).padStart(8)} ${win(res2, unres)} | ${toll.toFixed(2).padStart(8)}`
+    );
+  }
 }
 
 printTable("owned / reserved", 10);
 printTable("unreserved", 5);
-console.log("\nminerOH = 650/(1500-d)  (static miner dies at source);  haulerOH = carry*100/(1500-d)");
-console.log("bodyParts = 8 (miner) + 2*carry (haulers);  spawnLoad = bodyParts*3/(1500-d) = fraction of one spawn's uptime");
+printReserver();
+console.log("\nminerOH=650/(1500-d) (miner dies at source); haulerOH=carry*100/(1500-d); bodyParts=8+2*carry");
+console.log(`partPenalty = (bodyParts/life) * ${SPAWN_PART_ENERGY_VALUE} (spawn build-time priced in energy); effNet = netE - partPenalty (rank by this)`);
+console.log("reserver = (650 + 2 parts priced) / (600-d) per ROOM, split across the room's sources");

--- a/src/corps/economics.ts
+++ b/src/corps/economics.ts
@@ -46,26 +46,21 @@ export interface ChainScene {
 export const SPAWN_PARTS_PER_TICK = 1 / 3;
 
 /**
- * Rough energy/tick a single spawn can keep harvested + delivered. Used only to
- * PRICE spawn build-time in energy terms, not as a hard cap. Pricing the spawn's
- * 0.333 parts/tick against this gives {@link SPAWN_PART_ENERGY_VALUE}, the energy
- * a unit of spawn throughput is "worth" - so a part-hungry corp can be penalized
- * in pure energy and ranked against everything else. A conservative mid estimate
- * (a couple of well-staffed sources); tune against real colonies.
+ * Energy value of one unit of spawn throughput - energy per (part/tick), i.e. the
+ * energy a body part held continuously (respawned forever) is worth. Multiply a
+ * corp's {@link CorpEconomics.spawnPartsPerTick} by this to price its spawn
+ * build-time in energy, then subtract from net (see {@link effectiveNet}). This
+ * is what makes the spawn-time wall fall out of a pure-energy ranking: a far
+ * source whose haulers eat the build budget is penalized enough to lose to a near
+ * one, with no hard distance limit.
+ *
+ * Calibrated from a representative source at the average remote distance
+ * (~75 tiles): it nets ~7.4 e/tick on ~70 body parts, so a held part is worth
+ * ~7.4/70 ~ 0.1 e/tick, i.e. ~155 energy over its 1500-tick life. The implied
+ * "harvest a spawn can support" is ~155 * 0.333 ~ 52 e/tick. Tunable; recalibrate
+ * against real colonies.
  */
-export const SPAWN_SUPPORTED_HARVEST = 60;
-
-/**
- * Energy value of one unit of spawn throughput (energy per part/tick): how much
- * harvested energy the spawn could support if that build-time went to its best
- * use. = SPAWN_SUPPORTED_HARVEST / SPAWN_PARTS_PER_TICK. Multiply a corp's
- * {@link CorpEconomics.spawnPartsPerTick} by this to get its build-time cost in
- * energy, then subtract it from net energy (see {@link effectiveNet}). This is
- * what makes the spawn-time wall fall out of a pure-energy ranking: a far source
- * whose haulers eat the build budget is penalized enough to lose to a near one,
- * with no hard distance limit.
- */
-export const SPAWN_PART_ENERGY_VALUE = SPAWN_SUPPORTED_HARVEST / SPAWN_PARTS_PER_TICK;
+export const SPAWN_PART_ENERGY_VALUE = 155;
 
 /** What a corp projects it would cost and move, per tick, in a given scene. */
 export interface CorpEconomics {


### PR DESCRIPTION
Calibrates the spawn-part energy price to your number and documents the whole
effective-energy model.

- **Calibration:** `SPAWN_PART_ENERGY_VALUE = 155`, derived directly from a
  representative source at the average remote distance (~75 tiles): ~7.4 e/tick on
  ~70 parts → a held part is worth ~0.1 e/tick ≈ 155 over its life (replaces the
  placeholder 180).
- **Docs (`ECONOMIC_FRAMEWORK.md`):** new "Effective Energy" section — the hauler
  dominating and exploding with distance, travel-TTL shortening the miner's life,
  spawn build-time as a second budget priced in energy (so the distance cutoff
  falls out of `effectiveNet`, not a hard limit; the constant stands in for the
  colony's marginal part value), and reserving a room as a per-room cost amortized
  over its sources (why two sources reach farther).
- **`sim:energy`:** now shows the spawn-part penalty + `effNet` (the ranking
  number) and a reserve-or-not crossover for 1 vs 2 sources. With 155, `effNet`
  crosses zero ~50–75 tiles and reserving wins only at d≤50.

Unit tests green (the model tests reference the constant symbolically).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_