### PR TITLE
Document integration-suite flakiness (mockup storage contention)

### DIFF
--- a/docs/TESTING_THE_ECONOMY.md
+++ b/docs/TESTING_THE_ECONOMY.md
@@ -53,6 +53,14 @@ every corp — the colony couldn't start; it now runs one room.) There is a late
 robustness question — should the bootstrap survive a many-node world (a mature
 colony re-bootstrapping after a wipe)? — but it does not occur in normal play.
 
+**Run integration tests one file at a time, not as a back-to-back suite.** The
+mockup's storage subprocess does not always clean up between sequential
+`ScreepsServer` instances, so a later test's colony can malfunction (e.g. the
+flow-handoff probe fails *in the full suite* but passes run alone, where the
+hand-off is clearly fine — mining 4/10, hauling 6/10 by tick 500). This is test
+infrastructure flakiness, not a colony bug. If servers pile up, `rm -rf server/`
+and `pkill -f '@screeps/(storage|engine)'` between runs.
+
 ### Two practices that keep these honest
 
 - **Mutation verification.** A guard is only real if it bites. After writing a


### PR DESCRIPTION
Documents that the full integration suite is flaky due to the mockup's storage
subprocess not cleaning up between sequential `ScreepsServer` instances — the
flow-handoff probe fails *in the suite* but passes run alone (the hand-off is fine:
mining 4/10, hauling 6/10 by tick 500). Test-infra issue, not a colony bug. Run
integration tests one file at a time; `rm -rf server/` + pkill stale procs if they
pile up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_