### PR TITLE
Reserved remote mining: economics + value reservable sources as reserved

### DIFF
--- a/src/corps/economics.ts
+++ b/src/corps/economics.ts
@@ -111,3 +111,55 @@ export function travelTicksPerTile(energyCapacity: number): number {
   const t = Math.max(0, Math.min(1, (energyCapacity - 300) / (1300 - 300)));
   return EARLY - (EARLY - LATE) * t;
 }
+
+// ---------------------------------------------------------------------------
+// Reserving a remote room
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifetime of a creep carrying a CLAIM part (CREEP_CLAIM_LIFE_TIME). Reservers
+ * live only 600 ticks, not 1500 - a big part of why the reserver toll is steep.
+ */
+export const CLAIM_LIFETIME = 600;
+
+/**
+ * Reserver duty cycle. A reservation accumulates (to 5000) and decays 1/tick, so a
+ * reserver need not be present continuously - let it build up, let it tick down,
+ * then top up. ~50% duty roughly halves the amortized cost.
+ */
+export const RESERVER_DUTY = 0.5;
+
+/** Energy cost of the smallest reserver that can hold a room: 1 CLAIM + 1 MOVE. */
+export const RESERVER_BODY_COST = 650;
+
+/**
+ * Energy-equivalent cost per tick of keeping ONE remote room reserved from a spawn
+ * `distance` tiles away - the reserver's body upkeep plus its spawn build-time
+ * priced in energy, amortized over its short (CLAIM) life and its duty cycle.
+ * Returns Infinity when the room cannot even afford a reserver body (energyCapacity
+ * < 650, i.e. below RCL 3) - so reserving simply never wins there, with no RCL gate.
+ *
+ * This is a per-ROOM cost: one reserver covers all of a room's sources, so callers
+ * weigh it against the whole room's reserved gain (see {@link reserveRoomWorthIt}).
+ */
+export function reserverTollPerRoom(energyCapacity: number, distance: number): number {
+  if (energyCapacity < RESERVER_BODY_COST) return Infinity; // can't build a reserver yet
+  const RESERVER_PARTS = 2; // CLAIM + MOVE
+  const life = Math.max(1, CLAIM_LIFETIME - distance); // walks out, then reserves
+  const energyOH = RESERVER_BODY_COST / life;
+  const partOH = (RESERVER_PARTS / life) * SPAWN_PART_ENERGY_VALUE;
+  return RESERVER_DUTY * (energyOH + partOH);
+}
+
+/**
+ * Is reserving a remote room worth it? Reserving lifts each of the room's `sources`
+ * from the unreserved 5 e/tick to the reserved 10 (+5 each); that whole-room gain is
+ * weighed against the single per-room reserver toll. So two sources justify
+ * reserving (and reaching farther) where one might not, and a room too far - or a
+ * spawn too small to build a reserver - simply loses. The miner/hauler costs are
+ * the same either way, so they cancel and only the +5/source vs the toll matter.
+ */
+export function reserveRoomWorthIt(energyCapacity: number, distance: number, sources: number): boolean {
+  return sources * 5 > reserverTollPerRoom(energyCapacity, distance);
+}
+

--- a/src/execution/IncrementalAnalysis.ts
+++ b/src/execution/IncrementalAnalysis.ts
@@ -19,6 +19,7 @@ import {
 } from "../spatial";
 import { Node, NodeSurveyor, calculateNodeROI, createNode } from "../nodes";
 import { ChainSource } from "../corps/ChainEvaluator";
+import { RESERVER_BODY_COST } from "../corps/economics";
 import { ColonyNode, marginalNodeValue } from "../planning/ColonyEconomy";
 import { Colony } from "../colony";
 import { get7x7BoxAroundOwnedRooms } from "../utils";
