### PR TITLE
Rank the reserver as a started income unit so reserved mining beats plain mining

### DIFF
--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -127,14 +127,23 @@ export function collectDemands(registry: CorpRegistry, spawnId: string, ctx: Spa
     if (c.getSpawnId() !== spawnId) continue;
     for (const d of c.getSpawnDemand(ctx)) {
       // The reserver is INCOME work: it unlocks +5 e/tick on every source in the
-      // remote room it holds (a remote we already mine, so its demand only appears
-      // once that income is underway). Give it a groupId so spawnPriority places it
-      // in the income tier (it already declares producesIncome) - otherwise it sits
-      // at its base value (92), below every income corp AND every blocking consumer,
-      // and is starved forever while the colony ramps, so the remote never gets
-      // reserved and stays at the unreserved half-rate. It is a *fresh* income unit
-      // (not groupStarted), so the core miners/haulers still complete first.
+      // remote room it holds. Give it a groupId so spawnPriority places it in the
+      // income tier (it already declares producesIncome) - otherwise it sits at its
+      // base value (92), below every income corp AND every blocking consumer, and is
+      // starved forever while the colony ramps, so the remote never gets reserved and
+      // stays at the unreserved half-rate.
+      //
+      // It is also groupStarted: the reserver's demand only exists once a miner is
+      // already harvesting that remote (ReservationCorp.targetRooms gates on it), so
+      // the reserved-mining OP is already underway - reserving merely doubles an
+      // already-committed source (infra built, miner fielded). Treating it as a fresh
+      // unit would rank it BELOW opening a brand-new source (1e6+92 < 1e6+100), so the
+      // planner would open new sources before reserving one it already mines - the
+      // opposite of the intent that reserved mining outranks plain mining. As a
+      // started unit it leads all fresh source-opening while still yielding to the
+      // higher-value started haulers that move the base energy.
       d.groupId = c.id;
+      d.groupStarted = true;
       demands.push(d);
     }
   }

--- a/test/unit/spawn/reserverPriority.test.ts
+++ b/test/unit/spawn/reserverPriority.test.ts
@@ -42,9 +42,28 @@ describe("reserver spawn priority (income, not starved)", () => {
     expect(spawnPriority(grouped), "grouped reserver is income-tier").to.be.greaterThan(spawnPriority(blockingUpgrader));
   });
 
-  it("a fresh reserver still ranks below a started income corp (core mining completes first)", () => {
-    const reserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0" });
+  it("a started reserver still yields to a higher-value started hauler (base energy moves first)", () => {
+    // The reserver is groupStarted (its remote is already mined), but within the
+    // started income tier ranking is by value, so a started hauler (100+) that moves
+    // the base energy still outranks the reserver (92). The reserver only doubles the
+    // source the hauler is already emptying, so funding the hauler first is right.
+    const reserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0", groupStarted: true });
     const startedHauler = demand({ role: "hauler", value: 100, producesIncome: true, groupId: "src", groupStarted: true });
     expect(spawnPriority(reserver)).to.be.lessThan(spawnPriority(startedHauler));
+  });
+
+  it("a started reserver outranks opening a brand-new source (reserved mining beats plain mining)", () => {
+    // The headline intent: reserving a remote we ALREADY mine (doubling committed
+    // infrastructure) beats opening a fresh source (+5/tick but needs a new miner,
+    // haulers and road). The reserver's demand only exists once its remote has a
+    // miner, so it is a started unit (1e6+92) and leads any fresh source-opening
+    // miner (1e6+100) - which, as a *fresh* reserver (1e6+92 < 1e6+100), it would not.
+    const startedReserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0", groupStarted: true });
+    const freshMiner = demand({ role: "miner", value: 100, producesIncome: true, groupId: "new-src" });
+    expect(spawnPriority(startedReserver)).to.be.greaterThan(spawnPriority(freshMiner));
+
+    // The contrast that motivates groupStarted: a *fresh* reserver loses to the fresh miner.
+    const freshReserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0" });
+    expect(spawnPriority(freshReserver)).to.be.lessThan(spawnPriority(freshMiner));
   });
 });


### PR DESCRIPTION
## Problem

The reserver's spawn demand only exists once a miner is **already harvesting** the remote (`ReservationCorp.targetRooms` gates on a `workType:"harvest"` creep in the room). So the reserved-mining op is always *underway* when the demand appears — reserving merely **doubles an already-committed source** (infra built, miner fielded).

But `collectDemands` marked the reserver with only a `groupId`, leaving it a **fresh** income unit at `1e6 + 92` — *below even opening a brand-new source* (`1e6 + 100`). So the planner opened brand-new sources before reserving a remote it already mined — the opposite of the intent that reserved mining outranks plain mining — and the reservation bonus landed only very late (past tick 1200 in the probe) or not at all.

## Fix

Mark the reserver `groupStarted` (always accurate — the op is started whenever the demand exists). It now leads all fresh source-opening while still yielding to the higher-value started haulers that move the base energy.

## Validation

- Unit (`reserverPriority.test.ts`): a started reserver outranks a fresh source-opening miner; a *fresh* reserver (the old behavior) loses to it; the reserver still yields to a higher-value started hauler.
- Full unit suite green: **387 passing, 0 failing**.
- **Integration remote-mining probe: reservation now lands ~tick 900** (150 ticks after the first remote miner at ~750), where it previously never landed inside the 1200-tick horizon (`reserved true` from tick 900 on; 2 remote miners by 1200).

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_