### PR TITLE
Wire effectiveNet into the miner gate + refine reserver economics

### DIFF
--- a/docs/ECONOMIC_FRAMEWORK.md
+++ b/docs/ECONOMIC_FRAMEWORK.md
@@ -281,14 +281,22 @@ reach extends. Tune it to the colony, don't hard-code a distance.
 ### 4. Reserving a remote room is a per-ROOM cost
 
 Reserving lifts a remote source from 5 → 10 e/tick, but a reserver is **expensive
-in both currencies**: a `CLAIM+MOVE` body costs 650 energy, CLAIM creeps live only
-~600 ticks, and it must walk to the room — so amortized it is ~`650/(600−d)` e/tick
-*plus* its parts priced in energy, **per room**. That cost is shared across the
-room's sources, so it amortizes over them: a **two-source** room halves the
-per-source reserver cost, which is why two sources justify reserving (and reaching
-farther) where one source may not. Reserve only while `+5/source` gross beats the
-amortized per-source reserver cost — another decision that falls straight out of
-`effectiveNet`.
+in both currencies**: a `CLAIM+MOVE` body costs 650 energy, and CLAIM creeps live
+only **`CREEP_CLAIM_LIFE_TIME` = 600 ticks** (not 1500), so its short life makes it
+cost more than its body suggests. It also walks to the room — amortized ~`650/(600−d)`
+e/tick *plus* its parts priced in energy. Two effects pull that toll back down:
+
+- **Per-room, shared across the room's sources.** A **two-source** room halves the
+  per-source reserver cost, so two sources justify reserving (and reaching farther)
+  where one source may not.
+- **Duty cycle ~50%.** Reservation accumulates (up to 5000) and decays 1/tick, so a
+  reserver is *not* needed continuously — let it build up, let it tick down, then
+  top up. That roughly halves the amortized cost again.
+
+Reserve only while `+5/source` gross beats the (duty-cycled, per-source) reserver
+toll — another decision that falls straight out of `effectiveNet`. With both
+effects, the toll is ~0.8–1.2 e/tick per room and reserving wins out to ~50 tiles
+for one source, ~75 for two.
 
 ## ROI Tracking
 

--- a/scripts/effective-energy.ts
+++ b/scripts/effective-energy.ts
@@ -25,15 +25,20 @@ const MINER_PARTS = 8; // 5 WORK + 3 MOVE
 const SPAWN_PART_ENERGY_VALUE = 155; // energy per part/tick held
 
 // Reserver: a CLAIM+MOVE creep that holds a remote room at the full 3000 cap.
-// CLAIM creeps live only ~600 ticks; one CLAIM keeps a room reserved.
+// CLAIM creeps live only CREEP_CLAIM_LIFE_TIME = 600 ticks (vs 1500), so the
+// reserver's short life makes it more expensive than its body suggests.
 const CLAIM_LIFETIME = 600;
 const RESERVER_COST = COST.CLAIM + COST.MOVE; // 650
 const RESERVER_PARTS = 2; // CLAIM + MOVE
+// Reservation accumulates (up to 5000) and decays 1/tick, so a reserver is NOT
+// needed 100% of the time - let it build up, let it tick down, then top up. ~50%
+// duty roughly halves the amortized reserver cost.
+const RESERVER_DUTY = 0.5;
 
 /** Per-ROOM reserver cost in energy-equivalent (upkeep + parts priced), at distance d. */
 function reserverCostPerRoom(d: number): number {
   const life = Math.max(1, CLAIM_LIFETIME - d); // walks out, then reserves
-  return RESERVER_COST / life + (RESERVER_PARTS / life) * SPAWN_PART_ENERGY_VALUE;
+  return RESERVER_DUTY * (RESERVER_COST / life + (RESERVER_PARTS / life) * SPAWN_PART_ENERGY_VALUE);
 }
 
 /** Round trip ticks for a one-way distance d (matches calculateRoundTrip). */