@@ -630,8 +631,23 @@ function populateNodeResources(
         const isOwnedRoom = myUsername && intel.controllerOwner === myUsername;
         const isReservedByUs = myUsername && intel.controllerReservation === myUsername;
 
-        // Source capacity: 3000 for owned/reserved rooms, 1500 for unclaimed.
-        const sourceCapacity = isOwnedRoom || isReservedByUs ? 3000 : 1500;
+        // A controllered, unowned room we COULD reserve will be lifted to 3000 by
+        // the ReservationCorp once we mine it - so value its sources as reserved
+        // *now*, provided we can afford a reserver (capacity >= 650, i.e. RCL3+).
+        // Without this the planner sees only the unreserved 1500 (5 e/tick) and may
+        // never open a remote that is only worthwhile reserved - the reserved-mining
+        // op should rank like the 3000 it becomes. Over-commitment and too-far rooms
+        // are held back downstream by the source's own net-energy gate and the
+        // dynamic spawn-time budget, so no distance check is needed here.
+        const homeCapacity = Object.values(Game.spawns)[0]?.room?.energyCapacityAvailable ?? 300;
+        const couldReserve =
+          !!intel.controllerPos &&
+          !intel.controllerOwner &&
+          (!intel.controllerReservation || intel.controllerReservation === myUsername) &&
+          homeCapacity >= RESERVER_BODY_COST;
+
+        // Source capacity: 3000 for owned/reserved/reservable rooms, 1500 otherwise.
+        const sourceCapacity = isOwnedRoom || isReservedByUs || couldReserve ? 3000 : 1500;
 
         // Add sources from intel within territory
         for (const sourcePos of intel.sourcePositions || []) {

--- a/test/unit/corps/reserverEconomics.test.ts
+++ b/test/unit/corps/reserverEconomics.test.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import {
+  reserverTollPerRoom,
+  reserveRoomWorthIt,
+  CLAIM_LIFETIME,
+  RESERVER_BODY_COST
+} from "../../../src/corps/economics";
+
+/**
+ * Reserving a remote room: a per-room cost (one reserver covers all the room's
+ * sources, runs at ~50% duty, lives only 600 ticks) weighed against the +5 e/tick
+ * each source gains going from the unreserved 1500 cap to the reserved 3000. The
+ * decision falls out of the numbers - no RCL gate, just affordability and distance.
+ */
+describe("reserver economics", () => {
+  it("is unaffordable below RCL 3 (can't build a 650 reserver body)", () => {
+    // RCL2 capacity is 550 < 650, so no reserver can be built - toll is Infinity and
+    // reserving never wins, with no explicit RCL check.
+    expect(RESERVER_BODY_COST).to.equal(650);
+    expect(reserverTollPerRoom(550, 30)).to.equal(Infinity);
+    expect(reserveRoomWorthIt(550, 30, 2)).to.equal(false);
+    // RCL3 (800) can afford it.
+    expect(reserverTollPerRoom(800, 30)).to.be.lessThan(Infinity);
+  });
+
+  it("the toll rises with distance (short CLAIM life eaten by the walk)", () => {
+    const near = reserverTollPerRoom(1300, 25);
+    const far = reserverTollPerRoom(1300, 200);
+    expect(far).to.be.greaterThan(near);
+    // A reserver that has to walk most of its 600-tick life is very expensive.
+    expect(reserverTollPerRoom(1300, CLAIM_LIFETIME - 10)).to.be.greaterThan(far);
+  });
+
+  it("is worth it for any VIABLE remote distance, even a single source", () => {
+    // The toll (~0.9 e/tick at typical distances, after the ~50% duty cycle) is
+    // small next to the +5 e/tick each source gains, so once a spawn can afford a
+    // reserver every remote you'd actually mine is worth reserving - matching real
+    // play, where remotes are essentially always reserved.
+    for (const d of [25, 50, 100, 150]) {
+      expect(reserveRoomWorthIt(800, d, 1), `d=${d}, 1 source should reserve`).to.equal(true);
+    }
+  });
+
+  it("two sources amortize the reserver, so they reserve farther than one", () => {
+    // The per-room reserver is shared, so its per-source cost halves. The crossover
+    // where one source no longer justifies the toll but two still do sits far out
+    // (the toll only approaches 5-10 e/tick as the walk eats the 600-tick CLAIM
+    // life) - but it exists, which is the amortization at work.
+    let crossover = -1;
+    for (let d = 25; d <= 580; d += 5) {
+      if (!reserveRoomWorthIt(1300, d, 1) && reserveRoomWorthIt(1300, d, 2)) {
+        crossover = d;
+        break;
+      }
+    }
+    expect(crossover, "a band where 2 sources reserve but 1 does not").to.be.greaterThan(0);
+  });
+
+  it("stops reserving when the room is absurdly far (toll exceeds the gain)", () => {
+    // Near the CLAIM lifetime the reserver spends almost all its life walking, so
+    // the toll exceeds even two sources' +10 - reserving loses outright.
+    expect(reserveRoomWorthIt(1300, CLAIM_LIFETIME - 20, 2)).to.equal(false);
+  });
+});

--- a/test/unit/execution/refreshNodeResources.test.ts
+++ b/test/unit/execution/refreshNodeResources.test.ts
@@ -81,9 +81,52 @@ describe("refreshNodeResources (room-agnostic source claiming)", () => {
     const sources = node.resources.filter((r) => r.type === "source");
     expect(sources, "remote source should be claimed from intel").to.have.length(1);
     expect(sources[0].position.roomName).to.equal("W1N0");
-    // Unowned room: a source there regenerates only 1500 (not 3000) - the
-    // economics the planner already prices in.
+    // No controller in this intel (controllerPos null), so it can't be reserved -
+    // the source regenerates only the unreserved 1500.
     expect(sources[0].capacity).to.equal(1500);
+  });
+
+  it("values a reservable scouted room's source as RESERVED (3000) once a reserver is affordable", () => {
+    // Home is RCL3 (800 >= the 650 reserver body) and the remote room has a
+    // controller we could reserve (unowned, unreserved), so the planner values its
+    // source at the reserved 3000 - the rate it becomes once the ReservationCorp
+    // holds it. Without this the remote looks like 5 e/tick and may never be opened.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).Game.spawns = { Spawn1: { owner: { username: "me" }, room: { energyCapacityAvailable: 800 } } };
+    const colony = new Colony();
+    const node = createNode("n-remote", "W1N0", { x: 25, y: 25, roomName: "W1N0" }, 4, ["W1N0"], 100);
+    colony.addNode(node);
+    const result = resultWith("n-remote", [
+      { x: 25, y: 25, roomName: "W1N0" }, { x: 24, y: 25, roomName: "W1N0" }, { x: 26, y: 25, roomName: "W1N0" }
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const intel = intelWithSource(100, 25, 25) as any;
+    intel.controllerPos = { x: 10, y: 10 }; // a controller we could reserve
+    Memory.roomIntel!["W1N0"] = intel as never;
+
+    refreshNodeResources(colony, result);
+    expect(node.resources.filter((r) => r.type === "source")[0].capacity).to.equal(3000);
+  });
+
+  it("stays unreserved (1500) when a reserver is unaffordable (below RCL3)", () => {
+    // Same reservable room, but home is RCL1 (300 < 650) - it cannot build a
+    // reserver, so the source is valued at the unreserved 1500. No RCL gate: the
+    // affordability floor produces the cutoff.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).Game.spawns = { Spawn1: { owner: { username: "me" }, room: { energyCapacityAvailable: 300 } } };
+    const colony = new Colony();
+    const node = createNode("n-remote", "W1N0", { x: 25, y: 25, roomName: "W1N0" }, 4, ["W1N0"], 100);
+    colony.addNode(node);
+    const result = resultWith("n-remote", [
+      { x: 25, y: 25, roomName: "W1N0" }, { x: 24, y: 25, roomName: "W1N0" }, { x: 26, y: 25, roomName: "W1N0" }
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const intel = intelWithSource(100, 25, 25) as any;
+    intel.controllerPos = { x: 10, y: 10 };
+    Memory.roomIntel!["W1N0"] = intel as never;
+
+    refreshNodeResources(colony, result);
+    expect(node.resources.filter((r) => r.type === "source")[0].capacity).to.equal(1500);
   });
 
   it("does not claim a source outside the node's territory", () => {


### PR DESCRIPTION
Closes the chicken-and-egg in remote-mining valuation: the planner saw an unowned
remote source at only the unreserved 1500 (5 e/tick) until it was *already*
reserved, so a remote that's only worthwhile reserved was never opened (never
valued as reserved → never mined → never reserved).

- **Reserver economics (production code):** `reserverTollPerRoom` (energy upkeep +
  spawn build-time priced in energy, over the short 600-tick CLAIM life and ~50%
  duty cycle; Infinity below the 650 affordability floor = RCL3) and
  `reserveRoomWorthIt` (the room's +5/source gain vs one per-room toll). Tests pin
  the honest finding: the toll is small (~0.9 e/tick) next to +5/source, so once a
  spawn can afford a reserver every viable remote is worth reserving.
- **Planner valuation:** a controllered, unowned room we *could* reserve is valued
  at the reserved 3000 once a reserver is affordable — the rate it becomes once
  `ReservationCorp` (which already reserves rooms we mine) holds it. No RCL gate;
  the affordability floor + the source's net-energy gate + the dynamic spawn-time
  budget produce the cutoff.

Rebased onto the parallel corp-priority / path-distance / runt-recycling work;
428 unit tests passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_