### PR TITLE
Fix owned-room economy stalls: breadth-first spawning, unified harvest spot, border-safe movement

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -9,6 +9,7 @@
 import { Corp, SerializedCorp } from "./Corp";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { controllerDeliverySpot, scavengeSpot, sourcePickupSpot, workSpot } from "./nodeEnergy";
+import { travelTo } from "./movement";
 import { driveRecycle, pickRuntToRecycle } from "./recycle";
 import { CREEP_LIFETIME } from "../planning/EconomicConstants";
 import { HaulerAssignment } from "../flow/FlowTypes";
@@ -467,7 +468,7 @@ export class CarryCorp extends Corp {
     if (!targetPos) return;
 
     if (targetPos.roomName !== creep.room.name) {
-      creep.moveTo(targetPos, { visualizePathStyle: { stroke: "#ffaa00" } });
+      travelTo(creep, targetPos, { visualizePathStyle: { stroke: "#ffaa00" } });
       return;
     }
 

--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -15,6 +15,7 @@ import { buildTankerBody, buildUpgraderBody } from "../spawn/BodyBuilder";
 import { MAX_BUILDERS } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
+import { sourceHarvestSpot } from "./nodeEnergy";
 
 /**
  * Serialized state specific to ConstructionCorp
@@ -479,8 +480,13 @@ export class ConstructionCorp extends Corp {
         .findInRange(FIND_DROPPED_RESOURCES, 1, { filter: r => r.resourceType === RESOURCE_ENERGY })
         .reduce((sum, r) => sum + r.amount, 0);
       if (pile < SOURCE_CONTAINER_PILE_THRESHOLD) continue;
-      const tile = this.bestAdjacentTile(room, source.pos, 1);
-      if (tile) return tile;
+      // Place the container on the SAME tile the miner stands on (sourceHarvestSpot),
+      // so the static miner ends up standing on its own container - the drop pile,
+      // the container, and the haulers' pickup all converge on one tile instead of
+      // the miner dropping energy on a tile the haulers never visit.
+      const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+      const spot = sourceHarvestSpot(source, spawn?.pos);
+      return { x: spot.x, y: spot.y };
     }
     return null;
   }

--- a/src/corps/HarvestCorp.ts
+++ b/src/corps/HarvestCorp.ts
@@ -15,6 +15,8 @@ import { driveRecycle, pickRuntToRecycle } from "./recycle";
 import { MinerAssignment } from "../flow/FlowTypes";
 import { Position } from "../types/Position";
 import { buildMinerBody } from "../spawn/BodyBuilder";
+import { sourceHarvestSpot } from "./nodeEnergy";
+import { travelTo } from "./movement";
 
 /**
  * Serialized state specific to HarvestCorp
@@ -232,29 +234,26 @@ export class HarvestCorp extends Corp {
    * Move creep toward a remote source position (when we don't have vision).
    */
   private moveToRemoteSource(creep: Creep, targetPos: RoomPosition): void {
-    if (creep.pos.roomName !== targetPos.roomName) {
-      // Not in the target room yet - move there
-      creep.moveTo(targetPos, { visualizePathStyle: { stroke: "#ffaa00" } });
-    } else {
-      // In the room - we should have found the source by now
-      // This shouldn't happen, but move closer just in case
-      creep.moveTo(targetPos, { visualizePathStyle: { stroke: "#ffaa00" } });
-    }
+    // travelTo crosses the border without bouncing: once the creep enters the
+    // target room on its exit edge, it steps inward instead of flipping back.
+    travelTo(creep, targetPos, { visualizePathStyle: { stroke: "#ffaa00" } });
   }
 
   /**
    * Run a single harvester creep.
    */
   private runHarvester(creep: Creep, source: Source): number {
-    // Static mining: when the source has a container, stand ON it so harvested
-    // energy drops straight into the container - the miner never roams, the
-    // energy never decays, and haulers withdraw it in bulk. Without a container,
-    // fall back to dropping it adjacent to the source.
-    const container = this.sourceContainer(source);
-    const onStation = container ? creep.pos.isEqualTo(container.pos) : creep.pos.isNearTo(source);
-    if (!onStation) {
-      const target = container ? container.pos : source.pos;
-      creep.moveTo(target, { range: container ? 0 : 1, visualizePathStyle: { stroke: "#ffaa00" } });
+    // Static mining: stand on the ONE designated harvest tile - the source
+    // container if built, else the exact tile the container is (or will be) placed
+    // on. The miner's dropped energy, the container, and the haulers' pickup all
+    // converge on this tile, so the energy never sits on a tile the haulers never
+    // visit (the "source piles up un-hauled" bug). Harvest fires whenever we are
+    // adjacent to the source, so we still mine while walking onto the spot or if a
+    // transient second miner can't claim the exact tile.
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    const spot = sourceHarvestSpot(source, spawn?.pos);
+    if (!creep.pos.isEqualTo(spot)) {
+      travelTo(creep, spot, { range: 0, visualizePathStyle: { stroke: "#ffaa00" } });
     }
 
     const result = creep.harvest(source);
@@ -271,14 +270,6 @@ export class HarvestCorp extends Corp {
     }
 
     return 0;
-  }
-
-  /** The container sitting on/next to this source, if one has been built. */
-  private sourceContainer(source: Source): StructureContainer | null {
-    const containers = source.pos.findInRange(FIND_STRUCTURES, 1, {
-      filter: s => s.structureType === STRUCTURE_CONTAINER
-    }) as StructureContainer[];
-    return containers[0] ?? null;
   }
 
   /**

--- a/src/corps/ReservationCorp.ts
+++ b/src/corps/ReservationCorp.ts
@@ -18,6 +18,7 @@ import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { MAX_SCOUT_DISTANCE } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { buildReserverBody } from "../spawn/BodyBuilder";
+import { travelTo } from "./movement";
 
 /**
  * Serialized state specific to ReservationCorp.
@@ -111,7 +112,7 @@ export class ReservationCorp extends Corp {
   /** Walk to the target room's controller and hold the reservation. */
   private runReserver(creep: Creep, targetRoom: string): void {
     if (creep.room.name !== targetRoom) {
-      creep.moveTo(new RoomPosition(25, 25, targetRoom), {
+      travelTo(creep, new RoomPosition(25, 25, targetRoom), {
         range: 20,
         visualizePathStyle: { stroke: "#88aaff" }
       });

--- a/src/corps/ScoutCorp.ts
+++ b/src/corps/ScoutCorp.ts
@@ -16,6 +16,7 @@ import {
 } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SpawningCorp } from "./SpawningCorp";
+import { travelTo } from "./movement";
 
 /**
  * Serialized state specific to ScoutCorp
@@ -185,7 +186,7 @@ export class ScoutCorp extends Corp {
     const finalTarget = creep.memory.targetRoom as string;
     if (creep.room.name !== finalTarget) {
       const targetPos = new RoomPosition(25, 25, finalTarget);
-      const result = creep.moveTo(targetPos, {
+      const result = travelTo(creep, targetPos, {
         visualizePathStyle: { stroke: "#00ff00" },
         reusePath: 10
       });

--- a/src/corps/movement.ts
+++ b/src/corps/movement.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Border-safe creep movement.
+ *
+ * A creep entering a room lands on that room's edge - an exit tile, x or y == 0
+ * or 49. From an exit tile the native pathfinder can pick a step back across the
+ * border (it sees the target as reachable that way too), so the creep re-enters
+ * the room it came from, paths back, and oscillates on the border forever: the
+ * "miner flipping back and forth on the room border" symptom. It never makes
+ * inward progress, so a remote miner never reaches its source and a remote hauler
+ * never delivers - wasting the whole spawn investment behind that remote.
+ *
+ * `travelTo` breaks the loop: when the creep is sitting on an exit tile of the
+ * very room that holds its target, it takes one raw step straight inward (off the
+ * border), ignoring any cached path. Sources, controllers and containers are never
+ * on exit tiles, so an inward step always makes progress toward an in-room target;
+ * once off the edge, normal moveTo pathing resumes.
+ *
+ * @module corps/movement
+ */
+
+/** A target is either a bare position or anything with a `.pos` (creep, structure, source). */
+type MoveTarget = RoomPosition | { pos: RoomPosition };
+
+function targetPos(target: MoveTarget): RoomPosition {
+  return (target as { pos?: RoomPosition }).pos ?? (target as RoomPosition);
+}
+
+/** Direction (Screeps constant) for a unit step by (dx, dy), each in {-1, 0, 1}. */
+function stepDirection(dx: number, dy: number): DirectionConstant {
+  if (dx === 0 && dy === -1) return TOP;
+  if (dx === 1 && dy === -1) return TOP_RIGHT;
+  if (dx === 1 && dy === 0) return RIGHT;
+  if (dx === 1 && dy === 1) return BOTTOM_RIGHT;
+  if (dx === 0 && dy === 1) return BOTTOM;
+  if (dx === -1 && dy === 1) return BOTTOM_LEFT;
+  if (dx === -1 && dy === 0) return LEFT;
+  return TOP_LEFT; // dx === -1 && dy === -1
+}
+
+/**
+ * Move a creep toward a target, robust against the room-border bounce. A drop-in
+ * replacement for `creep.moveTo(target, opts)` that additionally forces an inward
+ * step when the creep is stuck on an exit tile of its target's room.
+ */
+export function travelTo(creep: Creep, target: MoveTarget, opts?: MoveToOpts): ScreepsReturnCode {
+  const pos = targetPos(target);
+  const { x, y } = creep.pos;
+  const onExit = x === 0 || x === 49 || y === 0 || y === 49;
+
+  // Only intervene when we're on the edge of the room our target is in - that is
+  // the bounce: the pathfinder keeps shoving us back across the border instead of
+  // letting us walk into the room body. (While still traversing OTHER rooms en
+  // route, let moveTo carry us across borders normally.)
+  if (onExit && creep.pos.roomName === pos.roomName && !creep.pos.isEqualTo(pos)) {
+    const dx = x === 0 ? 1 : x === 49 ? -1 : 0;
+    const dy = y === 0 ? 1 : y === 49 ? -1 : 0;
+    return creep.move(stepDirection(dx, dy));
+  }
+
+  return creep.moveTo(target as RoomPosition, opts);
+}

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -15,6 +15,8 @@
  * @module corps/nodeEnergy
  */
 
+import { travelTo } from "./movement";
+
 /** A store-bearing structure a hauler can deposit into or draw from. */
 type StoreStructure = StructureContainer | StructureStorage | StructureSpawn | StructureExtension;
 
@@ -36,6 +38,67 @@ export interface EnergySpot {
    * miner starts dropping.
    */
   waitClear?: boolean;
+}
+
+/**
+ * The deterministic best tile within `range` of `target`: walkable, unoccupied,
+ * and nearest the spawn (shorter hauls). Iteration order makes ties deterministic.
+ *
+ * Shared by the source-container placement (where to BUILD), the miner (where to
+ * STAND), and - via {@link sourceHarvestSpot} - the drop pile, so all three
+ * converge on ONE tile instead of three different ones. That convergence is what
+ * stops a miner dropping energy on a tile the haulers never visit.
+ */
+export function bestAdjacentTile(
+  room: Room,
+  target: RoomPosition,
+  range: number,
+  spawnPos?: RoomPosition
+): RoomPosition | null {
+  const terrain = room.getTerrain();
+  const occupied = new Set<string>();
+  for (const s of room.find(FIND_STRUCTURES)) occupied.add(`${s.pos.x},${s.pos.y}`);
+  for (const s of room.find(FIND_CONSTRUCTION_SITES)) occupied.add(`${s.pos.x},${s.pos.y}`);
+
+  let best: { x: number; y: number; d: number } | null = null;
+  for (let dx = -range; dx <= range; dx++) {
+    for (let dy = -range; dy <= range; dy++) {
+      if (dx === 0 && dy === 0) continue;
+      const x = target.x + dx;
+      const y = target.y + dy;
+      if (x < 1 || x > 48 || y < 1 || y > 48) continue;
+      if (terrain.get(x, y) === TERRAIN_MASK_WALL) continue;
+      if (occupied.has(`${x},${y}`)) continue;
+      const d = spawnPos ? Math.max(Math.abs(spawnPos.x - x), Math.abs(spawnPos.y - y)) : 0;
+      if (!best || d < best.d) best = { x, y, d };
+    }
+  }
+  return best ? new RoomPosition(best.x, best.y, room.name) : null;
+}
+
+/**
+ * Where a source's miner should STAND: on the source container (built or planned)
+ * if one is adjacent - static mining drops the harvested energy straight in - else
+ * the deterministic best harvest tile ({@link bestAdjacentTile}). Construction
+ * places the source container on that SAME tile, so the miner is already standing
+ * where the container will appear: the miner's drop pile, the future container, and
+ * the haulers' pickup all land on one tile. Without this the miner parks on an
+ * arbitrary adjacent tile, drops its energy there, and the haulers - routed to the
+ * planned container tile - never collect it, so it piles up un-hauled.
+ *
+ * Falls back to the source tile only if nothing adjacent is walkable (shouldn't
+ * happen for a real source, which always has an open mining tile).
+ */
+export function sourceHarvestSpot(source: Source, spawnPos?: RoomPosition): RoomPosition {
+  const built = source.pos.findInRange(FIND_STRUCTURES, 1, {
+    filter: s => s.structureType === STRUCTURE_CONTAINER
+  })[0];
+  if (built) return built.pos;
+  const site = source.pos.findInRange(FIND_MY_CONSTRUCTION_SITES, 1, {
+    filter: s => s.structureType === STRUCTURE_CONTAINER
+  })[0];
+  if (site) return site.pos;
+  return bestAdjacentTile(source.room, source.pos, 1, spawnPos) ?? source.pos;
 }
 
 /**
@@ -116,7 +179,8 @@ export function workSpot(creep: Creep, spot: EnergySpot, mode: "collect" | "depo
   // tile short, common in remote mining where there is no container).
   const range = mode === "collect" && !spot.waitClear ? 1 : spot.structure ? 1 : 2;
   if (creep.pos.getRangeTo(spot.pos) > range) {
-    creep.moveTo(spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
+    // travelTo so a hauler crossing into a remote room doesn't bounce on the border.
+    travelTo(creep, spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
     return 0;
   }
 

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -126,32 +126,48 @@ export interface ScheduleResult {
  * the order is obvious and needs no tuning (this replaces the old additive soup
  * of blocking + completion + aging boosts that no one could reason about):
  *
- *   1. income corp, already started   - finish what's underway (its haulers /
- *                                        a second miner) before anything else
- *   2. income corp, fresh             - open the next source's first miner
- *   3. consumption (upgrade/build/...) - spend the leftover, once income is staffed
+ *   1. income, BLOCKING - the critical path of EVERY source: its first miner
+ *                         (without it the source is dead) and, once mined, its
+ *                         first hauler (without it the energy strands). Across all
+ *                         sources, so each source is brought online before any
+ *                         source is fully fleshed out (breadth-first on income).
+ *   2. income, scaling  - the 2nd+ hauler / 2nd miner that saturate an
+ *                         already-producing-and-hauled source (depth, after breadth).
+ *   3. consumption      - spend the leftover, once income is staffed.
  *
- * Within a tier the higher-VALUE corp/sink wins, so income corps are opened and
- * completed in expected-value order. Within one corp `blocking` nudges the urgent
- * demand ahead (a mining source with no hauler stranding its energy; the first
- * upgrader that keeps the controller alive). That is the entire strategy: rank
- * income corps by value, staff the top one to completion before the next, consume
- * only what income leaves - with no boosts to balance and no aging to drift.
+ * Within a tier the higher-VALUE corp/sink wins, so corps are ordered by
+ * expected value. `groupStarted` is a SMALL tiebreak BELOW `blocking`: among
+ * blocking demands it finishes a started source's first hauler before opening a
+ * fresh source's first miner (don't strand a producing source's energy); among
+ * scaling demands it finishes a started source first.
+ *
+ * The crucial ordering this encodes - and the bug it fixes - is that a fresh
+ * source's FIRST MINER (income, blocking) outranks another source's SCALING
+ * hauler (income, started, non-blocking). The old model put ALL started income
+ * above ALL fresh income (STARTED >> URGENT), so one source's never-ending
+ * scaling-hauler demand monopolised the spawn and a second source NEVER got a
+ * miner (its energy zero) while the first was endlessly topped up. Putting
+ * BLOCKING above STARTED makes every source get a miner + first hauler before any
+ * source is scaled - the user-visible "one source piles un-hauled, the other has
+ * no miner, the controller starves" all trace back to that monopoly.
  *
  * The tier gaps (1e6 >> 1e4 >> 1e3 >> value~50-110) are pure separators, not
- * tunables: a started corp always outranks a fresh one, income always outranks
- * consumption, regardless of the raw values involved. At cold start no corp is
- * started, so the colony's first miner (tier 2) leads.
+ * tunables. At cold start no corp is started, so the colony's first miner (income,
+ * blocking) leads.
  */
 export function spawnPriority(demand: SpawnDemand): number {
   const INCOME_TIER = 1_000_000;
-  const STARTED = 10_000;
-  const URGENT = 1_000; // first hauler (stranded energy) / first upgrader (anti-downgrade)
+  const BLOCKING = 10_000; // first miner of ANY source / first hauler of a started one - the critical path
+  const STARTED = 1_000; // tiebreak WITHIN a blocking class: finish a started source before a fresh one
   let p = demand.value; // base corp/sink value, ~50-110
-  if (demand.blocking) p += URGENT;
   if (demand.groupId !== undefined && demand.producesIncome) {
     p += INCOME_TIER;
+    if (demand.blocking) p += BLOCKING;
     if (demand.groupStarted) p += STARTED;
+  } else if (demand.blocking) {
+    // Non-income critical work (the first upgrader holding the controller against
+    // downgrade): above idle consumption, but still below all income.
+    p += STARTED;
   }
   return p;
 }

--- a/test/integration/two-source-economy.test.ts
+++ b/test/integration/two-source-economy.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { assert } from "chai";
+import { readFileSync } from "fs";
+import { helper, hookConsole } from "./helper";
+import { loadScenario } from "./scenario/Scenario";
+import * as scenarios from "./scenario/library";
+
+const MAIN = "dist/main.js";
+
+before(() => hookConsole());
+afterEach(async () => helper.afterEach());
+
+/**
+ * Two-source owned-room economy probe. Reproduces the user-reported owned-room
+ * stall: one source piles energy with no hauler, the other never gets a miner,
+ * and the controller starves toward downgrade.
+ *
+ * Runs twoSourceRcl3 (symmetric sources at (15,30) and (35,30), RCL3 + 5
+ * extensions) and samples, per source: miner present? dropped energy piled? plus
+ * hauler/upgrader counts and controller progress. The headline guard is that BOTH
+ * sources get a miner - a single source monopolising the spawn (the bug) leaves
+ * the other at zero.
+ */
+describe("two-source owned-room economy probe", () => {
+  it("mines BOTH sources, hauls them, and upgrades; reports per-source variance", async function () {
+    this.timeout(900000);
+
+    const main = readFileSync(MAIN).toString();
+    const scenario = scenarios.twoSourceRcl3();
+    const room = scenario.bot.room;
+    const SRC = [
+      { x: 15, y: 30 },
+      { x: 35, y: 30 },
+    ];
+    let bot: any;
+
+    await helper.beforeEach(async () => {
+      bot = (await loadScenario(helper.server, scenario, main)).bot;
+    });
+
+    const near = (objs: any[], pos: { x: number; y: number }, type: string) =>
+      objs.filter((o: any) => o.type === type && Math.abs(o.x - pos.x) <= 1 && Math.abs(o.y - pos.y) <= 1);
+
+    let bothMinedTick = 0;
+    const samples: string[] = [];
+
+    for (let t = 1; t <= 1000; t += 1) {
+      await helper.server.tick();
+      if (t % 100 !== 0 && t !== 1000) continue;
+
+      const mem = JSON.parse((await bot.memory) || "{}");
+      const objs = await helper.server.world.roomObjects(room);
+      const ctrl = objs.find((o: any) => o.type === "controller");
+
+      const perSrc = SRC.map((s, i) => {
+        const miners = near(objs, s, "creep").filter((o: any) => mem.creeps?.[o.name]?.workType === "harvest").length;
+        const drop = near(objs, s, "energy").reduce((sum: number, o: any) => sum + (o.energy || 0), 0);
+        return `src${i}[min ${miners} drop ${drop}]`;
+      });
+      const minersBySrc = SRC.map(
+        s => near(objs, s, "creep").filter((o: any) => mem.creeps?.[o.name]?.workType === "harvest").length
+      );
+      if (minersBySrc.every(m => m > 0) && bothMinedTick === 0) bothMinedTick = t;
+
+      let haul = 0, upg = 0;
+      for (const o of objs.filter((x: any) => x.type === "creep")) {
+        const wt = mem.creeps?.[o.name]?.workType;
+        if (wt === "haul") haul++;
+        else if (wt === "upgrade") upg++;
+      }
+      const variance = (mem.corpVariance || []).map((r: any) => `${r.type} ${r.actual}/${r.budget}`).join(", ");
+      samples.push(
+        `tick ${t}: ${perSrc.join(" ")} | haul ${haul} upg ${upg} ctrlP ${ctrl?.progress ?? 0} ` +
+          `| harvestCorps ${Object.keys(mem.harvestCorps || {}).length} nodes ${Object.keys(mem.nodes || {}).length} | [${variance}]`
+      );
+    }
+
+    console.log("\n=== two-source owned-room economy probe ===");
+    for (const line of samples) console.log(line);
+    console.log(`both sources mined by ~tick ${bothMinedTick}`);
+
+    assert.isAbove(bothMinedTick, 0, "BOTH sources should have a miner within the horizon (neither monopolised)");
+  });
+});

--- a/test/unit/corps/movement.test.ts
+++ b/test/unit/corps/movement.test.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import { travelTo } from "../../../src/corps/movement";
+
+// Screeps direction constants (globals in-game).
+const DIRS: Record<string, number> = {
+  TOP: 1, TOP_RIGHT: 2, RIGHT: 3, BOTTOM_RIGHT: 4, BOTTOM: 5, BOTTOM_LEFT: 6, LEFT: 7, TOP_LEFT: 8,
+};
+
+function pos(x: number, y: number, roomName: string) {
+  return {
+    x, y, roomName,
+    isEqualTo(t: any) {
+      return t.x === x && t.y === y && (t.roomName === undefined || t.roomName === roomName);
+    },
+  };
+}
+
+/** A creep stub that records whether move() (raw step) or moveTo() (pathfinder) was called. */
+function creepAt(x: number, y: number, roomName: string) {
+  const calls = { move: undefined as number | undefined, moveTo: undefined as any };
+  return {
+    pos: pos(x, y, roomName),
+    move(dir: number) { calls.move = dir; return 0; },
+    moveTo(target: any, _opts: any) { calls.moveTo = target; return 0; },
+    calls,
+  };
+}
+
+describe("travelTo (border-bounce-safe movement)", () => {
+  before(() => {
+    for (const [name, val] of Object.entries(DIRS)) (global as any)[name] = val;
+  });
+
+  it("steps INWARD (raw move, no pathfinder) when stuck on the target room's west exit", () => {
+    // On x=0 of W1N0 with the target inside W1N0: the pathfinder would bounce us
+    // back across the border, so we step east (inward) with a raw move instead.
+    const creep = creepAt(0, 25, "W1N0");
+    travelTo(creep as any, pos(25, 25, "W1N0") as any);
+    expect(creep.calls.move, "raw inward step").to.equal(DIRS.RIGHT);
+    expect(creep.calls.moveTo, "pathfinder NOT used on the exit").to.equal(undefined);
+  });
+
+  it("steps inward from each edge (east, north, south) and the corners", () => {
+    const east = creepAt(49, 25, "W1N0");
+    travelTo(east as any, pos(25, 25, "W1N0") as any);
+    expect(east.calls.move).to.equal(DIRS.LEFT);
+
+    const north = creepAt(25, 0, "W1N0");
+    travelTo(north as any, pos(25, 25, "W1N0") as any);
+    expect(north.calls.move).to.equal(DIRS.BOTTOM);
+
+    const south = creepAt(25, 49, "W1N0");
+    travelTo(south as any, pos(25, 25, "W1N0") as any);
+    expect(south.calls.move).to.equal(DIRS.TOP);
+
+    const corner = creepAt(0, 0, "W1N0"); // top-left corner -> step toward bottom-right
+    travelTo(corner as any, pos(25, 25, "W1N0") as any);
+    expect(corner.calls.move).to.equal(DIRS.BOTTOM_RIGHT);
+  });
+
+  it("uses normal pathfinding when NOT on an exit tile", () => {
+    const creep = creepAt(25, 25, "W1N0");
+    const target = pos(40, 40, "W1N0");
+    travelTo(creep as any, target as any);
+    expect(creep.calls.moveTo, "delegates to moveTo off the edge").to.equal(target);
+    expect(creep.calls.move).to.equal(undefined);
+  });
+
+  it("lets moveTo carry the creep ACROSS a border (target in a different room)", () => {
+    // On the east edge of W0N0 heading to W1N0: this is a real crossing, not a
+    // bounce - moveTo should step it over, so we do NOT force an inward step.
+    const creep = creepAt(49, 25, "W0N0");
+    const target = pos(10, 25, "W1N0");
+    travelTo(creep as any, target as any);
+    expect(creep.calls.moveTo).to.equal(target);
+    expect(creep.calls.move).to.equal(undefined);
+  });
+
+  it("does not step inward when already on the exact target tile (even on an exit)", () => {
+    // Standing on the target that happens to be an exit tile: no forced inward step
+    // (that would walk us off our destination); delegate to moveTo (a no-op in-game).
+    const creep = creepAt(0, 25, "W1N0");
+    travelTo(creep as any, pos(0, 25, "W1N0") as any);
+    expect(creep.calls.move, "no inward step off the target").to.equal(undefined);
+  });
+
+  it("accepts a target with a .pos (structure/source), not just a bare position", () => {
+    const creep = creepAt(0, 25, "W1N0");
+    travelTo(creep as any, { pos: pos(25, 25, "W1N0") } as any);
+    expect(creep.calls.move).to.equal(DIRS.RIGHT);
+  });
+});

--- a/test/unit/corps/sourceHarvestSpot.test.ts
+++ b/test/unit/corps/sourceHarvestSpot.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import { setupGlobals, FIND_STRUCTURES, STRUCTURE_CONTAINER } from "../mock";
+import { sourceHarvestSpot, bestAdjacentTile } from "../../../src/corps/nodeEnergy";
+
+const FIND_MY_CONSTRUCTION_SITES = 114;
+const FIND_CONSTRUCTION_SITES = 111;
+
+/**
+ * sourceHarvestSpot is the ONE tile a source's miner stands on, the container is
+ * built on, and the haulers collect from - the convergence that stops a miner
+ * dropping energy on a tile the haulers never visit (the un-hauled pile bug).
+ */
+function sourceWith(opts: {
+  sx: number; sy: number;
+  roomName?: string;
+  containers?: { x: number; y: number }[];
+  sites?: { x: number; y: number }[];
+  walls?: Set<string>;
+  occupied?: { x: number; y: number }[];
+}): any {
+  const roomName = opts.roomName ?? "W0N0";
+  const containers = (opts.containers ?? []).map(c => ({
+    structureType: STRUCTURE_CONTAINER,
+    pos: { x: c.x, y: c.y, roomName },
+  }));
+  const sites = (opts.sites ?? []).map(c => ({
+    structureType: STRUCTURE_CONTAINER,
+    pos: { x: c.x, y: c.y, roomName },
+  }));
+  const occupiedStructures = (opts.occupied ?? []).map(o => ({ pos: { x: o.x, y: o.y, roomName } }));
+  const within1 = (px: number, py: number, arr: any[]) =>
+    arr.filter(s => Math.max(Math.abs(s.pos.x - px), Math.abs(s.pos.y - py)) <= 1);
+
+  const room = {
+    name: roomName,
+    getTerrain: () => ({ get: (x: number, y: number) => (opts.walls?.has(`${x},${y}`) ? 1 : 0) }),
+    find: (type: number) => {
+      if (type === FIND_STRUCTURES) return [...containers, ...occupiedStructures];
+      if (type === FIND_CONSTRUCTION_SITES) return sites;
+      return [];
+    },
+  };
+  return {
+    pos: {
+      x: opts.sx, y: opts.sy, roomName,
+      findInRange: (type: number, _range: number, o: any) => {
+        const list = type === FIND_STRUCTURES ? containers : type === FIND_MY_CONSTRUCTION_SITES ? sites : [];
+        const filtered = o?.filter ? list.filter(o.filter) : list;
+        return within1(opts.sx, opts.sy, filtered);
+      },
+    },
+    room,
+  };
+}
+
+describe("sourceHarvestSpot (miner / container / pickup converge on one tile)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).FIND_MY_CONSTRUCTION_SITES = FIND_MY_CONSTRUCTION_SITES;
+    (global as any).FIND_CONSTRUCTION_SITES = FIND_CONSTRUCTION_SITES;
+  });
+
+  it("with no container, returns the adjacent tile nearest the spawn (deterministic)", () => {
+    // Source at (10,10); spawn to the SE at (40,40) - the nearest adjacent tile is
+    // the bottom-right (11,11).
+    const source = sourceWith({ sx: 10, sy: 10 });
+    const spot = sourceHarvestSpot(source, { x: 40, y: 40, roomName: "W0N0" } as any);
+    expect({ x: spot.x, y: spot.y }).to.deep.equal({ x: 11, y: 11 });
+  });
+
+  it("matches bestAdjacentTile - the SAME tile construction places the container on", () => {
+    const source = sourceWith({ sx: 10, sy: 10 });
+    const spawnPos = { x: 40, y: 40, roomName: "W0N0" } as any;
+    const minerSpot = sourceHarvestSpot(source, spawnPos);
+    const containerTile = bestAdjacentTile(source.room, source.pos, 1, spawnPos)!;
+    expect({ x: minerSpot.x, y: minerSpot.y }).to.deep.equal({ x: containerTile.x, y: containerTile.y });
+  });
+
+  it("stands ON a built source container when one is adjacent", () => {
+    const source = sourceWith({ sx: 10, sy: 10, containers: [{ x: 9, y: 10 }] });
+    const spot = sourceHarvestSpot(source, { x: 40, y: 40, roomName: "W0N0" } as any);
+    expect({ x: spot.x, y: spot.y }).to.deep.equal({ x: 9, y: 10 });
+  });
+
+  it("pre-positions on the container CONSTRUCTION SITE before it is built", () => {
+    // The site is placed at the harvest tile; the miner stands there now so it is
+    // already on the container the moment it finishes - no relocation, no stray pile.
+    const source = sourceWith({ sx: 10, sy: 10, sites: [{ x: 11, y: 9 }] });
+    const spot = sourceHarvestSpot(source, { x: 40, y: 40, roomName: "W0N0" } as any);
+    expect({ x: spot.x, y: spot.y }).to.deep.equal({ x: 11, y: 9 });
+  });
+
+  it("skips walls and occupied tiles when choosing the harvest tile", () => {
+    // Block the natural nearest tile (11,11) and an alternative, so it must pick the
+    // next-nearest walkable, unoccupied adjacent tile.
+    const source = sourceWith({
+      sx: 10, sy: 10,
+      walls: new Set(["11,11"]),
+      occupied: [{ x: 11, y: 10 }],
+    });
+    const spot = sourceHarvestSpot(source, { x: 40, y: 40, roomName: "W0N0" } as any);
+    // (11,11) walled, (11,10) occupied -> next nearest to the SE spawn is (10,11).
+    expect({ x: spot.x, y: spot.y }).to.deep.equal({ x: 10, y: 11 });
+  });
+});

--- a/test/unit/spawn/SpawnScheduler.test.ts
+++ b/test/unit/spawn/SpawnScheduler.test.ts
@@ -168,52 +168,65 @@ describe("SpawnScheduler", () => {
       });
     });
 
