### PR TITLE
Fix reservation regression: group the reserver into the income tier

### DIFF
--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -124,7 +124,19 @@ export function collectDemands(registry: CorpRegistry, spawnId: string, ctx: Spa
   }
   for (const id in registry.reservationCorps) {
     const c = registry.reservationCorps[id];
-    if (c.getSpawnId() === spawnId) demands.push(...c.getSpawnDemand(ctx));
+    if (c.getSpawnId() !== spawnId) continue;
+    for (const d of c.getSpawnDemand(ctx)) {
+      // The reserver is INCOME work: it unlocks +5 e/tick on every source in the
+      // remote room it holds (a remote we already mine, so its demand only appears
+      // once that income is underway). Give it a groupId so spawnPriority places it
+      // in the income tier (it already declares producesIncome) - otherwise it sits
+      // at its base value (92), below every income corp AND every blocking consumer,
+      // and is starved forever while the colony ramps, so the remote never gets
+      // reserved and stays at the unreserved half-rate. It is a *fresh* income unit
+      // (not groupStarted), so the core miners/haulers still complete first.
+      d.groupId = c.id;
+      demands.push(d);
+    }
   }
 
   return demands;

--- a/test/unit/spawn/reserverPriority.test.ts
+++ b/test/unit/spawn/reserverPriority.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import { spawnPriority, SpawnDemand } from "../../../src/spawn/SpawnScheduler";
+
+function demand(over: Partial<SpawnDemand>): SpawnDemand {
+  return {
+    buyerCorpId: "c",
+    role: "miner",
+    value: 90,
+    blocking: false,
+    producesIncome: false,
+    desiredCost: 300,
+    minCost: 150,
+    since: 0,
+    ...over
+  };
+}
+
+/**
+ * The reserver is income work - it unlocks +5 e/tick on every source in the remote
+ * room it holds. The tiered spawnPriority puts a demand in the income tier only when
+ * it has BOTH producesIncome AND a groupId. The reserver declares producesIncome but
+ * collectDemands must give it a groupId (it now does) - otherwise it sits at its base
+ * value (92), below every income corp and below a blocking consumer, and is starved
+ * forever, so the remote never gets reserved and stays at the unreserved half-rate.
+ */
+describe("reserver spawn priority (income, not starved)", () => {
+  it("a grouped reserver outranks discretionary upgrading", () => {
+    const reserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0" });
+    const upgrader = demand({ role: "upgrader", value: 90, producesIncome: false });
+    expect(spawnPriority(reserver)).to.be.greaterThan(spawnPriority(upgrader));
+  });
+
+  it("grouping lifts the reserver above even a BLOCKING consumer (the starvation it fixes)", () => {
+    // The bug: an ungrouped reserver (92) is below a blocking first upgrader
+    // (90 + the urgent boost), so it never wins while the colony ramps.
+    const ungrouped = demand({ role: "reserver", value: 92, producesIncome: true });
+    const blockingUpgrader = demand({ role: "upgrader", value: 90, producesIncome: false, blocking: true });
+    expect(spawnPriority(ungrouped), "ungrouped reserver is starved").to.be.lessThan(spawnPriority(blockingUpgrader));
+
+    // The fix: with a groupId it joins the income tier, above consumption.
+    const grouped = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0" });
+    expect(spawnPriority(grouped), "grouped reserver is income-tier").to.be.greaterThan(spawnPriority(blockingUpgrader));
+  });
+
+  it("a fresh reserver still ranks below a started income corp (core mining completes first)", () => {
+    const reserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0" });
+    const startedHauler = demand({ role: "hauler", value: 100, producesIncome: true, groupId: "src", groupStarted: true });
+    expect(spawnPriority(reserver)).to.be.lessThan(spawnPriority(startedHauler));
+  });
+});


### PR DESCRIPTION
## Problem

The GOAP/tiered-priority refactor left the reserver demand **ungrouped**. The tiered `spawnPriority` only promotes a demand into the income tier when it has BOTH `producesIncome` AND a `groupId`. The reserver declares `producesIncome` but `collectDemands` never gave it a `groupId`, so it sat at its base value (92) — below every income corp and below every blocking consumer — and was starved forever while the colony ramped. The remote controller never got reserved and the remote stayed at the unreserved half-rate.

## Fix

`SpawnDirector.collectDemands` now stamps the reserver demand with `groupId = c.id`, placing it in the income tier (it already declares `producesIncome`). It is a *fresh* income unit (not `groupStarted`), so the core miners/haulers still complete first.

## Validation

- New `test/unit/spawn/reserverPriority.test.ts` (3 tests): a grouped reserver outranks discretionary upgrading; grouping lifts it above even a BLOCKING consumer (the exact starvation it fixes); a fresh reserver still ranks below a *started* income corp so core mining finishes first.
- Full unit suite green: **384 passing, 0 failing**.
- End-to-end remote-mining probe: reservation now lands (`reserved true` ~tick 1200), and the remote source's budget rises to the reserved rate.

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_