### PR TITLE
Capture economy testing learnings + expand spawn-part/dynamic-budget tests

### DIFF
--- a/docs/TESTING_THE_ECONOMY.md
+++ b/docs/TESTING_THE_ECONOMY.md
@@ -1,0 +1,102 @@
+# Testing & Tuning the Economy
+
+How we test the flow economy, how we measure whether a change actually helps, and
+the hard-won learnings behind the current model. Pair this with
+`ECONOMIC_FRAMEWORK.md` (the model itself).
+
+## The test toolkit
+
+The economy is an emergent result of many pieces talking to each other, so we test
+it at three altitudes — each cheap, each pinning a different seam.
+
+### 1. Fleet harnesses (unit, ~10ms) — *what does the pipeline build?*
+
+`test/unit/harness/` drives the REAL spawn pipeline (corp `getSpawnDemand` →
+`collectDemands` → `scheduleSpawn` → `SpawningCorp.executeSpawn`) and reports the
+fleet it produces. No re-implementation: whatever they print is what the live
+colony builds for the same inputs.
+
+- `spawnHarness.ts` → `simulateMinerFleet` — miner WORK sizing / cold-start splits.
+- `haulerHarness.ts` → `simulateHaulerFleet` — hauler CARRY sizing, even-splits, ratios.
+- `upgraderHarness.ts` → `simulateUpgraderFleet` — upgrader count/size, the #59 gate,
+  the #62 build rebalance.
+
+The fake spawn returns a room (`find(FIND_MY_CREEPS)`, `memory`) so room-aware corp
+logic (the upgrader's delivery-loop gate, the hauler's `yieldsToBuild`) runs for
+real — the bug we found earlier was tests passing for the *wrong* reason because
+`Game.getObjectById` returned null and that logic was silently skipped.
+
+### 2. Decision moments (unit, ~10ms) — *what spawns NEXT?*
+
+`test/unit/spawn/nextSpawn.test.ts` + `harness/spawnDecision.ts` freeze single
+economic moments and assert the one creep the director would spawn next (miner
+before upgrader, hold-for-blocking, fund-one-corp-fully, the supply-before-demand
+gate, …). Bugs hide in the *seams* between demand generation and scheduling, which
+a pure-scheduler test (synthetic demands) structurally can't reach.
+
+### 3. Integration probes (server, minutes) — *does it work end to end?*
+
+`test/integration/` runs the compiled bot on the real engine: `flow-handoff`
+(bootstrap→flow), `scenario-economy` (every source mined+hauled across geometries),
+`runt-economy` (runts get upsized). **Always use non-degenerate terrain** — an
+all-plain room produces zero nodes (degenerate peak detection) and the flow
+economy can't plan; use the walled two-chamber layout.
+
+### Two practices that keep these honest
+
+- **Mutation verification.** A guard is only real if it bites. After writing a
+  regression test, reintroduce the bug and confirm *exactly that* test fails (e.g.
+  removing the `colonyHasMiner` fix, or the #59 gate, fails only its test).
+- **Pin current behavior, even when imperfect.** Freeze what the code does today so
+  a later fix shows up as a reviewable diff. The hauler runt-tail was pinned as
+  `[3,1]`; when #63 even-split it, the test *updated* to `[2,2]` — the diff *is* the
+  improvement. (The miner 2×2 over-split is still pinned as a known wart.)
+
+## Measuring "is it better?" — the A/B harness
+
+`scripts/ab-cold-start.ts` (`npm run sim:ab`) stands up the same cold-start colony
+on the real engine (no free-economy mod, so growth is real) and reports cumulative
+control points. The bot under test is whatever `dist/main.js` is, so the *same*
+harness measures any commit: build at A → run; build at B → run; compare. The delta
+is the bot's behavior change alone.
+
+`scripts/effective-energy.ts` (`npm run sim:energy`) is the static model: net
+e/tick after TTL-adjusted miner+hauler overhead, total body parts, spawn-time load,
+the spawn-part energy penalty, and the reserve-or-not crossover.
+
+### The headline measurement
+
+Pre-batch baseline (`4c42e87`) vs the full current stack, same scenario, 3500 ticks:
+
+| tick | OLD | NEW |
+|------|-----|-----|
+| 1500 | 3365 | 2237 |
+| 2250 | 6597 | 6884 |
+| 3500 | **10185** | **19164** |
+
+**~2× the long-run output, and diverging** (final rate 9.8 vs 2.95 cp/tick).
+
+## Key learnings
+
+**Economic**
+- The **hauler dominates** remote-mining cost, not the miner; cost grows ~linearly
+  with distance while yield is flat.
+- A spawn has **two budgets**: energy *and* build-time (1 part / 3 ticks = 500 parts
+  per 1500-tick life). Build-time is often the *tighter* wall.
+- **Travel TTL**: a static miner walks out and dies at the source, mining only
+  `1500 − d` ticks — amortize its cost (and a reserver's) over the shortened life.
+- **Reserver** is a per-room cost: CLAIM creeps live only 600 ticks, but reservation
+  accumulates so a reserver runs at ~50% duty, and two sources share one reserver —
+  so the toll is much smaller than it first looks.
+- The "too far to mine" distance should **fall out of contention** (sources
+  competing for a spawn's build-time budget), not a hard limit. An idle spawn
+  reaches far; a saturated one pulls in.
+
+**Behavioral / measurement**
+- **Invest vs consume.** A heavier, better-balanced production base costs early-game
+  speed (slower to first upgrade) but roughly doubles long-run output. For a 24/7
+  colony, the one-time early tax is noise.
+- **Stalls hide in delivery.** The old colony *plateaued* after ~tick 2000 because a
+  hauling route collapsed (`hauling 1.33/10`) and mined energy stopped reaching the
+  controller. Watch per-route hauling actuals, not just mining.
+- The flow economy needs **non-degenerate terrain** to plan at all.

--- a/test/unit/corps/spawnPartsEconomics.test.ts
+++ b/test/unit/corps/spawnPartsEconomics.test.ts
@@ -2,9 +2,10 @@ import { expect } from "chai";
 import "../../../src/types/Memory";
 import { HarvestCorp } from "../../../src/corps/HarvestCorp";
 import { CarryCorp } from "../../../src/corps/CarryCorp";
+import { UpgradingCorp } from "../../../src/corps/UpgradingCorp";
 import { ChainScene, effectiveNet, SPAWN_PART_ENERGY_VALUE } from "../../../src/corps/economics";
 import { chebyshevDistance } from "../../../src/types/Position";
-import { HaulerAssignment } from "../../../src/flow/FlowTypes";
+import { HaulerAssignment, SinkAllocation } from "../../../src/flow/FlowTypes";
 
 const SPAWN = { x: 0, y: 0, roomName: "W1N1" };
 function scene(): ChainScene {
@@ -32,6 +33,32 @@ describe("spawn-part economics", () => {
     expect(e.spawnPartsPerTick).to.be.greaterThan(0);
     // A 5W3M miner (8 parts) at d=5 lives ~1500-15 ticks: 8/~1485 ~ 0.0054.
     expect(e.spawnPartsPerTick).to.be.closeTo(0.0054, 0.002);
+  });
+
+  it("a farther MINER draws more spawn parts/tick (shorter TTL -> rebuilt more often)", () => {
+    // Same 8-part body, but a static miner at d=200 lives only ~1300 ticks vs ~1495
+    // at d=5, so it consumes the spawn's build-rate more often. This is the TTL
+    // term the flat model used to miss.
+    const near = new HarvestCorp("v", "v", "src@5").project(scene()).spawnPartsPerTick;
+    const far = new HarvestCorp("v", "v", "src@200").project(scene()).spawnPartsPerTick;
+    expect(far).to.be.greaterThan(near);
+  });
+
+  it("an upgrader reports a spawn-part cost sized to its allocation", () => {
+    const corp = new UpgradingCorp("v", "v");
+    corp.setSinkAllocation({
+      sinkId: "c", sinkType: "controller", allocated: 6, demand: 6, unmet: 0, priority: 65
+    } as SinkAllocation);
+    expect(corp.project(scene()).spawnPartsPerTick).to.be.greaterThan(0);
+  });
+
+  it("a far source's build-time is dominated by the HAULER, not the miner", () => {
+    const d = 200;
+    const miner = new HarvestCorp("v", "v", `src@${d}`).project(scene());
+    const hauler = new CarryCorp("v", "v");
+    hauler.setHaulerAssignments([haulRoute(`src@${d}`, d)]);
+    const haul = hauler.project(scene());
+    expect(haul.spawnPartsPerTick).to.be.greaterThan(miner.spawnPartsPerTick);
   });
 
   it("a farther hauling route draws MORE spawn parts (the part-hungry term)", () => {

--- a/test/unit/flow/FlowSolver.test.ts
+++ b/test/unit/flow/FlowSolver.test.ts
@@ -605,6 +605,14 @@ describe("Economy Scenarios (from minimal-economy)", () => {
       }
     });
 
+    it("mines a lone far source a static price would have skipped (idle spawn reaches far)", () => {
+      // At d=120 the earlier STATIC effectiveNet penalty pushed the score negative
+      // (~75-tile cutoff) and skipped this source even with the spawn idle. With the
+      // dynamic budget it is the only claimant on its spawn, so spare build-time
+      // mines it. Guards against re-introducing a hard/static distance cutoff.
+      expect(solveIteratively(createScenario(120)).miners, "spare build-time reaches far").to.have.length(1);
+    });
+
     it("drops the least build-efficient source only when the spawn is the bottleneck", () => {
       // Three net-energy-positive but far (d=150) sources all funnel to ONE spawn.
       // Each is profitable, so with spare build-time all three would be mined - but


### PR DESCRIPTION
Captures the session's learnings and adds tests on the newest logic.

**Docs — `TESTING_THE_ECONOMY.md`:** the test toolkit at three altitudes (fleet
harnesses → what the pipeline builds; decision moments → what spawns next;
integration probes → end-to-end), the two practices that keep them honest
(mutation verification; pin current behavior so a fix is a reviewable diff), the
A/B measurement methodology + the ~2× headline result, and the key economic /
behavioral learnings (hauler dominates remote cost; spawn build-time is a second,
tighter budget; travel TTL; reserver per-room + duty-cycle economics; the cutoff
falls out of contention; invest-vs-consume; stalls hide in delivery; the flow
economy needs non-degenerate terrain).

**Tests:** per-corp spawn-part cost — a farther miner draws more parts/tick
(shorter TTL), the upgrader reports a cost, a far source's build-time is
hauler-dominated; plus the dynamic budget's headline — a lone far source a static
price would have skipped is mined when its spawn has spare build-time (guards the
idling-risk fix).

413 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_