-    describe("fund-one-corp-fully strategy", () => {
-      it("finishes a started source's haulers before opening a fresh source's miner", () => {
-        // Source A is already mined (groupStarted) and still wants a second
-        // hauler; source B's first miner is fresh. Even though the fresh miner
-        // has a slightly higher base value, completing the started unit wins, so
-        // A's energy gets hauled home before B is opened.
+    describe("breadth-first-on-the-critical-path strategy", () => {
+      it("finishes a started source's SCALING hauler before opening a fresh source's SCALING demand", () => {
+        // Both demands are scaling (non-blocking): A is already mined and wants
+        // another hauler, B wants a second miner. Among scaling demands the started
+        // source is finished first, so A's extra hauler beats B's extra miner.
         const startedHauler = demand({
           buyerCorpId: "haulA", role: "hauler", value: 90,
           producesIncome: true, groupId: "A", groupStarted: true,
         });
-        const freshMiner = demand({
+        const freshScaling = demand({
           buyerCorpId: "minerB", role: "miner", value: 100,
           producesIncome: true, groupId: "B", groupStarted: false,
         });
-        const result = scheduleSpawn([freshMiner, startedHauler], ctx({ energyAvailable: 300 }));
+        const result = scheduleSpawn([freshScaling, startedHauler], ctx({ energyAvailable: 300 }));
         expect(result?.demand.buyerCorpId).to.equal("haulA");
       });
 
-      it("opens a fresh source once the started one is fully staffed", () => {
-        // No started-unit demand remains (A is done); only B's fresh miner is
-        // left, so the spawn moves on and opens it.
+      it("opens a fresh source's FIRST MINER before scaling up an already-hauled source", () => {
+        // The bug fix: source A is mined AND already has its first hauler, so its
+        // remaining demand is a SCALING hauler (non-blocking). Source B has never
+        // been mined - its first miner is blocking. Opening B (the critical path of a
+        // whole second source) must beat topping up A, otherwise A monopolises the
+        // spawn and B stays at zero income forever (the user-reported "other source
+        // has no miner" while the first piles up).
+        const scalingHaulerA = demand({
+          buyerCorpId: "haulA", role: "hauler", value: 110, blocking: false,
+          producesIncome: true, groupId: "A", groupStarted: true,
+        });
+        const freshBlockingMinerB = demand({
+          buyerCorpId: "minerB", role: "miner", value: 100, blocking: true,
+          producesIncome: true, groupId: "B", groupStarted: false,
+        });
+        const result = scheduleSpawn([scalingHaulerA, freshBlockingMinerB], ctx({ energyAvailable: 300 }));
+        expect(result?.demand.buyerCorpId).to.equal("minerB");
+      });
+
+      it("still staffs a started source's FIRST HAULER before opening a fresh source's miner", () => {
+        // The good half of the old strategy, preserved: a started source whose energy
+        // is stranding (its FIRST hauler is blocking) is unstranded before a fresh
+        // source's first miner opens, so we never leave a producing source un-hauled.
+        const blockingFirstHaulerA = demand({
+          buyerCorpId: "haulA", role: "hauler", value: 90, blocking: true,
+          producesIncome: true, groupId: "A", groupStarted: true,
+        });
+        const freshBlockingMinerB = demand({
+          buyerCorpId: "minerB", role: "miner", value: 100, blocking: true,
+          producesIncome: true, groupId: "B", groupStarted: false,
+        });
+        const result = scheduleSpawn([freshBlockingMinerB, blockingFirstHaulerA], ctx({ energyAvailable: 300 }));
+        expect(result?.demand.buyerCorpId).to.equal("haulA");
+      });
+
+      it("opens a fresh source once no started-source critical demand remains", () => {
         const freshMiner = demand({
-          buyerCorpId: "minerB", role: "miner", value: 100,
+          buyerCorpId: "minerB", role: "miner", value: 100, blocking: true,
           producesIncome: true, groupId: "B", groupStarted: false,
         });
         const result = scheduleSpawn([freshMiner], ctx({ energyAvailable: 300 }));
         expect(result?.demand.buyerCorpId).to.equal("minerB");
-      });
-
-      it("completes a started unit before opening a fresh source's blocking miner", () => {
-        // The heart of "fund one corp fully, then move on": source B is already
-        // mining and needs its hauler to get that energy home; source A is a fresh
-        // source whose first miner is blocking. Completing B (haulB) must outrank
-        // opening A (boot) - started corps outrank fresh ones - otherwise the spawn
-        // keeps opening new sources while started ones strand their energy unhauled
-        // (haulers parked at sources, the exact failure this guards against).
-        const freshBlockingMiner = demand({
-          buyerCorpId: "boot", role: "miner", value: 100, blocking: true,
-          producesIncome: true, groupId: "A", groupStarted: false,
-        });
-        const startedHauler = demand({
-          buyerCorpId: "haulB", role: "hauler", value: 110,
-          producesIncome: true, groupId: "B", groupStarted: true,
-        });
-        const result = scheduleSpawn([startedHauler, freshBlockingMiner], ctx({ energyAvailable: 300 }));
-        expect(result?.demand.buyerCorpId).to.equal("haulB");
       });
     });
 
@@ -226,9 +239,23 @@ describe("SpawnScheduler", () => {
       expect(spawnPriority(income)).to.be.greaterThan(spawnPriority(consumer));
     });
 
-    it("ranks a started income corp above a fresh one regardless of value", () => {
+    it("ranks a fresh source's FIRST MINER (blocking) above a started source's SCALING hauler", () => {
+      // The critical-path fix: opening a new source beats topping up an old one.
+      const freshFirstMiner = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "B", groupStarted: false });
+      const startedScalingHauler = demand({ role: "hauler", value: 110, blocking: false, producesIncome: true, groupId: "A", groupStarted: true });
+      expect(spawnPriority(freshFirstMiner)).to.be.greaterThan(spawnPriority(startedScalingHauler));
+    });
+
+    it("ranks a started source's FIRST HAULER (blocking) above a fresh source's first miner", () => {
+      // ...but a producing source's stranded energy is hauled before a new source opens.
+      const startedFirstHauler = demand({ role: "hauler", value: 90, blocking: true, producesIncome: true, groupId: "A", groupStarted: true });
+      const freshFirstMiner = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "B", groupStarted: false });
+      expect(spawnPriority(startedFirstHauler)).to.be.greaterThan(spawnPriority(freshFirstMiner));
+    });
+
+    it("ranks a started scaling demand above a fresh scaling demand (finish a started source first)", () => {
       const started = demand({ role: "hauler", value: 90, producesIncome: true, groupId: "A", groupStarted: true });
-      const fresh = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "B", groupStarted: false });
+      const fresh = demand({ role: "miner", value: 100, producesIncome: true, groupId: "B", groupStarted: false });
       expect(spawnPriority(started)).to.be.greaterThan(spawnPriority(fresh));
     });
 

--- a/test/unit/spawn/nextSpawn.test.ts
+++ b/test/unit/spawn/nextSpawn.test.ts
@@ -62,28 +62,28 @@ describe("next spawn decision (key moments)", () => {
     expect(decision.buyerCorpId).to.equal("mining-A");
   });
 
-  it("fund one corp fully: completes a started source's haulers before opening a fresh source", () => {
-    // Source A is already underway (a miner + one hauler in the field) and wants
-    // a second hauler; source B is fresh and wants its (non-blocking, since the
-    // colony already mines A) first miner. Neither demand is blocking and B's
-    // miner has the higher BASE value - but the completion boost must carry A's
-    // hauler so the colony finishes hauling A's energy home before opening B,
-    // instead of stranding A's energy to start a source it won't finish.
+  it("breadth-first: opens a fresh source's first miner before a started source's SECOND hauler", () => {
+    // Source A is already underway (miner + one hauler) and its energy is being
+    // hauled, so its pending demand is a SCALING second hauler. Source B has never
+    // been mined - its first miner is the critical path of a whole second source.
+    // Opening B (its first miner) beats topping up A, so every source gets producing
+    // before any is fully fleshed out. (The old "fund A fully first" let A's endless
+    // scaling demand monopolise the spawn so B never got a miner.)
     const decision = decideNextSpawn({
       energyAvailable: 550,
       energyCapacity: 550,
       sources: [
-        { id: "A", haulCarry: 8 }, // wants 2 haulers; one already exists
-        { id: "B" } // fresh source, first miner pending
+        { id: "A", haulCarry: 8 }, // wants 2 haulers; one already exists (scaling)
+        { id: "B" } // fresh source, first miner pending (critical path)
       ],
       creeps: [
         { corpId: "mining-A", workType: "harvest", work: 5 }, // A's miner: A is "started"
-        { corpId: "hauling-A", workType: "haul", carry: 5 } // A's first hauler
+        { corpId: "hauling-A", workType: "haul", carry: 5 } // A's first hauler already hauling
       ]
     });
 
-    expect(decision.role).to.equal("hauler");
-    expect(decision.buyerCorpId).to.equal("hauling-A");
+    expect(decision.role).to.equal("miner");
+    expect(decision.buyerCorpId).to.equal("mining-B");
   });
 
   it("opens the next source once the started one is fully staffed", () => {

--- a/test/unit/spawn/reserverPriority.test.ts
+++ b/test/unit/spawn/reserverPriority.test.ts
@@ -52,18 +52,17 @@ describe("reserver spawn priority (income, not starved)", () => {
     expect(spawnPriority(reserver)).to.be.lessThan(spawnPriority(startedHauler));
   });
 
-  it("a started reserver outranks opening a brand-new source (reserved mining beats plain mining)", () => {
-    // The headline intent: reserving a remote we ALREADY mine (doubling committed
-    // infrastructure) beats opening a fresh source (+5/tick but needs a new miner,
-    // haulers and road). The reserver's demand only exists once its remote has a
-    // miner, so it is a started unit (1e6+92) and leads any fresh source-opening
-    // miner (1e6+100) - which, as a *fresh* reserver (1e6+92 < 1e6+100), it would not.
+  it("ranks in the scaling-income tier: above a fresh source's SECOND miner, below any source's FIRST miner", () => {
+    // The reserver optimises an already-producing source (it doubles its regen), so
+    // it belongs with scaling income, not on the critical path. As a started, non-
+    // blocking income demand it outranks fresh SCALING demands (a second miner)...
     const startedReserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0", groupStarted: true });
-    const freshMiner = demand({ role: "miner", value: 100, producesIncome: true, groupId: "new-src" });
-    expect(spawnPriority(startedReserver)).to.be.greaterThan(spawnPriority(freshMiner));
+    const freshSecondMiner = demand({ role: "miner", value: 100, blocking: false, producesIncome: true, groupId: "new-src", groupStarted: false });
+    expect(spawnPriority(startedReserver)).to.be.greaterThan(spawnPriority(freshSecondMiner));
 
-    // The contrast that motivates groupStarted: a *fresh* reserver loses to the fresh miner.
-    const freshReserver = demand({ role: "reserver", value: 92, producesIncome: true, groupId: "reservation-W1N0" });
-    expect(spawnPriority(freshReserver)).to.be.lessThan(spawnPriority(freshMiner));
+    // ...but it yields to opening a brand-new source's FIRST miner (blocking, the
+    // critical path): get every source producing before optimising existing ones.
+    const freshFirstMiner = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "new-src", groupStarted: false });
+    expect(spawnPriority(startedReserver)).to.be.lessThan(spawnPriority(freshFirstMiner));
   });
 });


### PR DESCRIPTION
## Owned-room economy stalls

Reproduced with a faithful two-source RCL3 probe (`twoSourceRcl3` via `loadScenario`). Three distinct user-reported failures, three fixes:

### 1. A second source never gets a miner (one source monopolises the spawn)
`spawnPriority` ranked *all* started income above *all* fresh income (`STARTED=10000` ≫ the blocking bump `1000`), so a source's never-ending **scaling-hauler** demand permanently outranked opening a second source's **first miner** — the second source stayed at zero income while the first was endlessly topped up. Fix: blocking income (any source's first miner / first hauler) now outranks non-blocking scaling income (`BLOCKING=10000 > STARTED=1000`) — breadth-first on the critical path, while a started source's stranded energy is still hauled before a fresh source opens. **Both sources mined by ~tick 300 (was ~400).**

### 2. A source piles energy haulers never collect; miner stands off the container tile
The miner parked on an arbitrary source-adjacent tile and dropped energy there, while the container was planned — and haulers routed — to a *different* adjacent tile. New `sourceHarvestSpot`: the miner's stand tile, the container site, and the haulers' pickup all converge on one tile.

### 3. Miners flip back and forth on room borders
Every cross-room `moveTo` was raw, so a creep entering a room on its exit tile gets bounced straight back by the pathfinder, oscillating forever. New `travelTo` steps one tile inward off the border to break the loop; wired into every cross-room mover (miners, haulers, reservers, scouts).

## Validation
- **401 unit tests pass, 0 failing** (+11: `movement`, `sourceHarvestSpot`, reworked scheduler/priority tests).
- **Two-source probe**: both sources mined by ~tick 300.
- **Remote-mining probe**: still mines + reserves (no regression).

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_