### PR TITLE
Keep a reservable remote valued at the reserved 3000 across the visibility boundary

### DIFF
--- a/src/execution/IncrementalAnalysis.ts
+++ b/src/execution/IncrementalAnalysis.ts
@@ -566,11 +566,30 @@ function populateNodeResources(
 
   // Get my username for ownership checks
   const myUsername = Object.values(Game.spawns)[0]?.owner?.username;
+  // Home energy capacity gates whether we can afford a reserver (RCL3+). Hoisted
+  // out of the per-room loop so both the live-vision and intel branches apply the
+  // same reservable-source lift (see couldReserve below).
+  const homeCapacity = Object.values(Game.spawns)[0]?.room?.energyCapacityAvailable ?? 300;
 
   for (const roomName of node.spansRooms) {
     // Try live data first (if we have vision)
     const room = Game.rooms[roomName];
     if (room) {
+      // A controllered, unowned room we COULD reserve regenerates only the
+      // unreserved 1500 *until* the ReservationCorp holds it - but its true worth
+      // is the reserved 3000 it becomes. Lift live source capacity to 3000 just as
+      // the intel branch does, so the valuation does not collapse from 3000 to 1500
+      // the moment a miner gives us vision of the remote (which would make the
+      // planner thrash on a remote that is only worthwhile reserved). Owned/already-
+      // reserved rooms already read 3000 from source.energyCapacity, so this only
+      // lifts the reservable-but-not-yet-reserved gap.
+      const ctrl = room.controller;
+      const couldReserveLive =
+        !!ctrl &&
+        !ctrl.owner &&
+        (!ctrl.reservation || ctrl.reservation.username === myUsername) &&
+        homeCapacity >= RESERVER_BODY_COST;
+
       // Add sources within territory
       for (const source of room.find(FIND_SOURCES)) {
         if (shouldClaimResource(source.pos.x, source.pos.y, roomName)) {
@@ -578,7 +597,7 @@ function populateNodeResources(
             type: "source",
             id: source.id,
             position: { x: source.pos.x, y: source.pos.y, roomName },
-            capacity: source.energyCapacity
+            capacity: couldReserveLive ? Math.max(source.energyCapacity, 3000) : source.energyCapacity
           });
         }
       }
@@ -639,7 +658,6 @@ function populateNodeResources(
         // op should rank like the 3000 it becomes. Over-commitment and too-far rooms
         // are held back downstream by the source's own net-energy gate and the
         // dynamic spawn-time budget, so no distance check is needed here.
-        const homeCapacity = Object.values(Game.spawns)[0]?.room?.energyCapacityAvailable ?? 300;
         const couldReserve =
           !!intel.controllerPos &&
           !intel.controllerOwner &&

--- a/test/unit/execution/refreshNodeResources.test.ts
+++ b/test/unit/execution/refreshNodeResources.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import "../../../src/types/Memory"; // load the Memory type augmentation
-import { Game as MockGame } from "../mock";
+import { Game as MockGame, FIND_SOURCES } from "../mock";
 import { Colony } from "../../../src/colony/Colony";
 import { createNode } from "../../../src/nodes/Node";
 import { refreshNodeResources } from "../../../src/execution/IncrementalAnalysis";
@@ -46,6 +46,14 @@ function resultWith(nodeId: string, positions: { x: number; y: number; roomName:
 
 describe("refreshNodeResources (room-agnostic source claiming)", () => {
   beforeEach(() => {
+    // The live-vision branch calls room.find with the bare FIND_* globals; make
+    // them resolve so the mock room's find matches FIND_SOURCES (105).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).FIND_SOURCES = FIND_SOURCES;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).FIND_MINERALS = 106;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).FIND_MY_SPAWNS = 112;
     // A bot that owns nothing in the remote room: a spawn (for the username
     // ownership probe) but no vision of and no controller in the remote room.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -124,6 +132,65 @@ describe("refreshNodeResources (room-agnostic source claiming)", () => {
     const intel = intelWithSource(100, 25, 25) as any;
     intel.controllerPos = { x: 10, y: 10 };
     Memory.roomIntel!["W1N0"] = intel as never;
+
+    refreshNodeResources(colony, result);
+    expect(node.resources.filter((r) => r.type === "source")[0].capacity).to.equal(1500);
+  });
+
+  it("keeps a visible reservable remote's source at the reserved 3000 (no collapse on vision)", () => {
+    // The valuation must not discontinue across the visibility boundary. Once a
+    // miner reaches a remote we get LIVE vision of it, and a live source reads its
+    // raw energyCapacity (1500 while unreserved) - so without the same couldReserve
+    // lift the live branch applies, the remote's worth would collapse 3000 -> 1500
+    // the instant we commit to it, making the planner thrash on a remote that is
+    // only worthwhile reserved. Home is RCL3 (800 >= 650), the live controller is
+    // unowned/unreserved, so the visible source stays valued at 3000.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).Game.spawns = { Spawn1: { owner: { username: "me" }, room: { energyCapacityAvailable: 800 } } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).Game.rooms = {
+      W1N0: {
+        name: "W1N0",
+        controller: { pos: { x: 10, y: 10 }, owner: undefined, reservation: undefined },
+        find: (type: number) =>
+          type === FIND_SOURCES
+            ? [{ id: "live-src", pos: { x: 25, y: 25 }, energyCapacity: 1500 }]
+            : []
+      }
+    };
+    const colony = new Colony();
+    const node = createNode("n-remote", "W1N0", { x: 25, y: 25, roomName: "W1N0" }, 4, ["W1N0"], 100);
+    colony.addNode(node);
+    const result = resultWith("n-remote", [
+      { x: 25, y: 25, roomName: "W1N0" }, { x: 24, y: 25, roomName: "W1N0" }, { x: 26, y: 25, roomName: "W1N0" }
+    ]);
+
+    refreshNodeResources(colony, result);
+    expect(node.resources.filter((r) => r.type === "source")[0].capacity).to.equal(3000);
+  });
+
+  it("does not lift a visible remote already reserved by someone else (stays 1500)", () => {
+    // A live remote whose controller is reserved by a RIVAL cannot be lifted - we
+    // can't reserve it, so its source is worth only the raw unreserved 1500.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).Game.spawns = { Spawn1: { owner: { username: "me" }, room: { energyCapacityAvailable: 800 } } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).Game.rooms = {
+      W1N0: {
+        name: "W1N0",
+        controller: { pos: { x: 10, y: 10 }, owner: undefined, reservation: { username: "rival" } },
+        find: (type: number) =>
+          type === FIND_SOURCES
+            ? [{ id: "live-src", pos: { x: 25, y: 25 }, energyCapacity: 1500 }]
+            : []
+      }
+    };
+    const colony = new Colony();
+    const node = createNode("n-remote", "W1N0", { x: 25, y: 25, roomName: "W1N0" }, 4, ["W1N0"], 100);
+    colony.addNode(node);
+    const result = resultWith("n-remote", [
+      { x: 25, y: 25, roomName: "W1N0" }, { x: 24, y: 25, roomName: "W1N0" }, { x: 26, y: 25, roomName: "W1N0" }
+    ]);
 
     refreshNodeResources(colony, result);
     expect(node.resources.filter((r) => r.type === "source")[0].capacity).to.equal(1500);


### PR DESCRIPTION
## Problem

`refreshNodeResources` values remote sources from two branches:

- **intel branch** (no vision): a reservable remote — controllered, unowned, unreserved, and we can afford a reserver (RCL3+) — has its source lifted to the reserved **3000**, because the ReservationCorp will lift it once we mine it.
- **live-vision branch** (a miner is there): used the raw `source.energyCapacity`, which is **1500** while the remote is unreserved.

So the instant a miner reached a remote and gave us vision, the source's valuation **collapsed 3000 → 1500** — precisely when we'd just committed to it. For a remote that is only worthwhile *reserved*, that discontinuity risks the planner de-prioritizing and thrashing on it right after opening it.

## Fix

Apply the same `couldReserve` lift in the live-vision branch (hoisting `homeCapacity` out of the per-room loop so both branches share it). Owned / already-reserved rooms already read 3000 from `source.energyCapacity`, so this only closes the reservable-but-not-yet-reserved gap; a remote reserved by a rival is correctly left at 1500.

## Validation

- Two new unit tests in `refreshNodeResources.test.ts`: a visible reservable remote stays valued at 3000 (no collapse on vision); a visible remote reserved by a rival stays at 1500.
- Full unit suite green: **386 passing, 0 failing**.
- Integration remote-mining probe: the remote is solidly mined (2 miners, `mining 10/10`) with no thrash across the visibility boundary. Reservation itself lands once the core home economy saturates its haulers (the reserver is a *fresh* income unit that correctly yields to started-but-still-hungry home hauling), so the probe reports rather than asserts reservation timing.

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_