--- a/src/flow/FlowSolver.ts
+++ b/src/flow/FlowSolver.ts
@@ -15,6 +15,8 @@
  * 6. Verify system is sustainable (overhead < harvest)
  */
 import {
+  BODY_COSTS,
+  CREEP_LIFETIME,
   FlowConstraints,
   FlowEdge,
   FlowProblem,
@@ -22,13 +24,16 @@ import {
   FlowSolution,
   FlowSource,
   HaulerAssignment,
+  MINER_COST,
   MINER_OVERHEAD_PER_TICK,
+  MINER_PARTS,
   MinerAssignment,
   SOURCE_ENERGY_PER_TICK,
   SinkAllocation,
   calculateCarryParts,
   calculateHaulerCostPerTick
 } from "./FlowTypes";
+import { SPAWN_PART_ENERGY_VALUE } from "../corps/economics";
 import { VariantConstraints, generateEdgeVariants, selectBestVariant } from "../framework/EdgeVariant";
 
 // =============================================================================
@@ -195,34 +200,35 @@ export class FlowSolver {
 
       const spawnDistance = nearestSpawn.distance;
 
-      // Calculate profitability: is this source worth mining?
-      // Net = harvestRate - minerOverhead - haulerOverhead
+      // Profitability in EFFECTIVE energy: gross harvest, minus the miner and
+      // hauler upkeep, minus the spawn BUILD-TIME those bodies consume priced in
+      // energy. Both overheads are amortized over the creep's TTL: a static miner
+      // walks `spawnDistance` tiles out and then dies at the source, so it lives
+      // (and amortizes) over CREEP_LIFETIME minus the walk - the farther the
+      // source, the more often it must be rebuilt. The spawn-part penalty is what
+      // makes a far source FALL OUT: its hauler fleet can stay net-energy-positive
+      // yet cost more spawn build-time than it is worth, so effectiveNet goes
+      // negative - no hard distance/efficiency threshold required.
       const harvestRate = source.capacity;
-      const minerOverhead = MINER_OVERHEAD_PER_TICK;
-
-      // Estimate hauler overhead to nearest sink (spawn)
-      // This is a conservative estimate - actual hauling may be shorter
+      const life = Math.max(1, CREEP_LIFETIME - spawnDistance);
+      const minerOverhead = MINER_COST / life;
       const carryParts = calculateCarryParts(harvestRate, spawnDistance);
-      const haulerOverhead = calculateHaulerCostPerTick(carryParts);
+      const haulerOverhead = (carryParts * (BODY_COSTS.CARRY + BODY_COSTS.MOVE)) / life;
+      const totalParts = MINER_PARTS + 2 * carryParts; // miner 8 + hauler CARRY+MOVE
+      const partPenalty = (totalParts / life) * SPAWN_PART_ENERGY_VALUE;
 
-      const totalOverhead = minerOverhead + haulerOverhead;
-      const netEnergy = harvestRate - totalOverhead;
+      const netEnergy = harvestRate - minerOverhead - haulerOverhead;
+      const effectiveNet = netEnergy - partPenalty;
+      // Rank by effective profit per gross energy, so when the spawn is the
+      // bottleneck the nearest (most build-time-efficient) sources are staffed first.
+      const efficiency = (effectiveNet / harvestRate) * 100;
 
-      // Calculate efficiency percentage: (harvestRate - totalOverhead) / harvestRate * 100
-      const efficiency = (netEnergy / harvestRate) * 100;
-
-      // Only mine if profitable:
-      // 1. Net energy must be positive (at least 2 e/tick buffer)
-      // 2. Efficiency must be at least 65% (otherwise overhead is too high)
-      // Higher thresholds = fewer but more profitable remote mines
-      // This prevents long-range mines that waste creep time and spawn capacity
-      const MIN_NET_ENERGY = 2.0;
-      const MIN_EFFICIENCY = 65;
-      if (netEnergy < MIN_NET_ENERGY || efficiency < MIN_EFFICIENCY) {
+      // Mine only when the source is worth more than the spawn build-time it eats.
+      if (effectiveNet <= 0) {
         console.log(
-          `[FlowSolver] Skipping unprofitable source ${source.id.slice(-8)}: ` +
-            `harvest=${harvestRate.toFixed(1)}, overhead=${totalOverhead.toFixed(2)}, ` +
-            `net=${netEnergy.toFixed(2)}, eff=${efficiency.toFixed(0)}%, distance=${spawnDistance}`
+          `[FlowSolver] Skipping source ${source.id.slice(-8)} (build-time not worth it): ` +
+            `harvest=${harvestRate.toFixed(1)}, net=${netEnergy.toFixed(2)}, ` +
+            `partPenalty=${partPenalty.toFixed(2)}, effNet=${effectiveNet.toFixed(2)}, distance=${spawnDistance}`
         );
         continue;
       }
@@ -233,7 +239,7 @@ export class FlowSolver {
         spawnId: nearestSpawn.id,
         spawnDistance,
         harvestRate: source.capacity,
-        spawnCostPerTick: MINER_OVERHEAD_PER_TICK,
+        spawnCostPerTick: minerOverhead,
         maxMiners: source.maxMiners,
         efficiency
       });

--- a/src/flow/FlowTypes.ts
+++ b/src/flow/FlowTypes.ts
@@ -30,6 +30,8 @@ export const BODY_COSTS = {
 
 /** Standard miner: 5W 3M */
 export const MINER_COST = 5 * BODY_COSTS.WORK + 3 * BODY_COSTS.MOVE; // 650
+/** Body parts of a standard miner (5 WORK + 3 MOVE), for spawn build-time costing. */
+export const MINER_PARTS = 8;
 
 /** Miner spawn overhead per tick */
 export const MINER_OVERHEAD_PER_TICK = MINER_COST / CREEP_LIFETIME; // ~0.433

--- a/test/unit/flow/FlowSolver.test.ts
+++ b/test/unit/flow/FlowSolver.test.ts
@@ -592,15 +592,21 @@ describe("Economy Scenarios (from minimal-economy)", () => {
       expect(sol30.efficiency).to.be.greaterThan(sol100.efficiency);
     });
 
-    it("should show efficiency decreasing with distance", () => {
-      const distances = [10, 20, 30, 50, 75, 100];
+    it("should show efficiency decreasing with distance, then the source falling out", () => {
+      // Within the profitable range, farther = lower effective efficiency.
       let prevEfficiency = 100;
-
-      for (const d of distances) {
+      for (const d of [10, 20, 30, 50]) {
         const solution = solveIteratively(createScenario(d));
+        expect(solution.miners, `d=${d} should still be mined`).to.have.length(1);
         expect(solution.efficiency).to.be.lessThan(prevEfficiency);
         prevEfficiency = solution.efficiency;
       }
+      // Past the build-time break-even (~75 tiles at the current SPAWN_PART_ENERGY_VALUE
+      // calibration) the source FALLS OUT: its hauler fleet costs more spawn
+      // build-time than the source is worth, so effectiveNet goes negative and no
+      // miner is assigned - no hard distance/efficiency threshold, it falls out of
+      // the effectiveNet gate.
+      expect(solveIteratively(createScenario(120)).miners, "a far source falls out").to.have.length(0);
     });
   });
 


### PR DESCRIPTION
Wires the effective-energy model into the planner, and refines the reserver
economics.

**`effectiveNet` replaces the hard distance/efficiency thresholds.**
`FlowSolver.assignMiners` decided "worth mining?" with two magic numbers
(`MIN_NET_ENERGY=2`, `MIN_EFFICIENCY=65%`) on a flat miner overhead. Now it uses
the full model: miner+hauler overhead amortized over the creep's TTL (a static
miner dies at the source after `CREEP_LIFETIME − walk`), plus the spawn
build-time the fleet consumes, priced in energy. A source is mined when
`effectiveNet = harvest − upkeep − partPenalty > 0`, and ranked by effective
efficiency so the spawn staffs the most build-time-efficient sources first. The
distance cutoff (~75 tiles at the current calibration) is no longer hard-coded —
a far source falls out because its hauler fleet costs more spawn build-time than
it's worth. The `efficiency decreasing with distance` test now also asserts a far
source (d=120) falls out.

**Reserver economics corrected.** CLAIM creeps live only 600 ticks (confirmed in
the engine constants), and reservation accumulates/decays so a reserver runs at
~50% duty (build up, tick down, top up) — halving the amortized cost on top of the
per-room amortization (two sources share one reserver). Net toll ~0.8–1.2 e/tick
per room; reserving wins to ~50 tiles (one source) / ~75 (two). Tool +
`ECONOMIC_FRAMEWORK.md` updated.

408 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_