### PR TITLE
Make the spawn-time wall dynamic (contention-based, not a fixed price)

### DIFF
--- a/src/flow/FlowSolver.ts
+++ b/src/flow/FlowSolver.ts
@@ -33,7 +33,15 @@ import {
   calculateCarryParts,
   calculateHaulerCostPerTick
 } from "./FlowTypes";
-import { SPAWN_PART_ENERGY_VALUE } from "../corps/economics";
+import { SPAWN_PARTS_PER_TICK } from "../corps/economics";
+
+/**
+ * Fraction of a spawn's build-rate that mining + hauling may claim. The spawn
+ * also builds upgraders, builders, reservers, so miners/haulers get only part of
+ * its 1/3 parts-per-tick. Tunable; it sets how hard the spawn-time budget bites
+ * before far sources start to fall out.
+ */
+const MINING_BUDGET_FRACTION = 0.6;
 import { VariantConstraints, generateEdgeVariants, selectBestVariant } from "../framework/EdgeVariant";
 
 // =============================================================================
@@ -191,58 +199,84 @@ export class FlowSolver {
     edgeMap: Map<string, FlowEdge>,
     _constraints: FlowConstraints
   ): MinerAssignment[] {
-    const assignments: MinerAssignment[] = [];
+    // Phase 1 - cost every source from its nearest spawn. A source is a CANDIDATE
+    // whenever it nets positive ENERGY (its real profit), no matter how far: we
+    // never skip a profitable source just for distance. We also record the spawn
+    // BUILD-TIME its miner+hauler fleet consumes (parts/tick over the TTL: a static
+    // miner walks out and then dies at the source, so it amortizes over
+    // CREEP_LIFETIME minus the walk). That build-time is what Phase 2 budgets.
+    interface Candidate {
+      spawnId: string;
+      netEnergy: number;
+      spawnPartsPerTick: number;
+      assignment: MinerAssignment;
+    }
+    const candidates: Candidate[] = [];
 
     for (const source of sources) {
-      // Find nearest spawn
       const nearestSpawn = this.findNearestSpawn(source.id, spawnSinks, edgeMap);
       if (!nearestSpawn) continue;
 
       const spawnDistance = nearestSpawn.distance;
-
-      // Profitability in EFFECTIVE energy: gross harvest, minus the miner and
-      // hauler upkeep, minus the spawn BUILD-TIME those bodies consume priced in
-      // energy. Both overheads are amortized over the creep's TTL: a static miner
-      // walks `spawnDistance` tiles out and then dies at the source, so it lives
-      // (and amortizes) over CREEP_LIFETIME minus the walk - the farther the
-      // source, the more often it must be rebuilt. The spawn-part penalty is what
-      // makes a far source FALL OUT: its hauler fleet can stay net-energy-positive
-      // yet cost more spawn build-time than it is worth, so effectiveNet goes
-      // negative - no hard distance/efficiency threshold required.
       const harvestRate = source.capacity;
       const life = Math.max(1, CREEP_LIFETIME - spawnDistance);
       const minerOverhead = MINER_COST / life;
       const carryParts = calculateCarryParts(harvestRate, spawnDistance);
       const haulerOverhead = (carryParts * (BODY_COSTS.CARRY + BODY_COSTS.MOVE)) / life;
-      const totalParts = MINER_PARTS + 2 * carryParts; // miner 8 + hauler CARRY+MOVE
-      const partPenalty = (totalParts / life) * SPAWN_PART_ENERGY_VALUE;
-
       const netEnergy = harvestRate - minerOverhead - haulerOverhead;
-      const effectiveNet = netEnergy - partPenalty;
-      // Rank by effective profit per gross energy, so when the spawn is the
-      // bottleneck the nearest (most build-time-efficient) sources are staffed first.
-      const efficiency = (effectiveNet / harvestRate) * 100;
 
-      // Mine only when the source is worth more than the spawn build-time it eats.
-      if (effectiveNet <= 0) {
+      if (netEnergy <= 0) {
         console.log(
-          `[FlowSolver] Skipping source ${source.id.slice(-8)} (build-time not worth it): ` +
-            `harvest=${harvestRate.toFixed(1)}, net=${netEnergy.toFixed(2)}, ` +
-            `partPenalty=${partPenalty.toFixed(2)}, effNet=${effectiveNet.toFixed(2)}, distance=${spawnDistance}`
+          `[FlowSolver] Skipping source ${source.id.slice(-8)} (net-energy-negative): ` +
+            `net=${netEnergy.toFixed(2)}, distance=${spawnDistance}`
         );
         continue;
       }
 
-      assignments.push({
-        sourceId: source.id,
-        nodeId: source.nodeId,
+      const spawnPartsPerTick = (MINER_PARTS + 2 * carryParts) / life; // miner 8 + hauler CARRY+MOVE
+      candidates.push({
         spawnId: nearestSpawn.id,
-        spawnDistance,
-        harvestRate: source.capacity,
-        spawnCostPerTick: minerOverhead,
-        maxMiners: source.maxMiners,
-        efficiency
+        netEnergy,
+        spawnPartsPerTick,
+        assignment: {
+          sourceId: source.id,
+          nodeId: source.nodeId,
+          spawnId: nearestSpawn.id,
+          spawnDistance,
+          harvestRate,
+          spawnCostPerTick: minerOverhead,
+          maxMiners: source.maxMiners,
+          efficiency: (netEnergy / harvestRate) * 100
+        }
       });
+    }
+
+    // Phase 2 - the DYNAMIC spawn-time wall. Each spawn builds one part every 3
+    // ticks; mining+hauling may claim only a fraction of that (consumers need the
+    // rest). Per spawn, keep candidates by descending net energy PER build-part,
+    // spending the budget; the rest fall out. So a far source is dropped ONLY when
+    // its spawn is actually the bottleneck - when there is spare build-time, every
+    // profitable source is mined no matter how far. This is the spawn-time wall as
+    // CONTENTION, not a fixed price: an idle spawn reaches far, a saturated one
+    // pulls in, and the cutoff distance emerges from the sources actually present.
+    const budgetPerSpawn = SPAWN_PARTS_PER_TICK * MINING_BUDGET_FRACTION;
+    candidates.sort((a, b) => b.netEnergy / b.spawnPartsPerTick - a.netEnergy / a.spawnPartsPerTick);
+
+    const usedBySpawn = new Map<string, number>();
+    const assignments: MinerAssignment[] = [];
+    for (const c of candidates) {
+      const spent = usedBySpawn.get(c.spawnId) ?? 0;
+      // Always staff a spawn's first (best) source even if it alone exceeds the
+      // mining budget - a spawn with one far source should still mine it.
+      if (spent > 0 && spent + c.spawnPartsPerTick > budgetPerSpawn) {
+        console.log(
+          `[FlowSolver] Source ${c.assignment.sourceId.slice(-8)} falls out: ` +
+            `spawn build-time budget spent (distance=${c.assignment.spawnDistance})`
+        );
+        continue;
+      }
+      usedBySpawn.set(c.spawnId, spent + c.spawnPartsPerTick);
+      assignments.push(c.assignment);
     }
 
     return assignments;

--- a/test/unit/flow/FlowSolver.test.ts
+++ b/test/unit/flow/FlowSolver.test.ts
@@ -592,21 +592,40 @@ describe("Economy Scenarios (from minimal-economy)", () => {
       expect(sol30.efficiency).to.be.greaterThan(sol100.efficiency);
     });
 
-    it("should show efficiency decreasing with distance, then the source falling out", () => {
-      // Within the profitable range, farther = lower effective efficiency.
+    it("should show efficiency decreasing with distance", () => {
+      // A single source has no spawn contention, so any net-energy-positive source
+      // is mined no matter how far - but farther = lower efficiency.
+      const distances = [10, 20, 30, 50, 75, 100];
       let prevEfficiency = 100;
-      for (const d of [10, 20, 30, 50]) {
+      for (const d of distances) {
         const solution = solveIteratively(createScenario(d));
-        expect(solution.miners, `d=${d} should still be mined`).to.have.length(1);
+        expect(solution.miners, `d=${d} should still be mined (no contention)`).to.have.length(1);
         expect(solution.efficiency).to.be.lessThan(prevEfficiency);
         prevEfficiency = solution.efficiency;
       }
-      // Past the build-time break-even (~75 tiles at the current SPAWN_PART_ENERGY_VALUE
-      // calibration) the source FALLS OUT: its hauler fleet costs more spawn
-      // build-time than the source is worth, so effectiveNet goes negative and no
-      // miner is assigned - no hard distance/efficiency threshold, it falls out of
-      // the effectiveNet gate.
-      expect(solveIteratively(createScenario(120)).miners, "a far source falls out").to.have.length(0);
+    });
+
+    it("drops the least build-efficient source only when the spawn is the bottleneck", () => {
+      // Three net-energy-positive but far (d=150) sources all funnel to ONE spawn.
+      // Each is profitable, so with spare build-time all three would be mined - but
+      // their combined hauler fleets exceed the spawn's mining build-time budget, so
+      // the least-efficient one FALLS OUT. No hard distance limit: it is dropped by
+      // contention for spawn time, and only because they share one spawn.
+      const source = (id: string, y: number): FlowSource =>
+        createFlowSource(id, `n-${id}`, { x: 150, y, roomName: "E1N1" });
+      const spawn = createFlowSink("spawn", "sp", "nsp", { x: 0, y: 0, roomName: "E1N1" }, 2, 50);
+      const sources = [source("a", 0), source("b", 8), source("c", -8)];
+      const edges: FlowEdge[] = sources.map(s => {
+        const d = Math.max(Math.abs(s.position.x), Math.abs(s.position.y - 0));
+        return {
+          id: createEdgeId(s.id, spawn.id), fromId: s.id, toId: spawn.id,
+          distance: d, roundTrip: calculateRoundTrip(d),
+          carryParts: 0, flowRate: 0, spawnCostPerTick: 0, hasRoads: false
+        };
+      });
+      const solution = solveIteratively({ sources, sinks: [spawn], edges, constraints: DEFAULT_CONSTRAINTS });
+      expect(solution.miners.length, "one far source falls out of the spawn-time budget").to.be.lessThan(3);
+      expect(solution.miners.length, "but the spawn still mines what it can afford").to.be.greaterThan(0);
     });
   });
 


### PR DESCRIPTION
Replaces the static `effectiveNet` distance gate with a contention-based budget,
so a far source falls out only when its spawn is actually the bottleneck.

`FlowSolver.assignMiners` is now two-phase:
1. **Gate on net energy > 0** — never skip a profitable source for distance alone;
   record each source's spawn build-time demand (parts/tick over the TTL).
2. **Per-spawn build-time budget** — keep sources by descending net-energy-per-
   build-part, spending `SPAWN_PARTS_PER_TICK × MINING_BUDGET_FRACTION`; the rest
   fall out.

So an idle spawn reaches as far as energy allows, a saturated one pulls in, and
the cutoff distance emerges from the sources present — the spawn-time wall as
contention, not a fixed price. Fixes the static-price idling risk (a profitable
far source no longer skipped when there's spare build-time).

Validation:
- 409 unit tests pass; new tests prove both halves (a lone source mines at any
  profitable distance; three far sources sharing one spawn drop the least
  build-efficient one to the budget).
- Cold-start integration run ramps cleanly to cp 2403 @ t=1500, both sources mined
  + hauled — tracks the pre-change trajectory (home sources are under budget, so
  the core economy is untouched).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_