### PR TITLE
Income-corp-first spawn ranking + real PathFinder distance for the profitability gate

### DIFF
--- a/scripts/repro-remote.ts
+++ b/scripts/repro-remote.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env ts-node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * repro-remote - home room with two LOCAL sources next to an unowned neighbor
+ * that also has sources. Question: does the bot mine its local sources, or does
+ * it spend spawn capacity reaching into the neighbor ("remote mines") while the
+ * local sources sit idle?
+ */
+import { readFileSync, mkdirSync } from "fs";
+import * as path from "path";
+import { loadLayout, padNeighborTerrain, RoomLayout } from "../test/integration/loadLayout";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ScreepsServer } = require("screeps-server-mockup");
+
+const HOME = "W0N0";
+const NEIGHBOR = "W1N0";
+
+/**
+ * A room with a perimeter wall ring (exit gaps in the middle of each side so
+ * creeps can still cross rooms). An all-plain room has a flat distance transform
+ * with no distinct peaks, so the node surveyor finds nothing and the colony loops
+ * on "No nodes in memory" forever; the wall border gives the analysis a gradient
+ * to peak on - the difference between a stuck bootstrap and a real economy.
+ */
+function walledTerrain(): string[] {
+  const rows: string[] = [];
+  for (let y = 0; y < 50; y += 1) {
+    let row = "";
+    for (let x = 0; x < 50; x += 1) {
+      const onBorder = x === 0 || x === 49 || y === 0 || y === 49;
+      const exitGap = (x >= 23 && x <= 26) || (y >= 23 && y <= 26);
+      row += onBorder && !exitGap ? "#" : ".";
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+function homeRoom(): RoomLayout {
+  return {
+    room: HOME,
+    terrain: walledTerrain(),
+    objects: [
+      { type: "controller", x: 25, y: 10 },
+      { type: "source", x: 15, y: 30 },
+      { type: "source", x: 35, y: 30 }
+    ]
+  };
+}
+
+// Unowned neighbor with its own sources (a remote-mine candidate).
+function neighborRoom(): RoomLayout {
+  return {
+    room: NEIGHBOR,
+    terrain: walledTerrain(),
+    objects: [
+      { type: "controller", x: 25, y: 25 },
+      { type: "source", x: 10, y: 20 },
+      { type: "source", x: 40, y: 20 }
+    ]
+  };
+}
+
+async function main(): Promise<void> {
+  const ticks = parseInt(process.argv[2] ?? "500", 10);
+  const port = 26000 + Math.floor(Math.random() * 1000);
+  const serverPath = path.resolve("server", `repro-remote-${port}`);
+  mkdirSync(path.join(serverPath, "logs"), { recursive: true });
+  const server = new ScreepsServer({ port, path: serverPath, logdir: path.join(serverPath, "logs") });
+
+  await server.world.reset();
+  await loadLayout(server.world, homeRoom());
+  await loadLayout(server.world, neighborRoom());
+  // Pad the full radius-3 analysis box (get7x7BoxAroundOwnedRooms) so terrain
+  // analysis can actually produce nodes - otherwise the colony loops forever on
+  // "No nodes in memory" and never mines.
+  await padNeighborTerrain(server.world, [HOME, NEIGHBOR], 3);
+
+  const modules = { main: readFileSync("dist/main.js").toString() };
+  const bot = await server.world.addBot({ username: "player", room: HOME, x: 25, y: 25, modules });
+
+  const interesting = /miner|Skipping|unprofitable|harvest|assignMiner|spawn|Spawn|hauler|error|Error|TypeError|undefined/i;
+  const seen = new Map<string, number>();
+  bot.on("console", (log: string[], results: any) => {
+    for (const line of log ?? []) {
+      if (interesting.test(line)) {
+        const key = line.replace(/\d+/g, "#").slice(0, 80);
+        seen.set(key, (seen.get(key) ?? 0) + 1);
+      }
+    }
+    for (const e of results?.errors ?? []) seen.set(`ERR ${String(e).slice(0, 80)}`, (seen.get(`ERR`) ?? 0) + 1);
+  });
+
+  await server.start();
+  for (let t = 1; t <= ticks; t += 1) {
+    await server.tick();
+    if (t % 50 === 0) process.stdout.write(".");
+  }
+  process.stdout.write("\n");
+
+  // Dump creep roster (role + position) for the home room.
+  {
+    const objs = await server.world.roomObjects(HOME);
+    const creeps = objs.filter((o: any) => o.type === "creep");
+    const sources = objs.filter((o: any) => o.type === "source");
+    console.log(`\n[home creeps] ${creeps.length}:`);
+    for (const c of creeps) {
+      const work = (c.body ?? []).filter((p: any) => p.type === "work").length;
+      const carry = (c.body ?? []).filter((p: any) => p.type === "carry").length;
+      console.log(`  (${c.x},${c.y}) work=${work} carry=${carry} fatigue=${c.fatigue ?? 0}`);
+    }
+    console.log(`[home sources] ${sources.map((s: any) => `(${s.x},${s.y})`).join(" ")}`);
+  }
+
+  const report = async (roomName: string) => {
+    const objs = await server.world.roomObjects(roomName);
+    const creeps = objs.filter((o: any) => o.type === "creep");
+    const sources = objs.filter((o: any) => o.type === "source");
+    const minedSources = sources.filter((s: any) =>
+      creeps.some((c: any) => Math.max(Math.abs(c.x - s.x), Math.abs(c.y - s.y)) <= 1 && (c.body ?? []).some((p: any) => p.type === "work"))
+    );
+    console.log(`  ${roomName}: ${creeps.length} creeps, ${minedSources.length}/${sources.length} sources have a miner adjacent`);
+    return { creeps: creeps.length, sources: sources.length, mined: minedSources.length };
+  };
+
+  console.log(`\n=== console (deduped, top 25 by frequency) ===`);
+  for (const [k, n] of [...seen.entries()].sort((a, b) => b[1] - a[1]).slice(0, 25)) {
+    console.log(`  x${n}  ${k}`);
+  }
+
+  console.log(`\n=== After ${ticks} ticks ===`);
+  const home = await report(HOME);
+  const nb = await report(NEIGHBOR);
+  console.log(
+    `\nLocal sources mined: ${home.mined}/${home.sources}.  Creeps in neighbor (remote): ${nb.creeps}.`
+  );
+  console.log(
+    home.mined < home.sources && nb.creeps > 0
+      ? "  => BUG REPRODUCED: local sources idle while creeps work the neighbor."
+      : home.mined === home.sources
+        ? "  => local sources are mined (no obvious local-starvation)."
+        : "  => local sources NOT fully mined, but no neighbor creeps either."
+  );
+  await server.stop();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("repro-remote failed:", err);
+    process.exit(1);
+  });

--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -9,7 +9,7 @@
 import { Corp, SerializedCorp } from "./Corp";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { controllerDeliverySpot, sourcePickupSpot, workSpot } from "./nodeEnergy";
-import { driveRecycle, pickRuntToRecycle, spawnIdleAndMaxed } from "./recycle";
+import { driveRecycle, pickRuntToRecycle } from "./recycle";
 import { CREEP_LIFETIME } from "../planning/EconomicConstants";
 import { HaulerAssignment } from "../flow/FlowTypes";
 import { buildHaulerBody } from "../spawn/BodyBuilder";
@@ -197,26 +197,33 @@ export class CarryCorp extends Corp {
   }
 
   /**
-   * Replace an undersized hauler with a full-size one, but only at zero cost:
-   * when the room is maxed out (every store full) and the spawn would otherwise
-   * idle. Spawning during bootstrap floors haulers at a modest size to keep the
-   * spawn affordable; that leaves the fleet short of the planned CARRY once it
-   * hits its target COUNT. Here - and only here, where the energy and the spawn
-   * tick would otherwise go to waste - we retire the smallest runt so its corp
-   * respawns it at full size, lifting realized throughput toward the plan. In a
-   * constrained room (the common case) the gate never opens, which is correct:
-   * we never disrupt deliveries to chase a bigger body we cannot afford.
+   * Actively heal a runt fleet by retiring the smallest hauler so getSpawnDemand
+   * rebuilds it bigger - but ONLY once conditions are ready: the spawn must already
+   * hold enough energy to rebuild a body strictly bigger than that runt RIGHT NOW.
+   * That gate is the whole trick. We do NOT wait for the runt to die of old age
+   * (1500 ticks of capped throughput), and we do NOT hold the spawn for a full body
+   * (that stalls - this colony's spawn is a flow-through conduit that rarely fills).
+   * We simply pounce whenever the spawn momentarily carries a full-ish load, swap a
+   * runt out for the bigger body it can afford on that tick, and converge the fleet
+   * upward one rung at a time. When the spawn is starved the gate stays shut, so we
+   * never disrupt deliveries to chase a body we cannot afford - no thrash.
    */
   private flagRuntForRecycling(creeps: Creep[], room: Room, spawn: StructureSpawn): void {
-    if (!spawnIdleAndMaxed(room, spawn)) return;
+    if (spawn.spawning) return; // a body is already mid-build; don't pile on
     if (creeps.some(c => c.memory.recycling)) return; // one at a time
+    if (creeps.length < 2) return; // never strand the source
 
-    const idx = pickRuntToRecycle(
-      creeps.map(c => c.getActiveBodyparts(CARRY)),
-      this.haulCarryNeeded(),
-      this.maxCarryPerHauler(room)
-    );
-    if (idx !== null) creeps[idx].memory.recycling = true;
+    const carry = creeps.map(c => c.getActiveBodyparts(CARRY));
+    const minCarry = Math.min(...carry);
+    const maxCarry = this.maxCarryPerHauler(room);
+    if (minCarry >= maxCarry) return; // nothing under-built to heal
+
+    // Conditions ready: the spawn can immediately build a hauler with at least one
+    // more CARRY than the smallest runt (1 CARRY + 1 MOVE = 100 energy per step).
+    const PART_PAIR_COST = 100;
+    if (room.energyAvailable < (minCarry + 1) * PART_PAIR_COST) return;
+
+    creeps[carry.indexOf(minCarry)].memory.recycling = true;
   }
 
   /**
@@ -667,15 +674,17 @@ export class CarryCorp extends Corp {
     // moves only 50 energy a round trip yet holds a fleet slot for its whole life;
     // the even split makes it 2 + 2). Each index gets the floor share and the first
     // `remainder` get one more - deterministic from spawn order. Once PAST the
-    // planned count we are topping up a runt shortfall, so size to just the missing
-    // CARRY rather than another full share.
+    // planned count we are healing a runt fleet (bootstrap under-built the bodies),
+    // so target a FULL body: the scheduler scales it down to whatever energy is on
+    // hand, but on a flush tick it lands a big hauler that flagRuntForRecycling can
+    // then swap a runt for - converging toward fewer, full-size bodies.
     let desiredCarry: number;
     if (current < targetHaulers) {
       const base = Math.floor(carryNeeded / targetHaulers);
       const remainder = carryNeeded % targetHaulers;
       desiredCarry = base + (current < remainder ? 1 : 0);
     } else {
-      desiredCarry = carryNeeded - fieldedCarry;
+      desiredCarry = maxCarryPerHauler;
     }
     desiredCarry = Math.max(1, Math.min(maxCarryPerHauler, desiredCarry));
     const desiredCost = desiredCarry * PART_PAIR_COST;

--- a/src/corps/HarvestCorp.ts
+++ b/src/corps/HarvestCorp.ts
@@ -367,9 +367,8 @@ export class HarvestCorp extends Corp {
         // must outrank consumption and get staffed, in expected-value order. The
         // old failure - a fresh source's miner outranking the haulers that complete
         // an already-started source, so the spawn fields miner after miner while
-        // energy strands unhauled - is prevented by COMPLETION_BOOST > BLOCKING_BOOST
-        // (a started unit's remaining staffing outranks opening a fresh one), not by
-        // withholding the block here.
+        // energy strands unhauled - is prevented by spawnPriority's tiers (a started
+        // income corp outranks opening a fresh one), not by withholding the block here.
         blocking: current === 0,
         producesIncome: true,
         desiredCost: desired.cost,

--- a/src/corps/HarvestCorp.ts
+++ b/src/corps/HarvestCorp.ts
@@ -361,13 +361,16 @@ export class HarvestCorp extends Corp {
         buyerCorpId: this.id,
         role: "miner",
         value: 100 + (assignment.efficiency ?? 0) * 0.5,
-        // Blocking only for the colony's FIRST miner (no income at all). Every
-        // additional source's miner is expansion, NOT blocking - otherwise each new
-        // source's miner (blocking) outranks the haulers that complete an already-
-        // mined source, and the spawn fields miner after miner while their energy
-        // strands unhauled. Non-blocking here lets the blocking haulers finish one
-        // mining operation before the spawn opens the next.
-        blocking: current === 0 && !this.colonyHasMiner(),
+        // A source's first miner is blocking, per SOURCE - an income unit must be
+        // staffed before any lower-value work (construction, upgrading). This is
+        // not gated on the whole colony having a miner: every source's first miner
+        // must outrank consumption and get staffed, in expected-value order. The
+        // old failure - a fresh source's miner outranking the haulers that complete
+        // an already-started source, so the spawn fields miner after miner while
+        // energy strands unhauled - is prevented by COMPLETION_BOOST > BLOCKING_BOOST
+        // (a started unit's remaining staffing outranks opening a fresh one), not by
+        // withholding the block here.
+        blocking: current === 0,
         producesIncome: true,
         desiredCost: desired.cost,
         minCost: min.cost,

--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -26,15 +26,10 @@ import { CorpRegistry } from "./CorpRunner";
  */
 const FLOW_MIN_RCL = 2;
 
-/** Persistent aging timestamps, keyed by `${buyerCorpId}:${role}`. */
-const demandSince: Map<string, number> = new Map();
-
 /**
  * Run the demand-driven spawn scheduler for all owned spawns.
  */
 export function runSpawnScheduling(registry: CorpRegistry): void {
-  const seenKeys = new Set<string>();
-
   for (const roomName in Game.rooms) {
     const room = Game.rooms[roomName];
     if (!room.controller?.my) continue;
@@ -59,14 +54,6 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
       const demands = collectDemands(registry, spawn.id, demandCtx);
       if (demands.length === 0) continue;
 
-      // Stamp aging timestamps so a repeatedly-losing demand eventually wins.
-      for (const demand of demands) {
-        const key = `${demand.buyerCorpId}:${demand.role}`;
-        seenKeys.add(key);
-        if (!demandSince.has(key)) demandSince.set(key, Game.time);
-        demand.since = demandSince.get(key)!;
-      }
-
       const ctx: ScheduleContext = {
         energyAvailable: room.energyAvailable,
         energyCapacity: room.energyCapacityAvailable,
@@ -78,7 +65,7 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
       if (!result) continue;
 
       const d = result.demand;
-      const ok = spawningCorp.executeSpawn(
+      spawningCorp.executeSpawn(
         d.role,
         d.buyerCorpId,
         result.energyBudget,
@@ -87,18 +74,7 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
         d.haulerRatio,
         d.bodyStrategy
       );
-      if (ok) {
-        // Reset aging for the demand we just fulfilled.
-        demandSince.delete(`${d.buyerCorpId}:${d.role}`);
-        seenKeys.delete(`${d.buyerCorpId}:${d.role}`);
-      }
     }
-  }
-
-  // Drop aging entries for demands that no longer exist, so a demand that
-  // disappears and later returns starts fresh rather than instantly aged.
-  for (const key of Array.from(demandSince.keys())) {
-    if (!seenKeys.has(key)) demandSince.delete(key);
   }
 }
 

--- a/src/flow/EconomyAdapter.ts
+++ b/src/flow/EconomyAdapter.ts
@@ -26,7 +26,7 @@ import { HaulerAssignment, SinkType } from "./FlowTypes";
 import { CorpRegistry } from "../execution/CorpRunner";
 import { CarryCorp } from "../corps/CarryCorp";
 import { FlowGraph } from "./FlowGraph";
-import { estimateWalkingDistance } from "../nodes/NodeNavigator";
+import { pathDistance } from "../nodes/NodeNavigator";
 
 /** Guaranteed controller trickle (energy/tick) so it never downgrades / fully stalls. */
 export const ANTI_DOWNGRADE_RESERVE = 2;
@@ -91,7 +91,7 @@ export function buildPlannerInput(graph: FlowGraph, spawnId: string): PlannerInp
     });
   }
 
