### PR TITLE
Depot + extension tender (local mover): fix hauler schooling across extensions

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -44,6 +44,14 @@ export type LocalSink = "spawn" | "controller";
 const SPAWN_PRIORITY_FREE_CAPACITY = 50;
 
 /**
+ * Small energy buffer kept in the core depot so the extension tender always has a
+ * load on hand. Deliberately modest: it only needs to bridge between hauler drop-offs,
+ * not bankroll the whole network - a large buffer would pull haulers off the
+ * controller to keep refilling the depot (the energy split is the flow solver's job).
+ */
+const DEPOT_BUFFER = 150;
+
+/**
  * Fill fraction at which a dedicated build source's container is judged to be
  * "backing up": the builder isn't draining the source's full output (a runt
  * builder, or no active consumption), so the energy just accumulates in the
@@ -540,6 +548,22 @@ export class CarryCorp extends Corp {
 
   /** Free energy capacity across the spawn network is worth a hauler's divert. */
   private spawnNetworkHungry(room: Room): boolean {
+    // When the tender owns the extensions, haulers are responsible only for the
+    // SPAWN structure itself - so judge hunger by the spawn alone. Counting the
+    // extensions here (which the tender fills, slower than haulers used to) would
+    // keep the network looking perpetually hungry and divert EVERY controller-bound
+    // hauler to the spawn, starving the controller.
+    if (room.memory.extensionTenderActive) {
+      const spawn = room.find(FIND_MY_SPAWNS)[0];
+      if ((spawn?.store.getFreeCapacity(RESOURCE_ENERGY) ?? 0) >= SPAWN_PRIORITY_FREE_CAPACITY) return true;
+      // The depot is the tender's reserve. Keep only a SMALL buffer there: divert a
+      // hauler when it's nearly empty so the tender never starves, but no more - a
+      // big reserve would make haulers refill the depot constantly and starve the
+      // controller (the total energy is fixed and the flow solver already split it).
+      // Once the buffer is met, haulers go back to feeding the controller.
+      const depot = this.coreDepot(room);
+      return !!depot && depot.store[RESOURCE_ENERGY] < DEPOT_BUFFER;
+    }
     const free = this.getSpawnZoneStructures(room).reduce(
       (sum, s) => sum + s.store.getFreeCapacity(RESOURCE_ENERGY),
       0

--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -587,6 +587,17 @@ export class CarryCorp extends Corp {
     creep.memory.homeSink = pickSinkByAllocation(this.haulerAssignments, committed);
   }
 
+  /** The core depot: a container adjacent to one of the room's spawns, if built. */
+  private coreDepot(room: Room): StructureContainer | null {
+    for (const spawn of room.find(FIND_MY_SPAWNS)) {
+      const c = spawn.pos.findInRange(FIND_STRUCTURES, 1, {
+        filter: s => s.structureType === STRUCTURE_CONTAINER
+      })[0] as StructureContainer | undefined;
+      if (c) return c;
+    }
+    return null;
+  }
+
   /** Attempt delivery to a specific local sink; returns true if it took action. */
   private tryDeliverTo(creep: Creep, room: Room, sink: LocalSink): boolean {
     if (sink === "controller") return this.deliverToController(creep, room);
@@ -598,6 +609,27 @@ export class CarryCorp extends Corp {
    * Returns false when there is no spawn structure that needs energy.
    */
   private deliverToSpawn(creep: Creep, room: Room): boolean {
+    // When the extension tender is active, haulers run the dumb source->depot bus:
+    // keep the spawn STRUCTURE itself topped (one tile, no fanning across extensions)
+    // so a dead tender can never deadlock the colony, then dump everything else into
+    // the depot for the tender to distribute. This is what stops the schooling - the
+    // haulers no longer chase a dozen half-full extensions.
+    if (room.memory.extensionTenderActive) {
+      const spawnNeedsEnergy = room
+        .find(FIND_MY_SPAWNS)
+        .find(s => s.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+      const depot = this.coreDepot(room);
+      const target: StructureSpawn | StructureContainer | undefined =
+        spawnNeedsEnergy ?? (depot && depot.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? depot : undefined);
+      if (target) {
+        const r = creep.transfer(target, RESOURCE_ENERGY);
+        if (r === ERR_NOT_IN_RANGE) travelTo(creep, target, { visualizePathStyle: { stroke: "#ffffff" } });
+        else if (r === OK) this.recordProduction(Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY)));
+        return true;
+      }
+      // Spawn and depot both full: fall through to help the wider network this once.
+    }
+
     const allSpawnStructures = this.getSpawnZoneStructures(room);
     if (allSpawnStructures.length === 0) return false;
 

--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -643,15 +643,19 @@ export class CarryCorp extends Corp {
         .find(FIND_MY_SPAWNS)
         .find(s => s.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
       const depot = this.coreDepot(room);
+      // Fill the spawn structure first (keep it alive), then top the depot only to
+      // its small buffer. Crucially, once both are satisfied we return FALSE rather
+      // than dumping more into the (2000-cap, never-full) depot - that lets
+      // deliverEnergy spill the surplus to the controller, exactly as it did in the
+      // pre-depot model when the spawn network filled up. Without this the depot
+      // soaks up every spare load and the controller starves.
       const target: StructureSpawn | StructureContainer | undefined =
-        spawnNeedsEnergy ?? (depot && depot.store.getFreeCapacity(RESOURCE_ENERGY) > 0 ? depot : undefined);
-      if (target) {
-        const r = creep.transfer(target, RESOURCE_ENERGY);
-        if (r === ERR_NOT_IN_RANGE) travelTo(creep, target, { visualizePathStyle: { stroke: "#ffffff" } });
-        else if (r === OK) this.recordProduction(Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY)));
-        return true;
-      }
-      // Spawn and depot both full: fall through to help the wider network this once.
+        spawnNeedsEnergy ?? (depot && depot.store[RESOURCE_ENERGY] < DEPOT_BUFFER ? depot : undefined);
+      if (!target) return false;
+      const r = creep.transfer(target, RESOURCE_ENERGY);
+      if (r === ERR_NOT_IN_RANGE) travelTo(creep, target, { visualizePathStyle: { stroke: "#ffffff" } });
+      else if (r === OK) this.recordProduction(Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY)));
+      return true;
     }
 
     const allSpawnStructures = this.getSpawnZoneStructures(room);

--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -16,7 +16,7 @@ import { pickRepairTarget, wantsMaintenanceBuilder, REPAIR_TO } from "./repair";
 import { MAX_BUILDERS } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
-import { sourceHarvestSpot } from "./nodeEnergy";
+import { bestAdjacentTile, sourceHarvestSpot } from "./nodeEnergy";
 
 /**
  * Serialized state specific to ConstructionCorp
@@ -189,7 +189,9 @@ export class ConstructionCorp extends Corp {
 
     const wantsContainer =
       rcl >= CONTAINER_MIN_RCL &&
-      (this.findMissingSourceContainer(room) !== null || this.findMissingControllerContainer(room) !== null);
+      (this.findMissingSourceContainer(room) !== null ||
+        this.findMissingCoreDepot(room) !== null ||
+        this.findMissingControllerContainer(room) !== null);
     const canBuildMore = activeSites === 0 && (currentExtensions < maxExtensions || wantsContainer);
 
     if (canBuildMore) {
@@ -428,6 +430,18 @@ export class ConstructionCorp extends Corp {
       }
     }
 
+    // 1.5 Core depot: a container beside the spawn. Haulers dump into it and the
+    //     extension tender drains it to fill the extensions - the split that keeps
+    //     the long-range haulers off the extensions (no schooling). Comes right
+    //     after source containers so the tender has somewhere to draw from early.
+    if (rcl >= CONTAINER_MIN_RCL) {
+      const depot = this.findMissingCoreDepot(room);
+      if (depot) {
+        this.placeSite(room, depot.x, depot.y, STRUCTURE_CONTAINER, 0);
+        return;
+      }
+    }
+
     // 2. Extensions: cheap (3000), near the sources, and they compound spawn
     //    capacity (bigger creeps) - so they come BEFORE the far controller
     //    container. Building the controller container first (it sits ~20 tiles
@@ -459,6 +473,21 @@ export class ConstructionCorp extends Corp {
     } else {
       console.log(`[Construction] Failed to place ${type} at (${x}, ${y}): ${result}`);
     }
+  }
+
+  /**
+   * The core depot: a container tile beside the spawn (the haulers' drop-off and
+   * the extension tender's draw point). Null when one already exists adjacent to a
+   * spawn (a source container next to the spawn doubles as the depot) or the room
+   * is at its container cap.
+   */
+  private findMissingCoreDepot(room: Room): { x: number; y: number } | null {
+    if (this.containerBudgetFull(room)) return null;
+    const spawn = room.find(FIND_MY_SPAWNS)[0];
+    if (!spawn) return null;
+    if (this.hasContainerNear(room, spawn.pos, 1)) return null;
+    const tile = bestAdjacentTile(room, spawn.pos, 1, spawn.pos);
+    return tile ? { x: tile.x, y: tile.y } : null;
   }
 
   /**

--- a/src/corps/Corp.ts
+++ b/src/corps/Corp.ts
@@ -13,7 +13,8 @@ export type CorpType =
   | "building"
   | "bootstrap"
   | "scout"
-  | "reservation";
+  | "reservation"
+  | "moving";
 
 /**
  * Serialized corp state for persistence

--- a/src/corps/ExtensionTenderCorp.ts
+++ b/src/corps/ExtensionTenderCorp.ts
@@ -60,6 +60,21 @@ export class ExtensionTenderCorp extends Corp {
     return this.getTenders().length;
   }
 
+  /** True once a flow miner is producing in the room (income before infrastructure). */
+  private roomHasMiner(room: Room): boolean {
+    for (const name in Game.creeps) {
+      const c = Game.creeps[name];
+      if (
+        c.room.name === room.name &&
+        c.memory.workType === "harvest" &&
+        (c.memory.corpId ?? "").startsWith("mining-")
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * The core depot: a container adjacent to one of the room's spawns. This is the
    * one structure haulers dump into and the tender draws from. Null until built.
@@ -146,10 +161,13 @@ export class ExtensionTenderCorp extends Corp {
 
   /**
    * Demand one oversized tender once a depot exists and there are extensions to
-   * keep filled. The FIRST tender is blocking: without it the extensions (which
-   * the haulers no longer fill) would never charge, leaving the room stuck at the
-   * bare spawn's 300 capacity. Sized to refill the whole extension set in ~one
-   * trip (a bit oversized, since it works in bursts).
+   * keep filled. NON-blocking: it is infrastructure (it tops the topmost
+   * consumption tier, above building/upgrading), not core income, so it must not
+   * hold the spawn ahead of the miners/haulers that produce the energy it moves -
+   * until it spawns, room.memory.extensionTenderActive stays false and the haulers
+   * keep filling the extensions themselves, so nothing is starved in the meantime.
+   * Sized to refill the whole extension set in ~one trip (a bit oversized, since it
+   * works in bursts).
    */
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
@@ -159,6 +177,10 @@ export class ExtensionTenderCorp extends Corp {
 
     const extensions = room.find(FIND_MY_STRUCTURES, { filter: s => s.structureType === STRUCTURE_EXTENSION });
     if (extensions.length === 0) return [];
+
+    // Infrastructure follows income: don't spawn a tender before the room has a
+    // miner, or it takes the first spawn slot and delays the economy it depends on.
+    if (!this.roomHasMiner(room)) return [];
 
     const tenders = this.getTenders();
     if (tenders.length >= 1) return []; // one (oversized) tender per room is enough
@@ -174,7 +196,7 @@ export class ExtensionTenderCorp extends Corp {
         buyerCorpId: this.id,
         role: "tanker",
         value: 96, // infrastructure: above upgrading/building, below the core mining economy
-        blocking: true, // the first tender unlocks the extensions the haulers stopped filling
+        blocking: false, // infrastructure, not core income - never hold the spawn ahead of producers
         producesIncome: false,
         desiredCost: carry * PART_PAIR,
         minCost: Math.min(carry, 2) * PART_PAIR,

--- a/src/corps/ExtensionTenderCorp.ts
+++ b/src/corps/ExtensionTenderCorp.ts
@@ -1,0 +1,202 @@
+/**
+ * @fileoverview ExtensionTenderCorp - a LOCAL MOVER (type "moving"): it does
+ * intra-node energy carrying, the short last leg the long-range haulers shouldn't.
+ *
+ * Haulers are inter-node and should run a dumb source->depot bus, not fan out
+ * across a dozen extensions chasing whichever one has a sliver of free space
+ * (that reactive convergence is what makes them "school" on one tile). So once a
+ * room has a CORE DEPOT - a container beside the spawn the haulers dump into -
+ * this local mover takes over the last leg: it withdraws from the depot and tops
+ * up the extensions (and the spawn) as a dedicated job.
+ *
+ * Extensions drain in a BURST (a whole creep's cost vanishes the instant it
+ * spawns) and then sit idle until the next spawn, so the tender is deliberately
+ * oversized - big enough to refill the whole extension set from the depot in
+ * roughly one trip - and mostly idles between bursts.
+ *
+ * @module corps/ExtensionTenderCorp
+ */
+
+import { Corp, SerializedCorp } from "./Corp";
+import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
+import { Position } from "../types/Position";
+import { travelTo } from "./movement";
+
+export interface SerializedExtensionTenderCorp extends SerializedCorp {
+  spawnId: string;
+}
+
+/** A spawn or extension the tender keeps topped up. */
+type FillTarget = StructureSpawn | StructureExtension;
+
+export class ExtensionTenderCorp extends Corp {
+  private spawnId: string;
+
+  public constructor(nodeId: string, spawnId: string, customId?: string) {
+    super("moving", nodeId, customId);
+    this.spawnId = spawnId;
+  }
+
+  public getSpawnId(): string {
+    return this.spawnId;
+  }
+
+  public getPosition(): Position {
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    if (spawn) return { x: spawn.pos.x, y: spawn.pos.y, roomName: spawn.pos.roomName };
+    return { x: 25, y: 25, roomName: this.nodeId.split("-")[0] };
+  }
+
+  private getTenders(): Creep[] {
+    const creeps: Creep[] = [];
+    for (const name in Game.creeps) {
+      const c = Game.creeps[name];
+      if (c.memory.corpId === this.id && c.memory.workType === "tank" && !c.spawning) creeps.push(c);
+    }
+    return creeps;
+  }
+
+  public getCreepCount(): number {
+    return this.getTenders().length;
+  }
+
+  /**
+   * The core depot: a container adjacent to one of the room's spawns. This is the
+   * one structure haulers dump into and the tender draws from. Null until built.
+   */
+  private coreDepot(room: Room): StructureContainer | null {
+    for (const spawn of room.find(FIND_MY_SPAWNS)) {
+      const c = spawn.pos.findInRange(FIND_STRUCTURES, 1, {
+        filter: s => s.structureType === STRUCTURE_CONTAINER
+      })[0] as StructureContainer | undefined;
+      if (c) return c;
+    }
+    return null;
+  }
+
+  /** Spawn + extensions in the room with free energy capacity, nearest the tender first. */
+  private fillTargets(room: Room, from: RoomPosition): FillTarget[] {
+    const targets = room.find(FIND_MY_STRUCTURES, {
+      filter: s =>
+        (s.structureType === STRUCTURE_EXTENSION || s.structureType === STRUCTURE_SPAWN) &&
+        (s as FillTarget).store.getFreeCapacity(RESOURCE_ENERGY) > 0
+    }) as FillTarget[];
+    return targets.sort((a, b) => from.getRangeTo(a.pos) - from.getRangeTo(b.pos));
+  }
+
+  public work(tick: number): void {
+    this.lastActivityTick = tick;
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    if (!spawn) return;
+    const room = spawn.room;
+
+    const depot = this.coreDepot(room);
+    const tenders = this.getTenders();
+
+    // Signal the haulers: while a depot exists AND a tender is alive to drain it,
+    // haulers run the dumb source->depot bus instead of fanning across extensions.
+    // If the tender dies the flag clears and haulers resume filling the spawn
+    // network directly, so a dead tender can never deadlock the colony.
+    room.memory.extensionTenderActive = !!depot && tenders.length > 0;
+
+    for (const creep of tenders) this.runTender(creep, room, depot);
+  }
+
+  /**
+   * A tender shuttles depot -> extensions/spawn: fill while it has energy, reload
+   * from the depot when empty. It only flips state on full/empty, so it makes
+   * complete trips (a clean burst) rather than dithering with partial loads.
+   */
+  private runTender(creep: Creep, room: Room, depot: StructureContainer | null): void {
+    if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) creep.memory.working = false;
+    if (!creep.memory.working && creep.store.getFreeCapacity() === 0) creep.memory.working = true;
+
+    if (creep.memory.working) {
+      const target = this.fillTargets(room, creep.pos)[0];
+      if (!target) {
+        // Nothing to fill: idle on the depot so the next burst is served instantly.
+        if (depot && !creep.pos.isNearTo(depot)) travelTo(creep, depot, { range: 1 });
+        return;
+      }
+      if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        travelTo(creep, target, { range: 1, visualizePathStyle: { stroke: "#ffff88" } });
+      } else {
+        this.recordProduction(Math.min(creep.store[RESOURCE_ENERGY], target.store.getFreeCapacity(RESOURCE_ENERGY)));
+      }
+      return;
+    }
+
+    // Reloading: draw from the depot (fall back to the largest nearby drop pile so a
+    // not-yet-built depot still works).
+    if (depot && depot.store[RESOURCE_ENERGY] > 0) {
+      if (creep.withdraw(depot, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        travelTo(creep, depot, { range: 1, visualizePathStyle: { stroke: "#ffff88" } });
+      }
+      return;
+    }
+    const pile = creep.pos.findClosestByRange(FIND_DROPPED_RESOURCES, {
+      filter: r => r.resourceType === RESOURCE_ENERGY && r.amount > 0
+    });
+    if (pile) {
+      if (creep.pickup(pile) === ERR_NOT_IN_RANGE) travelTo(creep, pile, { range: 1 });
+    } else if (depot && !creep.pos.isNearTo(depot)) {
+      travelTo(creep, depot, { range: 1 });
+    }
+  }
+
+  /**
+   * Demand one oversized tender once a depot exists and there are extensions to
+   * keep filled. The FIRST tender is blocking: without it the extensions (which
+   * the haulers no longer fill) would never charge, leaving the room stuck at the
+   * bare spawn's 300 capacity. Sized to refill the whole extension set in ~one
+   * trip (a bit oversized, since it works in bursts).
+   */
+  public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    if (!spawn) return [];
+    const room = spawn.room;
+    if (!this.coreDepot(room)) return []; // no depot yet -> haulers still fill the network
+
+    const extensions = room.find(FIND_MY_STRUCTURES, { filter: s => s.structureType === STRUCTURE_EXTENSION });
+    if (extensions.length === 0) return [];
+
+    const tenders = this.getTenders();
+    if (tenders.length >= 1) return []; // one (oversized) tender per room is enough
+
+    // Carry enough to refill every extension (+ the spawn) in roughly one trip; the
+    // scheduler scales the body down to the energy on hand if it can't afford it all.
+    const PART_PAIR = 100; // CARRY + MOVE
+    const maxCarry = Math.max(1, Math.min(Math.floor(ctx.energyCapacity / PART_PAIR), 25));
+    const carry = Math.max(1, Math.min(extensions.length + 1, maxCarry));
+
+    return [
+      {
+        buyerCorpId: this.id,
+        role: "tanker",
+        value: 96, // infrastructure: above upgrading/building, below the core mining economy
+        blocking: true, // the first tender unlocks the extensions the haulers stopped filling
+        producesIncome: false,
+        desiredCost: carry * PART_PAIR,
+        minCost: Math.min(carry, 2) * PART_PAIR,
+        since: 0,
+        bodyParam: carry
+      }
+    ];
+  }
+
+  public serialize(): SerializedExtensionTenderCorp {
+    return { ...super.serialize(), spawnId: this.spawnId };
+  }
+
+  public deserialize(data: SerializedExtensionTenderCorp): void {
+    super.deserialize(data);
+    this.spawnId = data.spawnId ?? this.spawnId;
+  }
+}
+
+/** Create an ExtensionTenderCorp for an owned room's spawn. */
+export function createExtensionTenderCorp(room: Room): ExtensionTenderCorp | null {
+  const spawn = room.find(FIND_MY_SPAWNS)[0];
+  if (!spawn) return null;
+  return new ExtensionTenderCorp(`${room.name}-tender`, spawn.id);
+}

--- a/src/corps/index.ts
+++ b/src/corps/index.ts
@@ -26,6 +26,12 @@ export { ConstructionCorp, SerializedConstructionCorp, createConstructionCorp } 
 export { ReservationCorp, SerializedReservationCorp, createReservationCorp } from "./ReservationCorp";
 
 export {
+  ExtensionTenderCorp,
+  SerializedExtensionTenderCorp,
+  createExtensionTenderCorp
+} from "./ExtensionTenderCorp";
+
+export {
   SpawningCorp,
   SerializedSpawningCorp,
   SpawnOrder,

--- a/src/execution/CorpRunner.ts
+++ b/src/execution/CorpRunner.ts
@@ -14,6 +14,7 @@ import {
   CarryCorp,
   ConstructionCorp,
   Corp,
+  ExtensionTenderCorp,
   HarvestCorp,
   ReservationCorp,
   ScoutCorp,
@@ -21,6 +22,7 @@ import {
   UpgradingCorp,
   createBootstrapCorp,
   createConstructionCorp,
+  createExtensionTenderCorp,
   createReservationCorp,
   createScoutCorp,
   createSpawningCorp
@@ -38,6 +40,8 @@ export interface CorpRegistry {
   constructionCorps: { [roomName: string]: ConstructionCorp };
   spawningCorps: { [spawnId: string]: SpawningCorp };
   reservationCorps: { [roomName: string]: ReservationCorp };
+  /** Extension tenders (local movers) keyed by room name */
+  extensionTenderCorps: { [roomName: string]: ExtensionTenderCorp };
 }
 
 /**
@@ -52,7 +56,8 @@ export function createCorpRegistry(): CorpRegistry {
     scoutCorps: {},
     constructionCorps: {},
     spawningCorps: {},
-    reservationCorps: {}
+    reservationCorps: {},
+    extensionTenderCorps: {}
   };
 }
 
@@ -240,6 +245,35 @@ export function runConstructionCorps(registry: CorpRegistry): void {
       constructionCorp.plan(Game.time);
     }
     constructionCorp.work(Game.time);
+  }
+}
+
+/**
+ * Run extension tender corps (local movers) for all owned rooms. The tender
+ * withdraws from the core depot and tops up the spawn + extensions, so haulers can
+ * run a dumb source->depot bus instead of fanning across extensions.
+ */
+export function runExtensionTenderCorps(registry: CorpRegistry): void {
+  for (const roomName in Game.rooms) {
+    const room = Game.rooms[roomName];
+    if (!room.controller?.my) continue;
+    if (room.find(FIND_MY_SPAWNS).length === 0) continue;
+
+    let corp = registry.extensionTenderCorps[roomName];
+    if (!corp) {
+      const saved = Memory.extensionTenderCorps?.[roomName];
+      if (saved) {
+        corp = new ExtensionTenderCorp(saved.nodeId, saved.spawnId, saved.id);
+        corp.deserialize(saved);
+      } else {
+        const created = createExtensionTenderCorp(room);
+        if (!created) continue;
+        created.createdAt = Game.time;
+        corp = created;
+      }
+      registry.extensionTenderCorps[roomName] = corp;
+    }
+    corp.work(Game.time);
   }
 }
 

--- a/src/execution/Persistence.ts
+++ b/src/execution/Persistence.ts
@@ -197,6 +197,12 @@ export function persistState(
     Memory.reservationCorps[roomName] = registry.reservationCorps[roomName].serialize();
   }
 
+  // Persist extension tender corps (local movers)
+  Memory.extensionTenderCorps = {};
+  for (const roomName in registry.extensionTenderCorps) {
+    Memory.extensionTenderCorps[roomName] = registry.extensionTenderCorps[roomName].serialize();
+  }
+
   // Persist spawning corps
   Memory.spawningCorps = {};
   for (const spawnId in registry.spawningCorps) {

--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -125,6 +125,10 @@ export function collectDemands(registry: CorpRegistry, spawnId: string, ctx: Spa
     const c = registry.constructionCorps[id];
     if (c.getSpawnId() === spawnId) demands.push(...c.getSpawnDemand(ctx));
   }
+  for (const id in registry.extensionTenderCorps) {
+    const c = registry.extensionTenderCorps[id];
+    if (c.getSpawnId() === spawnId) demands.push(...c.getSpawnDemand(ctx));
+  }
   for (const id in registry.reservationCorps) {
     const c = registry.reservationCorps[id];
     if (c.getSpawnId() !== spawnId) continue;

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -17,6 +17,7 @@ export {
   runRealCorps,
   runScoutCorps,
   runConstructionCorps,
+  runExtensionTenderCorps,
   runReservationCorps,
   runSpawningCorps,
   logCorpStats,

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,7 @@ import {
   restoreVisualizationCache,
   runBootstrapCorps,
   runConstructionCorps,
+  runExtensionTenderCorps,
   runIncrementalAnalysis,
   runRealCorps,
   runReservationCorps,
@@ -184,6 +185,7 @@ export const loop = ErrorMapper.wrapLoop(() => {
   runRealCorps(corps);
   runScoutCorps(corps);
   runConstructionCorps(corps);
+  runExtensionTenderCorps(corps);
   runReservationCorps(corps);
 
   // Snapshot budget-vs-actual variance so outlier corps (those straying furthest

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -11,6 +11,7 @@ import {
   SerializedBootstrapCorp,
   SerializedCarryCorp,
   SerializedConstructionCorp,
+  SerializedExtensionTenderCorp,
   SerializedHarvestCorp,
   SerializedReservationCorp,
   SerializedScoutCorp,
@@ -164,6 +165,11 @@ declare global {
      * Serialized spawning corps by spawn ID.
      */
     spawningCorps?: { [spawnId: string]: SerializedSpawningCorp };
+
+    /**
+     * Serialized extension tender corps (local movers) by room name.
+     */
+    extensionTenderCorps?: { [roomName: string]: SerializedExtensionTenderCorp };
   }
 
   /**
@@ -186,6 +192,15 @@ declare global {
      * down). Set by ConstructionCorp, read by CarryCorp. Cleared when not building.
      */
     dedicatedBuildSourceId?: string;
+
+    /**
+     * True while a core depot exists AND a live extension tender is draining it.
+     * Set by ExtensionTenderCorp, read by CarryCorp: when set, haulers run the dumb
+     * source->depot bus instead of fanning across extensions; when the tender dies
+     * it clears and haulers resume filling the spawn network directly (so a dead
+     * tender can never deadlock the colony).
+     */
+    extensionTenderActive?: boolean;
   }
 
   /**

--- a/test/integration/scenario/library.ts
+++ b/test/integration/scenario/library.ts
@@ -209,6 +209,34 @@ export function twoSourceRcl3Containers(opts: { room?: string } = {}): Scenario 
 }
 
 /**
+ * twoSourceRcl3 with source containers AND a core depot container beside the spawn
+ * (25,25) already built, so the depot+extension-tender path is exercised from tick
+ * 1 instead of waiting ~1500 ticks for the containers to be built. Used to validate
+ * that the local-mover tender fills extensions and haulers run the source->depot bus.
+ */
+export function twoSourceRcl3Depot(opts: { room?: string } = {}): Scenario {
+  const base = twoSourceRcl3(opts);
+  const room = base.bot.room;
+  const containers = [
+    { x: 15, y: 29 }, // on source 1 (15,30)
+    { x: 35, y: 29 }, // on source 2 (35,30)
+    { x: 24, y: 25 }, // CORE DEPOT: adjacent to the spawn at (25,25)
+  ];
+  return {
+    ...base,
+    name: "two-source-rcl3-depot",
+    description: base.description + " Plus source containers and a core depot by the spawn.",
+    state: {
+      ...base.state,
+      structures: [
+        ...(base.state?.structures ?? []),
+        ...containers.map((c) => ({ room, type: "container", x: c.x, y: c.y, energy: 0 })),
+      ],
+    },
+  };
+}
+
+/**
  * The three-chamber room pre-advanced to RCL 2 with two extensions already
  * built in the source chamber, so the controller-starvation-during-construction
  * regime reproduces in ~100 ticks instead of ~600. Use for fast economy

--- a/test/integration/two-source-economy.test.ts
+++ b/test/integration/two-source-economy.test.ts
@@ -26,7 +26,7 @@ describe("two-source owned-room economy probe", () => {
     this.timeout(900000);
 
     const main = readFileSync(MAIN).toString();
-    const scenario = scenarios.twoSourceRcl3();
+    const scenario = scenarios.twoSourceRcl3Depot();
     const room = scenario.bot.room;
     const SRC = [
       { x: 15, y: 30 },

--- a/test/integration/two-source-economy.test.ts
+++ b/test/integration/two-source-economy.test.ts
@@ -62,16 +62,27 @@ describe("two-source owned-room economy probe", () => {
       );
       if (minersBySrc.every(m => m > 0) && bothMinedTick === 0) bothMinedTick = t;
 
-      let haul = 0, upg = 0;
+      let haul = 0, upg = 0, tend = 0;
       for (const o of objs.filter((x: any) => x.type === "creep")) {
         const wt = mem.creeps?.[o.name]?.workType;
         if (wt === "haul") haul++;
         else if (wt === "upgrade") upg++;
+        else if (wt === "tank" && (mem.creeps?.[o.name]?.corpId || "").includes("tender")) tend++;
       }
+      // Extension fill: how charged the extension set is (the tender's job).
+      const exts = objs.filter((o: any) => o.type === "extension");
+      const extEnergy = exts.reduce((s: number, e: any) => s + (e.store?.energy ?? e.energy ?? 0), 0);
+      const extCap = exts.length * 50;
+      const spawnObj = objs.find((o: any) => o.type === "spawn");
+      const containers = objs.filter((o: any) => o.type === "container");
+      const depot = spawnObj
+        ? containers.find((c: any) => Math.max(Math.abs(c.x - spawnObj.x), Math.abs(c.y - spawnObj.y)) <= 1)
+        : undefined;
       const variance = (mem.corpVariance || []).map((r: any) => `${r.type} ${r.actual}/${r.budget}`).join(", ");
       samples.push(
-        `tick ${t}: ${perSrc.join(" ")} | haul ${haul} upg ${upg} ctrlP ${ctrl?.progress ?? 0} ` +
-          `| harvestCorps ${Object.keys(mem.harvestCorps || {}).length} nodes ${Object.keys(mem.nodes || {}).length} | [${variance}]`
+        `tick ${t}: ${perSrc.join(" ")} | haul ${haul} tend ${tend} upg ${upg} ctrlP ${ctrl?.progress ?? 0} ` +
+          `| ext ${extEnergy}/${extCap} depot ${depot ? (depot.store?.energy ?? 0) : "none"} ` +
+          `| [${variance}]`
       );
     }
 

--- a/test/unit/corps/extensionTender.test.ts
+++ b/test/unit/corps/extensionTender.test.ts
@@ -52,9 +52,13 @@ describe("ExtensionTenderCorp spawn demand (local mover)", () => {
     Game.creeps = {};
   });
 
-  // corpFor mutates Game.getObjectById; restore the shared mock so later test files
-  // (e.g. getSpawnDemand.test.ts) don't inherit a room without .memory.
-  afterEach(() => setupGlobals());
+  // corpFor mutates the shared mock Game.getObjectById; restore it (and creeps) so
+  // later test files (e.g. getSpawnDemand.test.ts) don't inherit a room without
+  // .memory. The mock Game is a singleton, so setupGlobals alone won't reset it.
+  afterEach(() => {
+    Game.getObjectById = () => null;
+    Game.creeps = {};
+  });
 
   const ctx = { energyCapacity: 800, tick: 100 };
 

--- a/test/unit/corps/extensionTender.test.ts
+++ b/test/unit/corps/extensionTender.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { setupGlobals, Game } from "../mock";
+import { ExtensionTenderCorp } from "../../../src/corps/ExtensionTenderCorp";
+
+const FIND_MY_SPAWNS = 112;
+const FIND_STRUCTURES = 107;
+const FIND_MY_STRUCTURES = 108;
+
+/**
+ * The extension tender (a local mover) only asks for a creep once there's a depot
+ * to draw from and extensions to fill, and it runs exactly one (oversized) tender
+ * per room. Without a depot the haulers still fill the network themselves, so no
+ * tender is wanted.
+ */
+function room(opts: { depot?: boolean; extensions?: number }): any {
+  const spawnPos = {
+    x: 25, y: 25, roomName: "W0N0",
+    findInRange: (type: number) =>
+      type === FIND_STRUCTURES && opts.depot ? [{ structureType: "container", pos: { x: 24, y: 25 } }] : []
+  };
+  const spawn = { id: "spawn1", pos: spawnPos, store: { getFreeCapacity: () => 0 } };
+  const extensions = Array.from({ length: opts.extensions ?? 0 }, (_, i) => ({
+    structureType: "extension",
+    pos: { x: 20 + i, y: 20 },
+    store: { getFreeCapacity: () => 50 }
+  }));
+  return {
+    name: "W0N0",
+    find: (type: number, o?: any) => {
+      if (type === FIND_MY_SPAWNS) return [spawn];
+      if (type === FIND_MY_STRUCTURES) {
+        const all = [spawn, ...extensions];
+        return o?.filter ? all.filter(o.filter) : all;
+      }
+      return [];
+    },
+    _spawn: spawn
+  };
+}
+
+describe("ExtensionTenderCorp spawn demand (local mover)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).FIND_MY_SPAWNS = FIND_MY_SPAWNS;
+    (global as any).FIND_STRUCTURES = FIND_STRUCTURES;
+    (global as any).FIND_MY_STRUCTURES = FIND_MY_STRUCTURES;
+    (global as any).STRUCTURE_EXTENSION = "extension";
+    (global as any).STRUCTURE_SPAWN = "spawn";
+    (global as any).STRUCTURE_CONTAINER = "container";
+    Game.creeps = {};
+  });
+
+  const ctx = { energyCapacity: 800, tick: 100 };
+
+  function corpFor(r: any): ExtensionTenderCorp {
+    Game.getObjectById = (id: string) => (id === "spawn1" ? { ...r._spawn, room: r } : null) as any;
+    return new ExtensionTenderCorp("W0N0-tender", "spawn1");
+  }
+
+  it("asks for NOTHING when there is no depot (haulers still fill the network)", () => {
+    const corp = corpFor(room({ depot: false, extensions: 5 }));
+    expect(corp.getSpawnDemand(ctx as any)).to.have.length(0);
+  });
+
+  it("asks for NOTHING when there are no extensions to fill", () => {
+    const corp = corpFor(room({ depot: true, extensions: 0 }));
+    expect(corp.getSpawnDemand(ctx as any)).to.have.length(0);
+  });
+
+  it("asks for ONE blocking, oversized tender when a depot and extensions exist", () => {
+    const corp = corpFor(room({ depot: true, extensions: 5 }));
+    const demand = corp.getSpawnDemand(ctx as any);
+    expect(demand).to.have.length(1);
+    expect(demand[0].role).to.equal("tanker");
+    expect(demand[0].blocking, "the first tender unlocks the extensions").to.equal(true);
+    expect(demand[0].bodyParam, "sized to refill the whole extension set (+spawn)").to.equal(6);
+  });
+
+  it("asks for nothing once a tender is already fielded (one per room)", () => {
+    const r = room({ depot: true, extensions: 5 });
+    const corp = corpFor(r);
+    Game.creeps = { t1: { memory: { corpId: corp.id, workType: "tank" }, spawning: false } } as any;
+    expect(corp.getSpawnDemand(ctx as any)).to.have.length(0);
+  });
+});

--- a/test/unit/corps/extensionTender.test.ts
+++ b/test/unit/corps/extensionTender.test.ts
@@ -69,19 +69,30 @@ describe("ExtensionTenderCorp spawn demand (local mover)", () => {
     expect(corp.getSpawnDemand(ctx as any)).to.have.length(0);
   });
 
-  it("asks for ONE blocking, oversized tender when a depot and extensions exist", () => {
+  it("asks for NOTHING before the room has a miner (income before infrastructure)", () => {
     const corp = corpFor(room({ depot: true, extensions: 5 }));
+    Game.creeps = {}; // no miner yet
+    expect(corp.getSpawnDemand(ctx as any)).to.have.length(0);
+  });
+
+  it("asks for ONE non-blocking, oversized tender when a depot, extensions and a miner exist", () => {
+    const r = room({ depot: true, extensions: 5 });
+    const corp = corpFor(r);
+    Game.creeps = { m1: { room: { name: "W0N0" }, memory: { corpId: "mining-abc", workType: "harvest" }, spawning: false } } as any;
     const demand = corp.getSpawnDemand(ctx as any);
     expect(demand).to.have.length(1);
     expect(demand[0].role).to.equal("tanker");
-    expect(demand[0].blocking, "the first tender unlocks the extensions").to.equal(true);
+    expect(demand[0].blocking, "infrastructure, must not hold the spawn ahead of producers").to.equal(false);
     expect(demand[0].bodyParam, "sized to refill the whole extension set (+spawn)").to.equal(6);
   });
 
   it("asks for nothing once a tender is already fielded (one per room)", () => {
     const r = room({ depot: true, extensions: 5 });
     const corp = corpFor(r);
-    Game.creeps = { t1: { memory: { corpId: corp.id, workType: "tank" }, spawning: false } } as any;
+    Game.creeps = {
+      m1: { room: { name: "W0N0" }, memory: { corpId: "mining-abc", workType: "harvest" }, spawning: false },
+      t1: { room: { name: "W0N0" }, memory: { corpId: corp.id, workType: "tank" }, spawning: false }
+    } as any;
     expect(corp.getSpawnDemand(ctx as any)).to.have.length(0);
   });
 });

--- a/test/unit/corps/extensionTender.test.ts
+++ b/test/unit/corps/extensionTender.test.ts
@@ -52,6 +52,10 @@ describe("ExtensionTenderCorp spawn demand (local mover)", () => {
     Game.creeps = {};
   });
 
+  // corpFor mutates Game.getObjectById; restore the shared mock so later test files
+  // (e.g. getSpawnDemand.test.ts) don't inherit a room without .memory.
+  afterEach(() => setupGlobals());
+
   const ctx = { energyCapacity: 800, tick: 100 };
 
   function corpFor(r: any): ExtensionTenderCorp {


### PR DESCRIPTION
## Depot + extension tender (local mover) — fixes hauler "schooling"

Haulers were long-range *and* fanned out across every extension (`getCirculationTarget`), reactively converging on whichever had free space — the schooling. This introduces the depot+filler split:

- **Core depot**: `ConstructionCorp` places a container beside the spawn (right after the source containers).
- **`ExtensionTenderCorp`** (type `"moving"` — a *local mover*, distinct from the long-range haulers, aligned with the existing "local mover" language): withdraws from the depot and tops up the spawn + extensions as a dedicated job. Oversized (sized to refill the whole extension set in ~one trip) since extensions drain in bursts. Non-blocking and gated on the room already having a miner, so infrastructure never delays the income it depends on.
- **Haulers** now run a dumb source→depot bus once a depot exists *and* a tender is alive (`room.memory.extensionTenderActive`): they keep the spawn structure topped (one tile, no fanning), top the depot to a small buffer, then **spill surplus to the controller** (as the pre-depot model did when the network filled). If the tender dies the flag clears and haulers resume filling the network directly — a dead tender can never deadlock the colony.

## Validation (two-source RCL3 probe with a pre-built depot)

| metric | baseline (no depot) | depot + tender |
|---|---|---|
| both sources mined | ~300 | ~300 |
| extensions | intermittent | **full (300/300)** |
| controller progress @1000 | 694 | 484 |
| depot | — | steady ~150 buffer |

Haulers no longer fan across extensions (schooling addressed); the tender keeps extensions full; the controller is fed again (484 — healthy, steadily upgrading). The ~30% controller gap vs baseline is the tender's overhead plus keeping the extensions fuller — an intentional architectural trade. Full unit suite green (**438 passing**), incl. new tender spawn-demand tests; graceful degradation confirmed (economy healthy when the depot/tender aren't built yet).

https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiMtPL3aKoSYX3JxRdjeqn)_