### PR TITLE
Record room intel from vision, not just scout visits (fix Finding A)

### DIFF
--- a/src/corps/ScoutCorp.ts
+++ b/src/corps/ScoutCorp.ts
@@ -67,6 +67,21 @@ export class ScoutCorp extends Corp {
     const homeRoom = spawn.room.name;
     const creeps = this.getActiveCreeps();
 
+    // Record intel for EVERY room we currently have vision of - any room in
+    // Game.rooms means we see it (a creep there, or we own it), not just rooms a
+    // scout creep is visiting. Without this, a remote room we are already MINING
+    // never gets its controller recorded until a dedicated scout reaches it, so
+    // the planner cannot value its source as reservable (3000) and leaves it at
+    // the unreserved 1500. Throttled to rooms whose intel is missing or stale (a
+    // continuously-mined room is re-recorded once per STALE_THRESHOLD), so it stays
+    // cheap. recordRoomIntel stamps lastVisit, keeping the room fresh in between.
+    for (const roomName in Game.rooms) {
+      const intel = Memory.roomIntel?.[roomName];
+      if (!intel || Game.time - intel.lastVisit >= STALE_THRESHOLD) {
+        this.recordRoomIntel(Game.rooms[roomName]);
+      }
+    }
+
     for (const creep of creeps) {
       if (!creep.memory.targetRoom) {
         const target = this.findStaleRoomExcluding(homeRoom, this.getAssignedTargets());

--- a/test/unit/corps/scoutIntel.test.ts
+++ b/test/unit/corps/scoutIntel.test.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { setupGlobals, Game, Memory, FIND_SOURCES, FIND_MINERALS } from "../mock";
+import { ScoutCorp } from "../../../src/corps/ScoutCorp";
+
+/**
+ * The ScoutCorp records room intel for EVERY room the bot has vision of - any
+ * room in Game.rooms - not just rooms a scout creep is visiting. A remote room we
+ * are already mining is visible (a creep is there), so its controller gets
+ * recorded even without a dedicated scout; that is what lets the planner value its
+ * source as reservable (3000) instead of leaving it at the unreserved 1500.
+ */
+function remoteRoom(name: string, opts: { reservation?: string; lastVisit?: number } = {}): any {
+  return {
+    name,
+    controller: {
+      level: 0,
+      pos: { x: 10, y: 10 },
+      owner: undefined,
+      reservation: opts.reservation ? { username: opts.reservation } : undefined
+    },
+    find: (type: number) => {
+      if (type === FIND_SOURCES) return [{ pos: { x: 25, y: 25 } }];
+      if (type === FIND_MINERALS) return [];
+      return []; // hostiles etc.
+    }
+  };
+}
+
+describe("ScoutCorp intel from vision (not just scouts)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).FIND_HOSTILE_STRUCTURES = 110; // not in the base mock globals
+    Game.creeps = {}; // no scout creeps anywhere
+    Game.time = 1000;
+    Game.getObjectById = () => ({ room: { name: "W0N0" } }); // the home spawn
+    (Memory as any).roomIntel = {};
+  });
+
+  it("records a visible remote room's controller with no scout creep present", () => {
+    Game.rooms = { W1N0: remoteRoom("W1N0") };
+    new ScoutCorp("W0N0-scout", "spawn1").work(Game.time);
+
+    const intel = (Memory as any).roomIntel!.W1N0 as any;
+    expect(intel, "intel recorded for the visible room").to.exist;
+    expect(intel.controllerPos).to.deep.equal({ x: 10, y: 10 });
+    expect(intel.sourcePositions).to.deep.equal([{ x: 25, y: 25 }]);
+    expect(intel.lastVisit).to.equal(Game.time);
+  });
+
+  it("captures the controller reservation so the planner can see who holds it", () => {
+    Game.rooms = { W1N0: remoteRoom("W1N0", { reservation: "me" }) };
+    new ScoutCorp("W0N0-scout", "spawn1").work(Game.time);
+    expect(((Memory as any).roomIntel!.W1N0 as any).controllerReservation).to.equal("me");
+  });
+
+  it("does not re-record a freshly-seen room every tick (throttled)", () => {
+    // Pre-seed fresh intel with a sentinel; a throttled pass should leave it.
+    (Memory as any).roomIntel!.W1N0 = { lastVisit: Game.time, sentinel: true } as any;
+    Game.rooms = { W1N0: remoteRoom("W1N0") };
+    new ScoutCorp("W0N0-scout", "spawn1").work(Game.time);
+    expect(((Memory as any).roomIntel!.W1N0 as any).sentinel, "fresh intel left untouched").to.equal(true);
+  });
+});


### PR DESCRIPTION
Fixes Finding A from the variance dig: `ScoutCorp.recordRoomIntel` only ran for a
scout creep's current room, so a remote room we were already MINING never got its
controller recorded until a dedicated scout reached it — and the planner's
`couldReserve` valuation therefore left its source at the unreserved 1500 instead
of the reservable 3000.

Now `ScoutCorp.work` records intel for **every room in `Game.rooms`** (any room we
have vision of — a creep there, or owned), throttled to missing/stale rooms so it
stays cheap (`recordRoomIntel` stamps `lastVisit`). So a remote we mine is recorded
as soon as it is visible, not only when a scout reaches it.

Tests (new `scoutIntel.test.ts`): a visible room's controller (+ reservation) is
recorded with no scout creep present; fresh intel is not re-recorded. 426 unit
tests passing.

Note: this is a strict intel-coverage improvement. Its downstream payoff
(`couldReserve` raising the remote budget to 10) was not yet visible end-to-end
after the new GOAP `CorpPlanner` landed in parallel — that planner may read source
capacity differently from `IncrementalAnalysis`'s nodes, and remote reservation
behaviour also changed; flagged for separate investigation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_