-  return { sources, sinks, spawnId, dist: estimateWalkingDistance };
+  return { sources, sinks, spawnId, dist: pathDistance };
 }
 
 /** Plan the economy directly from the live flow graph. */

--- a/src/flow/FlowGraph.ts
+++ b/src/flow/FlowGraph.ts
@@ -24,7 +24,7 @@ import {
   createFlowSource
 } from "./FlowTypes";
 import { Node, getResourcesByType } from "../nodes/Node";
-import { NodeNavigator, estimateWalkingDistance } from "../nodes/NodeNavigator";
+import { NodeNavigator, pathDistance } from "../nodes/NodeNavigator";
 import { countMiningSpots } from "../analysis/SourceAnalysis";
 
 // =============================================================================
@@ -225,9 +225,10 @@ export class FlowGraph {
         // Verify sink has a valid node
         if (!this.nodes.has(sink.nodeId)) continue;
 
-        // Calculate distance using direct position-to-position estimation
-        // This is more accurate than navigator paths which may have incorrect weights
-        const distance = estimateWalkingDistance(source.position, sink.position);
+        // Real (cached) path distance, so walls/swamps between a source and its
+        // sink are reflected in the haul round-trip and the profitability gate.
+        // Falls back to the analytic estimate when PathFinder can't path.
+        const distance = pathDistance(source.position, sink.position);
 
         // Create edge
         const edgeId = createEdgeId(source.id, sink.id);

--- a/src/nodes/NodeNavigator.ts
+++ b/src/nodes/NodeNavigator.ts
@@ -103,6 +103,71 @@ export function estimateWalkingDistance(from: Position, to: Position): number {
 }
 
 /**
+ * Cache of real path distances keyed by the two (static) endpoint positions.
+ * Sources, spawns and controllers never move, so a path computed once is valid
+ * for the life of the process; in real Screeps this resets on a global reset,
+ * which simply recomputes. Keeps PathFinder (expensive) off the per-tick path.
+ */
+const pathDistanceCache = new Map<string, number>();
+
+function positionKey(p: Position): string {
+  return `${p.roomName}:${p.x},${p.y}`;
+}
+
+/** Clear the path-distance cache. Test seam; not used in the live game. */
+export function clearPathDistanceCache(): void {
+  pathDistanceCache.clear();
+}
+
+/**
+ * Real walking distance (in tile-steps) between two positions via PathFinder,
+ * cached by the endpoints. Falls back to {@link estimateWalkingDistance} when
+ * PathFinder is unavailable or cannot complete a path - e.g. unit-test mocks, or
+ * a remote whose terrain isn't loaded - so callers always get a finite number.
+ *
+ * This is what the remote-mining profitability gate needs. The analytic estimate
+ * ignores walls and swamps, so a source a few tiles away as the crow flies but
+ * walled off behind a long detour looks far cheaper to haul from than it is -
+ * the colony then opens remotes it can never haul home profitably (the "lots of
+ * miners out, little energy back" failure). Real path cost reflects the detour,
+ * so the planner rejects those remotes.
+ */
+export function pathDistance(from: Position, to: Position): number {
+  const key = `${positionKey(from)}->${positionKey(to)}`;
+  const cached = pathDistanceCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const estimate = estimateWalkingDistance(from, to);
+  let result = estimate;
+
+  const pf = (globalThis as { PathFinder?: typeof PathFinder }).PathFinder;
+  const RP = (globalThis as { RoomPosition?: typeof RoomPosition }).RoomPosition;
+  if (pf && typeof pf.search === "function" && typeof RP === "function") {
+    try {
+      const origin = new RP(from.x, from.y, from.roomName);
+      const goal = { pos: new RP(to.x, to.y, to.roomName), range: 1 };
+      const search = pf.search(origin, goal, {
+        plainCost: 1,
+        swampCost: 5,
+        maxOps: 4000,
+        maxRooms: 16
+      });
+      // A real completed path: trust its step count. The mock (and an
+      // unreachable/unloaded target) returns an empty or incomplete path - keep
+      // the analytic estimate in that case.
+      if (search && !search.incomplete && search.path && search.path.length > 0) {
+        result = search.path.length;
+      }
+    } catch {
+      result = estimate;
+    }
+  }
+
+  pathDistanceCache.set(key, result);
+  return result;
+}
+
+/**
  * Edge data including type and weight.
  */
 export interface EdgeData {

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -42,6 +42,8 @@ export {
   createEdgeKey,
   parseEdgeKey,
   estimateWalkingDistance,
+  pathDistance,
+  clearPathDistanceCache,
   createNodeNavigator,
   buildEconomicEdges,
   addEconomicEdgesToNavigator

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -62,9 +62,9 @@ export interface SpawnDemand {
   /**
    * True when this demand's group is already underway - it has its bootstrap
    * producer in the field (e.g. the source is already being mined) and what
-   * remains is to finish staffing it. Such demands are boosted so the spawn
-   * completes a started income unit before opening a brand-new one. See
-   * {@link COMPLETION_BOOST}.
+   * remains is to finish staffing it. {@link spawnPriority} ranks such demands
+   * above fresh income corps so the spawn completes a started income unit before
+   * opening a brand-new one.
    */
   groupStarted?: boolean;
   /** Ideal body cost given the flow demand. */
@@ -121,42 +121,39 @@ export interface ScheduleResult {
   reason: string;
 }
 
-/** How much a demand's effective value grows per tick spent waiting. */
-export const AGING_VALUE_PER_TICK = 0.5;
-
 /**
- * How much to boost a demand that *completes an already-started income unit*
- * (a source that is already being mined and now needs its haulers, or a second
- * miner). This is the "fund one corp fully before opening the next" strategy:
- * the spawn should finish staffing the source it has already started - getting
- * that energy actually hauled home - before it spends spawn time opening a
- * fresh source whose energy will just strand unhauled. This was the root of the
- * "lots of remote miners going out, little energy coming back" failure: a fresh
- * source's first miner (base value) used to outrank an already-mined source's
- * remaining haulers, so the colony kept opening sources it never finished.
+ * Spawn priority of a single demand - higher spawns first. Strictly TIERED, so
+ * the order is obvious and needs no tuning (this replaces the old additive soup
+ * of blocking + completion + aging boosts that no one could reason about):
  *
- * The boost sits *above* {@link effectiveValue}'s blocking boost (1000): finishing
- * an already-started income unit (getting its energy hauled home) outranks opening
- * a fresh source whose first miner is itself blocking. This is the ordering that
- * makes income corps complete one at a time, highest-value first, instead of the
- * spawn fielding miner after miner across many half-staffed sources (the "haulers
- * parked at minerless sources in every room" failure). At cold start no unit is
- * started yet, so the colony's very first miner (blocking, no completion-boosted
- * rival exists) still comes first.
+ *   1. income corp, already started   - finish what's underway (its haulers /
+ *                                        a second miner) before anything else
+ *   2. income corp, fresh             - open the next source's first miner
+ *   3. consumption (upgrade/build/...) - spend the leftover, once income is staffed
+ *
+ * Within a tier the higher-VALUE corp/sink wins, so income corps are opened and
+ * completed in expected-value order. Within one corp `blocking` nudges the urgent
+ * demand ahead (a mining source with no hauler stranding its energy; the first
+ * upgrader that keeps the controller alive). That is the entire strategy: rank
+ * income corps by value, staff the top one to completion before the next, consume
+ * only what income leaves - with no boosts to balance and no aging to drift.
+ *
+ * The tier gaps (1e6 >> 1e4 >> 1e3 >> value~50-110) are pure separators, not
+ * tunables: a started corp always outranks a fresh one, income always outranks
+ * consumption, regardless of the raw values involved. At cold start no corp is
+ * started, so the colony's first miner (tier 2) leads.
  */
-export const COMPLETION_BOOST = 2000;
-
-/**
- * Effective value used for ranking: base value, a large boost for blocking
- * demands, a boost for completing an already-started income unit (see
- * {@link COMPLETION_BOOST}), plus anti-starvation aging so a demand that keeps
- * losing eventually wins.
- */
-export function effectiveValue(demand: SpawnDemand, tick: number): number {
-  const BLOCKING_BOOST = 1000;
-  const age = Math.max(0, tick - demand.since);
-  const completing = demand.producesIncome && demand.groupStarted ? COMPLETION_BOOST : 0;
-  return demand.value + (demand.blocking ? BLOCKING_BOOST : 0) + completing + AGING_VALUE_PER_TICK * age;
+export function spawnPriority(demand: SpawnDemand): number {
+  const INCOME_TIER = 1_000_000;
+  const STARTED = 10_000;
+  const URGENT = 1_000; // first hauler (stranded energy) / first upgrader (anti-downgrade)
+  let p = demand.value; // base corp/sink value, ~50-110
+  if (demand.blocking) p += URGENT;
+  if (demand.groupId !== undefined && demand.producesIncome) {
+    p += INCOME_TIER;
+    if (demand.groupStarted) p += STARTED;
+  }
+  return p;
 }
 
 /**
@@ -165,10 +162,9 @@ export function effectiveValue(demand: SpawnDemand, tick: number): number {
  * fill).
  *
  * Decision procedure:
- *  1. Rank demands by {@link effectiveValue} (blocking + completion + aging
- *     aware - so a started income unit's remaining staffing outranks opening a
- *     fresh one; see {@link COMPLETION_BOOST}).
- *  2. Walk from highest value:
+ *  1. Rank demands by {@link spawnPriority} (a started income corp's remaining
+ *     staffing outranks opening a fresh source, which outranks consumption).
+ *  2. Walk from highest priority:
  *     - If we can afford the demand's minimum body, spawn it now, spending up
  *       to its desired cost (capped by available energy) - UNLESS we are holding
  *       the spawn for a higher-ranked blocking demand we cannot yet afford, in
@@ -194,7 +190,7 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
   // raw value and get funded with nothing to pick up.
   const eligible = withMinerPrecedence(demands);
 
-  const ranked = [...eligible].sort((a, b) => effectiveValue(b, ctx.tick) - effectiveValue(a, ctx.tick));
+  const ranked = [...eligible].sort((a, b) => spawnPriority(b) - spawnPriority(a));
 
   // Set once we pass a blocking demand we cannot afford yet but the room can
   // eventually build. From then on we decline to spend the dribble on

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -135,13 +135,16 @@ export const AGING_VALUE_PER_TICK = 0.5;
  * source's first miner (base value) used to outrank an already-mined source's
  * remaining haulers, so the colony kept opening sources it never finished.
  *
- * The boost is sized to sit *above* the base values of the economy
- * (miner/hauler/builder/upgrader are all ~90-110) so completion wins decisively
- * over opening, yet *below* {@link effectiveValue}'s blocking boost (1000) so a
- * genuinely blocking bootstrap demand (the colony's first miner, the first
- * upgrader that keeps the controller alive) still comes first.
+ * The boost sits *above* {@link effectiveValue}'s blocking boost (1000): finishing
+ * an already-started income unit (getting its energy hauled home) outranks opening
+ * a fresh source whose first miner is itself blocking. This is the ordering that
+ * makes income corps complete one at a time, highest-value first, instead of the
+ * spawn fielding miner after miner across many half-staffed sources (the "haulers
+ * parked at minerless sources in every room" failure). At cold start no unit is
+ * started yet, so the colony's very first miner (blocking, no completion-boosted
+ * rival exists) still comes first.
  */
-export const COMPLETION_BOOST = 150;
+export const COMPLETION_BOOST = 2000;
 
 /**
  * Effective value used for ranking: base value, a large boost for blocking
@@ -242,20 +245,17 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
 }
 
 /**
- * Drop hauler demands whose source has NO miner in the field yet - the first
- * miner must be staffed before its haulers (a hauler with no miner has nothing
- * to carry). Gated on `groupStarted` (a miner is already mining), NOT on the
- * mere presence of a miner demand: once the first miner exists, its haulers may
- * proceed even while a bigger/second miner is still wanted - otherwise an
- * under-target miner starves its own haulers forever and the source's energy
- * strands unhauled. Other roles pass through. Pure, so it can be unit tested.
+ * Drop hauler demands whose source has NO miner in the field (`groupStarted` is
+ * false) - a hauler with no miner has nothing to carry, so it must never spawn.
+ * This is the single invariant behind "no hauler without a staffed miner": it
+ * fires on the source's mining state directly, so it catches BOTH a source whose
+ * miner is still being staffed AND an orphan hauler whose source has no miner
+ * demand at all (e.g. a remote source the miner-profitability gate rejected) -
+ * the "green haulers parked at minerless sources in every room" failure. Once a
+ * miner is mining (`groupStarted`), its haulers proceed even while a bigger/second
+ * miner is still wanted. Demands with no groupId (non-source roles) pass through.
+ * Pure, so it can be unit tested.
  */
 export function withMinerPrecedence(demands: SpawnDemand[]): SpawnDemand[] {
-  const sourcesWithoutMiner = new Set(
-    demands.filter(d => d.role === "miner" && !d.groupStarted && d.groupId !== undefined).map(d => d.groupId)
-  );
-  if (sourcesWithoutMiner.size === 0) return demands;
-  return demands.filter(
-    d => !(d.role === "hauler" && d.groupId !== undefined && sourcesWithoutMiner.has(d.groupId))
-  );
+  return demands.filter(d => !(d.role === "hauler" && d.groupId !== undefined && d.groupStarted === false));
 }

--- a/test/integration/loadLayout.ts
+++ b/test/integration/loadLayout.ts
@@ -245,14 +245,14 @@ function formatRoomName(x: number, y: number): string {
  * PathFinder something to read; creeps still have no targets out there, so they
  * never actually leave their room.
  */
-export async function padNeighborTerrain(world: any, rooms: string[]): Promise<void> {
+export async function padNeighborTerrain(world: any, rooms: string[], radius = 1): Promise<void> {
   const real = new Set(rooms);
   const needed = new Set<string>();
   for (const name of rooms) {
     const c = parseRoomName(name);
     if (!c) continue;
-    for (let dx = -1; dx <= 1; dx += 1) {
-      for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -radius; dx <= radius; dx += 1) {
+      for (let dy = -radius; dy <= radius; dy += 1) {
         if (dx === 0 && dy === 0) continue;
         const neighbor = formatRoomName(c.x + dx, c.y + dy);
         if (!real.has(neighbor)) needed.add(neighbor);

--- a/test/unit/harness/spawnDecision.ts
+++ b/test/unit/harness/spawnDecision.ts
@@ -6,7 +6,7 @@
  *   - each corp's getSpawnDemand (count, sizing, value, blocking flags),
  *   - the director's collectDemands grouping (groupId / groupStarted, the
  *     "fund one income unit fully" bookkeeping), and
- *   - the scheduler (withMinerPrecedence + effectiveValue ranking + the
+ *   - the scheduler (withMinerPrecedence + spawnPriority ranking + the
  *     wait-for-blocking / affordability decision).
  *
  * Bugs hide in the *seams* between them - e.g. a miner that stopped counting as

--- a/test/unit/nodes/pathDistance.test.ts
+++ b/test/unit/nodes/pathDistance.test.ts
@@ -1,0 +1,85 @@
+import { expect } from "chai";
+import {
+  pathDistance,
+  clearPathDistanceCache,
+  estimateWalkingDistance
+} from "../../../src/nodes/NodeNavigator";
+import { Position } from "../../../src/types/Position";
+
+const at = (x: number, y: number, roomName = "W0N0"): Position => ({ x, y, roomName });
+
+// pathDistance() is the seam that feeds real walls/swamps into the remote-mining
+// profitability gate. These tests pin its contract against a stub PathFinder:
+// trust a completed path's step count, otherwise fall back to the analytic
+// estimate, and only ever search a given endpoint pair once.
+describe("pathDistance", () => {
+  const g = globalThis as unknown as { PathFinder?: unknown; RoomPosition?: unknown };
+  let savedPF: unknown;
+  let savedRP: unknown;
+
+  beforeEach(() => {
+    savedPF = g.PathFinder;
+    savedRP = g.RoomPosition;
+    clearPathDistanceCache();
+    // Minimal RoomPosition so pathDistance can build origin/goal.
+    g.RoomPosition = function (this: Position, x: number, y: number, roomName: string) {
+      this.x = x;
+      this.y = y;
+      this.roomName = roomName;
+    };
+  });
+
+  afterEach(() => {
+    g.PathFinder = savedPF;
+    g.RoomPosition = savedRP;
+    clearPathDistanceCache();
+  });
+
+  it("uses the real PathFinder step count when a path completes", () => {
+    // A walled detour: the real path is far longer than the crow-flies estimate.
+    const detour = new Array(40).fill({});
+    g.PathFinder = { search: () => ({ path: detour, ops: 100, cost: 80, incomplete: false }) };
+
+    const from = at(5, 5);
+    const to = at(8, 5);
+    expect(estimateWalkingDistance(from, to)).to.equal(3); // crow-flies says "cheap"
+    expect(pathDistance(from, to)).to.equal(40); // real detour says "expensive"
+  });
+
+  it("falls back to the analytic estimate when the path is incomplete", () => {
+    g.PathFinder = { search: () => ({ path: [], ops: 4000, cost: 0, incomplete: true }) };
+    const from = at(5, 5);
+    const to = at(8, 5);
+    expect(pathDistance(from, to)).to.equal(estimateWalkingDistance(from, to));
+  });
+
+  it("falls back when PathFinder returns an empty path (e.g. the unit-test mock)", () => {
+    g.PathFinder = { search: () => ({ path: [], ops: 0, cost: 0, incomplete: false }) };
+    const from = at(5, 5);
+    const to = at(12, 5);
+    expect(pathDistance(from, to)).to.equal(estimateWalkingDistance(from, to));
+  });
+
+  it("falls back when PathFinder is unavailable", () => {
+    g.PathFinder = undefined;
+    const from = at(5, 5);
+    const to = at(20, 5);
+    expect(pathDistance(from, to)).to.equal(estimateWalkingDistance(from, to));
+  });
+
+  it("caches by endpoint so PathFinder is searched only once per pair", () => {
+    let calls = 0;
+    g.PathFinder = {
+      search: () => {
+        calls++;
+        return { path: new Array(10).fill({}), ops: 1, cost: 1, incomplete: false };
+      }
+    };
+    const from = at(1, 1);
+    const to = at(9, 9);
+    pathDistance(from, to);
+    pathDistance(from, to);
+    pathDistance(from, to);
+    expect(calls).to.equal(1);
+  });
+});

--- a/test/unit/spawn/SpawnScheduler.test.ts
+++ b/test/unit/spawn/SpawnScheduler.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import {
   scheduleSpawn,
-  effectiveValue,
+  spawnPriority,
   SpawnDemand,
   ScheduleContext,
 } from "../../../src/spawn/SpawnScheduler";
@@ -201,7 +201,7 @@ describe("SpawnScheduler", () => {
         // The heart of "fund one corp fully, then move on": source B is already
         // mining and needs its hauler to get that energy home; source A is a fresh
         // source whose first miner is blocking. Completing B (haulB) must outrank
-        // opening A (boot) - COMPLETION_BOOST > BLOCKING_BOOST - otherwise the spawn
+        // opening A (boot) - started corps outrank fresh ones - otherwise the spawn
         // keeps opening new sources while started ones strand their energy unhauled
         // (haulers parked at sources, the exact failure this guards against).
         const freshBlockingMiner = demand({
@@ -217,27 +217,25 @@ describe("SpawnScheduler", () => {
       });
     });
 
-    describe("anti-starvation aging", () => {
-      it("lets a long-waiting demand overtake a higher-base-value newcomer", () => {
-        const newcomer = demand({ buyerCorpId: "new", value: 100, since: 1000 });
-        const oldcomer = demand({ buyerCorpId: "old", value: 10, since: 0 });
-        // After enough ticks, aging on the old demand exceeds the value gap.
-        const result = scheduleSpawn([newcomer, oldcomer], ctx({ tick: 1000, energyAvailable: 300 }));
-        expect(result?.demand.buyerCorpId).to.equal("old");
-      });
-    });
   });
 
-  describe("effectiveValue()", () => {
-    it("boosts blocking demands above non-blocking ones", () => {
-      const block = demand({ blocking: true, value: 1 });
-      const noblock = demand({ blocking: false, value: 1 });
-      expect(effectiveValue(block, 0)).to.be.greaterThan(effectiveValue(noblock, 0));
+  describe("spawnPriority()", () => {
+    it("ranks any income corp above consumption, even a higher-value consumer", () => {
+      const income = demand({ role: "miner", value: 100, producesIncome: true, groupId: "A" });
+      const consumer = demand({ role: "upgrader", value: 110, blocking: true }); // no groupId
+      expect(spawnPriority(income)).to.be.greaterThan(spawnPriority(consumer));
     });
 
-    it("increases with age", () => {
-      const d = demand({ value: 10, since: 0 });
-      expect(effectiveValue(d, 100)).to.be.greaterThan(effectiveValue(d, 0));
+    it("ranks a started income corp above a fresh one regardless of value", () => {
+      const started = demand({ role: "hauler", value: 90, producesIncome: true, groupId: "A", groupStarted: true });
+      const fresh = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "B", groupStarted: false });
+      expect(spawnPriority(started)).to.be.greaterThan(spawnPriority(fresh));
+    });
+
+    it("nudges the urgent (blocking) demand ahead within a tier", () => {
+      const urgent = demand({ role: "hauler", value: 90, blocking: true, producesIncome: true, groupId: "A", groupStarted: true });
+      const scaling = demand({ role: "miner", value: 90, blocking: false, producesIncome: true, groupId: "A", groupStarted: true });
+      expect(spawnPriority(urgent)).to.be.greaterThan(spawnPriority(scaling));
     });
   });
 });

--- a/test/unit/spawn/SpawnScheduler.test.ts
+++ b/test/unit/spawn/SpawnScheduler.test.ts
@@ -197,8 +197,14 @@ describe("SpawnScheduler", () => {
         expect(result?.demand.buyerCorpId).to.equal("minerB");
       });
 
-      it("still lets a blocking bootstrap demand outrank a started unit's completion", () => {
-        const bootstrapMiner = demand({
+      it("completes a started unit before opening a fresh source's blocking miner", () => {
+        // The heart of "fund one corp fully, then move on": source B is already
+        // mining and needs its hauler to get that energy home; source A is a fresh
+        // source whose first miner is blocking. Completing B (haulB) must outrank
+        // opening A (boot) - COMPLETION_BOOST > BLOCKING_BOOST - otherwise the spawn
+        // keeps opening new sources while started ones strand their energy unhauled
+        // (haulers parked at sources, the exact failure this guards against).
+        const freshBlockingMiner = demand({
           buyerCorpId: "boot", role: "miner", value: 100, blocking: true,
           producesIncome: true, groupId: "A", groupStarted: false,
         });
@@ -206,8 +212,8 @@ describe("SpawnScheduler", () => {
           buyerCorpId: "haulB", role: "hauler", value: 110,
           producesIncome: true, groupId: "B", groupStarted: true,
         });
-        const result = scheduleSpawn([startedHauler, bootstrapMiner], ctx({ energyAvailable: 300 }));
-        expect(result?.demand.buyerCorpId).to.equal("boot");
+        const result = scheduleSpawn([startedHauler, freshBlockingMiner], ctx({ energyAvailable: 300 }));
+        expect(result?.demand.buyerCorpId).to.equal("haulB");
       });
     });
 

--- a/test/unit/spawn/minerPrecedence.test.ts
+++ b/test/unit/spawn/minerPrecedence.test.ts
@@ -25,28 +25,31 @@ describe("withMinerPrecedence", () => {
     expect(out.map(d => d.role)).to.deep.equal(["miner"]);
   });
 
-  it("keeps haulers once their source has no pending miner demand", () => {
-    // srcA's miner is fully staffed (no miner demand), so its haulers proceed.
+  it("drops an orphan hauler whose source has no miner in the field", () => {
+    // srcA has a hauler demand but no miner mining yet (groupStarted false) - e.g.
+    // a remote source the miner-profitability gate rejected. The hauler has nothing
+    // to carry, so it must be dropped (the "parked at a minerless source" failure).
     const demands = [demand("hauler", "srcA"), demand("upgrader", "roomX")];
     const out = withMinerPrecedence(demands);
 
-    expect(out).to.have.length(2);
+    expect(out.map(d => d.role)).to.deep.equal(["upgrader"]);
   });
 
   it("keeps a source's haulers once its first miner is in the field (groupStarted)", () => {
     // srcA still wants a bigger/second miner, but one is already mining
-    // (groupStarted) - so its haulers must NOT be held back.
-    const demands = [demand("miner", "srcA", 100, true), demand("hauler", "srcA")];
+    // (groupStarted) - so its haulers must NOT be held back. collectDemands stamps
+    // every demand of a started source with groupStarted=true.
+    const demands = [demand("miner", "srcA", 100, true), demand("hauler", "srcA", 100, true)];
     const out = withMinerPrecedence(demands);
 
     expect(out.map(d => d.role)).to.deep.equal(["miner", "hauler"]);
   });
 
-  it("only holds back haulers of the same source, not other sources", () => {
+  it("holds back haulers of unstarted sources, keeps haulers of a started one", () => {
     const demands = [
-      demand("miner", "srcA"),
+      demand("miner", "srcA"), // srcA not mining yet -> its hauler held
       demand("hauler", "srcA"),
-      demand("hauler", "srcB") // srcB has no pending miner -> allowed
+      demand("hauler", "srcB", 100, true) // srcB is mining (groupStarted) -> allowed
     ];
     const out = withMinerPrecedence(demands);
 

--- a/test/unit/spawn/nextSpawn.test.ts
+++ b/test/unit/spawn/nextSpawn.test.ts
@@ -132,18 +132,19 @@ describe("next spawn decision (key moments)", () => {
     expect(withHauler.role).to.equal("upgrader");
   });
 
-  it("funds the upgrader before opening a fresh source once income is staffed", () => {
-    // Source A is fully staffed and its energy is coming home, but the colony has
-    // not upgraded yet (no upgrader in the field, so the upgrader demand is
-    // blocking). A fresh source B wants its first (non-blocking) miner. The
-    // colony must drive RCL - fund the blocking upgrader - rather than open yet
-    // another source while the controller goes un-upgraded.
+  it("opens a fresh (profitable) source's miner before the first upgrader", () => {
+    // Source A is fully staffed and its energy is coming home. A fresh source B
+    // wants its first miner; an upgrader also waits. Income outranks consumption:
+    // a source's miner is the highest-value corp and is staffed first, before the
+    // colony spends spawn time upgrading. (Sources B would NOT exist here if the
+    // miner-profitability gate had rejected it as an unprofitable remote - that
+    // gate, not the upgrader, is what keeps the colony from sprawling.)
     const decision = decideNextSpawn({
       energyAvailable: 550,
       energyCapacity: 550,
       sources: [
         { id: "A", haulCarry: 4 }, // fully staffed below
-        { id: "B" } // fresh: first miner pending, non-blocking
+        { id: "B" } // fresh: first miner pending (blocking, per source)
       ],
       upgrader: true,
       creeps: [
@@ -152,8 +153,8 @@ describe("next spawn decision (key moments)", () => {
       ]
     });
 
-    expect(decision.role).to.equal("upgrader");
-    expect(decision.buyerCorpId).to.equal("upgrading-W1N1");
+    expect(decision.role).to.equal("miner");
+    expect(decision.buyerCorpId).to.equal("mining-B");
   });
 
   it("holds the spawn rather than spawning a 1-WORK miner runt at a drained spawn", () => {


### PR DESCRIPTION
Merges this session's work back to master. Direct `git push origin master` is blocked by the session git proxy (HTTP 403 on `git-receive-pack`), so the merge-back goes through a PR.

## What's in here

**Staff income corps first, complete each source before opening the next** (`c87efe4`)
Per-source miner blocking so every source's first miner outranks consumption.

**Replace the spawn-ranking heuristic soup with one tiered corp-atomic priority** (`f56e964`)
`effectiveValue` (additive `BLOCKING_BOOST` + `COMPLETION_BOOST` + per-tick aging) is replaced by a single strictly tiered `spawnPriority`:
1. income corp, already started — finish its haulers / second miner
2. income corp, fresh — open the next source's first miner
3. consumption (upgrade / build / …) — spend what income leaves

Within a tier the higher-value corp wins; `blocking` nudges the urgent demand. The tier gaps are pure separators, not tunables. Deletes the three boost/aging constants and the per-demand aging bookkeeping in SpawnDirector.

**Use real cached PathFinder distance for the remote-mining profitability gate** (`b24cd34`, `3a6d426`)
`estimateWalkingDistance` ignored walls/swamps, so a source walled off behind a long detour looked cheap to haul from and the planner opened remotes it could never haul home. Adds `pathDistance()` — real PathFinder step count, cached by the static source/spawn/controller endpoints, with an analytic fallback when PathFinder can't complete a path (unit-test mocks, unloaded remote terrain). FlowGraph edge weights and the EconomyAdapter planner `dist` now use it.

## Verification
- 413 unit tests pass (including 5 new `pathDistance` contract tests and master's economics tests after the merge).
- Walled local-vs-remote repro still mines 2/2 local with no creeps wasted on the neighbor, with real PathFinder now computing local distances too.

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_