### PR TITLE
Energy-store thermostat: balance income vs. build/upgrade by stored-energy fill

### DIFF
--- a/docs/GOD_POINTS_CHAIN_DESIGN.md
+++ b/docs/GOD_POINTS_CHAIN_DESIGN.md
@@ -3,12 +3,13 @@
 Status: **proposal / design-only** (no code yet). Companion to
 [`ECONOMIC_FRAMEWORK.md`](./ECONOMIC_FRAMEWORK.md).
 
-> Earlier drafts chased a "god-points" terminal-value model. We dropped it: it
-> modeled a value we'd have to invent and tune. This design keys off **measured
-> state** instead. And we control on the **stored-energy level**, not its rate of
-> change — the level is the integral of net flow, so it's naturally smooth and
-> matched to the slow spawn actuator. The desired behavior falls out of one
-> feedback loop.
+> This revision replaces an earlier draft whose premise ("the consumer corps
+> ignore their flow allocation") turned out to be **wrong on inspection** — the
+> corps already size themselves from their allocation. The real faults are
+> upstream, in the flow solver and spawn scheduler, and are documented below with
+> file:line evidence. We control on the **stored-energy level** (not its noisy
+> derivative), because the level is the integral of net flow — smooth, and matched
+> to the slow spawn actuator.
 
 ## 1. The problem, in one screenshot
 
@@ -21,237 +22,216 @@ Room W43N23, established, 24h:
 | energy on construction | **0** |
 | control points | flat / ~0 |
 
-The colony harvests plenty and pours almost all of it into *making more creeps*
-(haulers, remote-mining crews). The two activities that actually advance the
-empire — **upgrading** and **construction** — get nothing. A source-container site
-sat unbuilt for a very long time because no builder ever spawned.
+The colony harvests plenty and pours ~82% of it into *making more creeps*
+(haulers, remote-mining crews). Construction and upgrading — the activities that
+advance the empire — get almost nothing.
 
-## 2. Root cause: the flow→corp gap, and an unregulated economy
+## 2. Root cause (verified against the code)
 
-Two concrete faults:
+Three concrete facts, established by reading the pipeline end to end:
 
-1. **Consumers ignore their allocation.** The flow solver computes a controller
-   and construction allocation, then the corps **throw it away** and use ad-hoc
-   heuristics:
-   - `UpgradingCorp.plan()` sets upgrader count from an RCL rule
-     (`rcl<=2 ? 1 : 2`, capped at 3). It holds a flow-allocation field but does
-     not size from it.
-   - `ConstructionCorp` floors the builder to a dedicated-source guess, and then
-     the spawn scheduler's income tier buries it anyway.
+1. **Consumers already size from their allocation — this is NOT the bug.**
+   `ConstructionCorp.builderPlan` sizes builder WORK from `getTotalAllocatedEnergy()`
+   (`ConstructionCorp.ts:254-285`); `UpgradingCorp.getSpawnDemand` sizes upgrader
+   count from `sinkAllocation.allocated` (`UpgradingCorp.ts:408-419`). A unit test
+   already asserts this (`getSpawnDemand.test.ts:71-89`). The RCL heuristic in
+   `UpgradingCorp.plan()` is vestigial — it doesn't drive spawning.
 
-   So the flow and the corps speak different languages, and the consumer side
-   never grows to use available energy.
+2. **Income monopolises spawn time (the decisive fault).**
+   `spawnPriority` puts every income demand at **`+1,000,000`**
+   (`SpawnScheduler.ts:158-173`), and `scheduleSpawn` **returns on the first
+   affordable demand in priority order** (`SpawnScheduler.ts:223-236`). So while
+   any income demand is present and affordable — always, with a full
+   spawn+extensions — income spawns and the flow-budgeted consumers below it are
+   never reached. Income is count-capped *per source*, but CorpPlanner adds every
+   profitable source including **unbounded remote/transient sources**
+   (`flowAdapter.ts:71-80`, producer selection `CorpPlanner.ts:182-236`), so its
+   demand never empties. The advertised anti-starvation aging (`since`) that would
+   let a waiting consumer eventually win is **declared but never implemented** — no
+   corp sets it and `spawnPriority` never reads it.
 
-2. **Nothing regulates income.** The spawn scheduler ranks income (miner/hauler)
-   in a `+1,000,000` tier above every consumer, and nothing tells it the *Nth*
-   hauler or *Mth* remote mine produces no benefit. We are **spawn-bound, not
-   energy-bound** — there is surplus energy — yet the colony keeps spending its
-   scarce spawn time on more income instead of consuming what it already has.
+3. **Construction can't absorb the surplus even when valued higher.**
+   The routing weights already prefer building: `DEFAULT_SINK_VALUE` is
+   `spawn 100 > construction 70 > controller 50 > storage 1`
+   (`CorpPlanner.ts:92-96`). But the construction sink's **capacity is pinned at
+   `CONSTRUCTION_ABSORB_RATE = 5` e/tick** (`flowAdapter.ts:39,115`), while the
+   controller sink's capacity is the whole supply (`flowAdapter.ts:120`,
+   "mops up the remainder"). So surplus routes *past* construction (capped at 5)
+   into the controller. Construction is preferred but throttled.
+
+**Net:** the spawn is monopolised by uncapped income, so even the controller's
+remainder allocation can't be consumed (no upgrader ever gets a spawn tick → flat
+control points), and construction is throttled at 5 e/tick regardless. The 212K
+on creeps is the income monopoly; the 0 on construction is the absorb cap plus the
+monopoly.
 
 ## 3. The idea: stored-energy *level* is the thermostat
 
 We are spawn-bound and energy-rich, so the quantity to regulate is **stored
-energy**, and the gauge is **container + storage levels**.
+energy**; the gauge is **container + storage levels**.
 
-**Control on the level, not the rate.** A naive "surplus/tick" signal
-(`Δstores`) is noisy tick-to-tick, and spawning a creep is a slow actuator
-(hundreds of ticks to field a fleet). Driving a laggy actuator from a noisy
-derivative oscillates. The **level** is the integral of net flow — it already
-low-pass-filters the noise and moves on the same slow timescale as spawning. So
-we read the gauge and compare to a setpoint band:
-
-```
-fill = storedEnergy(room) / storableCapacity(room)        # 0..1, smooth
-```
-
-- **`fill` high** (stores near full): we collect more than we use → grow the
-  consumers (build/upgrade) to spend it, and stop adding income.
-- **`fill` low** (stores near empty): consumers are outrunning income → throttle
-  consumers (and/or add income, if spawn budget allows).
-- **`fill` in-band**: balanced — the "optimum that evenly consumes the surplus"
-  is the equilibrium the loop settles into, not a number we compute.
-
-No modeled value, no god points, no differentiation of a noisy signal. Just a
-thermostat reading a slow, real gauge.
-
-## 4. Three small changes (the whole design)
-
-### 4.1 Read the level
-
-A single cheap function, run each planning cycle:
+**Control on the level, not the rate.** A "surplus/tick" signal (`Δstores`) is
+noisy, and spawning is a slow actuator — driving a laggy actuator from a noisy
+derivative oscillates. The **level** is the integral of net flow: already
+low-pass-filtered and moving on the same slow timescale as spawning. Read the
+gauge and compare to a setpoint band:
 
 ```
-storeFill(room) -> 0..1     # stored energy / storable capacity
+fill = storedEnergy(room) / storableCapacity(room)   # 0..1, smooth
 ```
 
-From container + storage contents over their capacity. Smooth by construction —
-no trend/derivative needed. (We may keep the trend around later as a secondary
-tiebreak, but the **level is the primary control signal.**)
+- **`fill` high** → we collect more than we use → let consumers grow and **stop
+  adding income**.
+- **`fill` low** → consumers outrunning income → throttle consumers / unblock
+  income.
+- **`fill` in band** → balanced; the equilibrium falls out, it isn't computed.
 
-### 4.2 Consumer demand scales with fill
+## 4. The changes (small, and upstream)
 
-In the flow graph, set the **construction + controller sink demand as a function
-of `fill`** instead of a fixed/priority constant — e.g. demand rises as `fill`
-climbs above a low setpoint and saturates near full. The solver already routes
-energy to sinks; now it routes *more* of it to consumers exactly when the
-reservoir is backing up. This is the only change to the solver inputs.
+### 4.1 Read the level — `storeFill(room) -> 0..1`
 
-### 4.3 Tighten the handoff — consumers size from their allocation
+Stored energy / storable capacity, from containers + storage. Smooth by
+construction; no derivative. The shared signal for the two levers below.
 
-Make each consumer corp size its crew **purely from its sink allocation**:
+### 4.2 Lever 1 — bound income growth by `fill` (the decisive fix)
 
-```
-desired WORK  ≈  allocatedEnergy/tick  /  per-WORK consumption rate
-```
+In CorpPlanner producer selection / transient-source detection
+(`CorpPlanner.ts:182-236`, `flowAdapter.ts:71-80`), **stop adding marginal sources
+(especially remote/transient) and stop growing hauler counts beyond delivery need
+while `fill` is above the high setpoint.** Income demand then *empties*, and the
+scheduler — walking its ranked list — finally reaches the consumers the flow has
+already budgeted. This is what breaks the 212K-into-creeps monopoly, and it needs
+no change to the `+1e6` tier itself.
 
-- **Delete** `UpgradingCorp`'s RCL heuristic; the upgrader fleet is whatever its
-  controller allocation funds (keep a small safety cap against a stale
-  allocation, and a floor while downgrade is imminent).
-- **Delete** `ConstructionCorp`'s dedicated-source over-floor; the builder fleet
-  is whatever its construction allocation funds.
+### 4.3 Lever 2 — let construction absorb the surplus
 
-Now `getSpawnDemand` is a **pure function of the allocation** — the flow and the
-corps finally speak one language. Corps stay dumb: they don't decide *how much*,
-they only execute their funded size.
+Replace the fixed `CONSTRUCTION_ABSORB_RATE = 5` with a capacity that **scales
+with `fill`** (and/or active-site count × remaining work), so the existing value-70
+preference can actually pull surplus into building instead of spilling it to the
+controller. Keep the weights as-is — construction already outranks the controller;
+it just needs the headroom to act on that.
 
-### 4.4 Let fill regulate income too
+### 4.4 Lever 3 — consumers size from allocation (mostly done) + aging backstop
 
-The same level caps income: when `fill` is high, the colony already collects more
-than it uses, so **stop opening new haulers / remote mines**. Gate income growth
-(the marginal hauler, the next remote source) on `fill` being above the high
-setpoint. One signal grows consumers *and* caps income — precisely what kills the
-212K-into-creeps over-spawn.
+The corps already size from allocation (§2.1). Remaining cleanup: drop the
+vestigial RCL `targetUpgraders` path so allocation is the single input. Optionally
+**wire up the dormant `since` aging** as a backstop so a long-starved consumer can
+eventually win even if income bounding is imperfect — small, and it makes the
+system robust rather than relying on income emptying perfectly.
 
 ## 5. Why the behavior falls out
 
-A plain negative-feedback loop on a slow variable:
+A slow negative-feedback loop:
 
 ```
-stores fill → fill high → consumer allocation grows → more build/upgrade WORK
-            → energy drains → fill returns to band → settles
+stores fill → fill high → income growth gated off (Lever 1) → income demand empties
+           → scheduler reaches flow-budgeted consumers → builders/upgraders spawn
+           → construction absorb scaled up (Lever 2) → energy drains into progress
+           → fill returns to band → income unblocks → settles
 ```
 
-Because we're spawn-bound, the consumer WORK we can field is capped by spawn
-time, so the loop settles wherever the spawn budget balances income against
-consumption. The "right" amount of build/upgrade is an **equilibrium of the
-thermostat**, not a formula we maintain. Tuning is the setpoint band and the
-build/upgrade weights (§6) — a couple of constants, not a model.
+Spawn-bound means the consumer WORK we can field is capped by spawn time, so the
+loop settles where the spawn budget balances income against consumption — the
+"optimum that evenly consumes the surplus" as an equilibrium, not a formula.
 
-## 6. The build/upgrade split: a weight, not a switch
+## 6. The build/upgrade split — already a weight, not a switch
 
-Ideally construction is just **weighted higher** so energy naturally prefers it,
-yet upgrading still draws flow where that makes more sense (e.g. construction
-queue is short but the controller is starving / near downgrade). This is the
-god-points routing idea applied narrowly to the split:
-
-```
-construction sink weight  >  controller sink weight
-```
-
-The solver allocates the fill-driven consumer budget across both by weight, so
-both can receive energy simultaneously — construction just wins ties. Start with
-a weight high enough that it behaves like "construction-first" while sites exist,
-but keep it a tunable weight (not a hard gate) so upgrading is never fully
-starved. This is the one real policy knob.
+`DEFAULT_SINK_VALUE` already encodes exactly the weighting we wanted: construction
+(70) is preferred over the controller (50), but the controller still draws the
+remainder, so upgrading is never fully starved. **No new split logic is needed** —
+Lever 2 just removes the absorb cap that currently prevents the existing
+preference from taking effect. The one tunable knob is the construction absorb
+scaling (and, if we ever want it, nudging the 70/50 weights).
 
 ## 7. What maps onto existing code
 
-| concern | today | after |
+| concern | today | change |
 | --- | --- | --- |
-| consumer crew size | RCL heuristic / dedicated-source floor | `WORK = allocation / rate` (pure) |
-| consumer ↔ flow | allocation field, mostly ignored | allocation is the *only* input |
-| consumer sink demand | fixed / priority constant | function of `storeFill` |
-| build vs upgrade | n/a (upgrade-only got energy by luck) | sink **weights** (construction > controller) |
-| income growth | unbounded (income tier) | gated on `fill` above high setpoint |
-| stored energy | unmonitored | the regulated variable (`storeFill`) |
+| consumer crew size | already `allocation / rate` | drop vestigial RCL path (cosmetic) |
+| income growth | uncapped (remote/transient unbounded) | **gate on `storeFill` ≥ high setpoint** |
+| construction absorb | fixed `=5` e/tick | **scale with `storeFill`** (and site work) |
+| build vs upgrade weight | `DEFAULT_SINK_VALUE` 70 > 50 | keep |
+| anti-starvation aging | declared, never wired | optionally implement `since` |
+| stored energy | unmonitored | `storeFill(room)` — the regulated variable |
 
-The spawn scheduler does **not** need its income tier ripped out for this to
-work: once consumer demand is real and bounded *and* income growth is gated on
-fill, the scheduler's free spawn ticks naturally flow to the consumers. We can
-revisit the tier later if needed, but it is not on the critical path here.
+The scheduler's `+1e6` income tier does **not** need ripping out: once income
+growth is bounded by fill, its demand empties and the free spawn ticks flow to
+consumers on their own.
 
 ## 8. Migration plan (incremental, each step shippable + tested)
 
-1. **Add `storeFill(room)` + a probe.** Report stored energy, capacity, fill, and
-   per-role spawn share; establish the W43N23 baseline (construction 0, fill
-   climbing toward full). No behavior change.
-2. **Size consumers from their allocation.** Replace `UpgradingCorp`'s RCL
-   heuristic and `ConstructionCorp`'s floor with allocation-driven sizing. With
-   current allocations this alone should let build/upgrade grow. Gate behind
-   tests + probe (construction energy > 0).
-3. **Drive consumer sink demand from fill, split by weight.** Feed `storeFill`
-   into construction + controller sink demand; weight construction above
-   controller. Probe: fill holds its band; control-points/tick rises.
-4. **Gate income growth on fill.** Stop opening marginal haulers / remote mines
-   while `fill` is above the high setpoint. Probe: energy-on-creeps share drops;
-   no income starvation at cold start.
+1. **`storeFill(room)` + a probe.** Report stored energy, capacity, fill, and
+   per-role spawn share; establish the W43N23 baseline (income-dominated spawn,
+   fill climbing, construction 0). No behavior change.
+2. **Lever 1 — gate income growth on `fill`.** Stop adding remote/transient and
+   marginal sources while `fill` is above the high setpoint. Probe: energy-on-creeps
+   share drops; consumers start getting spawn ticks; no income starvation at cold
+   start (`fill` starts low).
+3. **Lever 2 — scale construction absorb with `fill`.** Replace the fixed `=5`.
+   Probe: with sites present, construction energy > 0 and rises with `fill`;
+   controller still fed; `fill` holds its band.
+4. **Lever 3 — cleanup + optional `since` aging.** Drop the vestigial RCL path;
+   wire `since` as a starvation backstop. Probe: a long-waiting builder eventually
+   spawns even under (artificially) sustained income demand.
 
 ## 9. Test plan — a graduated ladder
 
-Build the test ladder bottom-up: **prove each corp in isolation doing one job
-well**, then combine corps and complicate the scenario one rung at a time. **Do
-not advance a rung until the one below is efficient and flexible** (handles
-asymmetric/swamp/variant layouts, not just the happy path). Each rung has a
-hard efficiency bar, not just "it runs."
+Build the ladder bottom-up: **prove each corp in isolation doing one job well**,
+then combine corps and complicate the scenario one rung at a time. **Do not advance
+a rung until the one below is efficient and flexible** (handles asymmetric/swamp/
+variant layouts, not just the happy path). Each rung has a hard efficiency bar.
 
-The existing scenario library (`test/integration/scenario/library.ts`:
+Substrate confirmed to exist: mock-based corp unit tests (`test/unit/corps/`, e.g.
+`getSpawnDemand.test.ts`, `pickSinkByAllocation.test.ts`) for single-corp isolation,
+and the integration scenario library (`test/integration/scenario/library.ts`:
 `singleSource`, `asymmetricTwoSource`, `swampSource`, `twoSourceRcl3Containers`,
-`remoteSource`, …) and `RoomBuilder` are the building blocks — most rungs reuse
-or lightly extend them.
+`remoteSource`, …) + `RoomBuilder` for combined rungs.
 
-**Rung 0 — unit (pure functions, no sim).**
-`storeFill` from container/storage contents (graceful when no storage exists);
-consumer spawn demand is a pure function of allocation (no hidden heuristic);
-income gate fires only above the high setpoint; weighted split routes more to
-construction but never zero to upgrade.
+**Rung 0 — unit (pure functions, no sim).** `storeFill` from container/storage
+contents (graceful when no storage exists); consumer spawn demand is a pure
+function of allocation (extend `getSpawnDemand.test.ts`); income-growth gate fires
+only above the high setpoint; construction absorb scales with `fill`.
 
-**Rung 1 — each corp alone, one job.** One corp, a scenario that isolates its
-function, an efficiency bar:
-- *UpgradingCorp* on a controller with a stocked container → controller progress
-  per energy at/near the WORK-rate ceiling; fleet size tracks its allocation.
-- *ConstructionCorp* with a stocked source/container and one site → site
-  completes; builder WORK tracks allocation; no idle builders.
-- *Income (miner+hauler)* on `singleSource` → source drained, no pile-up; across
+**Rung 1 — each corp alone, one job** (mock-based unit tests, efficiency bar each):
+- *UpgradingCorp* with a stocked controller container → controller progress per
+  energy near the WORK ceiling; fleet tracks allocation.
+- *ConstructionCorp* with a stocked source + one site → site completes; builder
+  WORK tracks allocation; no idle builders.
+- *Income (miner+hauler)* on `singleSource` → source drained, no pile-up; repeat on
   `asymmetricTwoSource`/`swampSource` to prove flexibility.
 
-**Rung 2 — two corps, the handoff.** Income + one consumer, so the flow→corp
-allocation actually drives the consumer: `singleSourceRcl3` with a site (income →
-construction) and with a starving controller (income → upgrade). Bar: consumer
-energy > 0, `fill` doesn't run away, no income starvation.
+**Rung 2 — two corps, the handoff** (`singleSourceRcl3` + a site / + a starving
+controller): income → consumer. Bar: consumer energy > 0, `fill` doesn't run away,
+no income starvation.
 
-**Rung 3 — the split under one roof.** Income + construction + upgrade together
-(`twoSourceRcl3Containers`): the fill-driven budget splits by weight — both
-consumers fed, construction favored, `fill` held in band. This is the W43N23
-reproduction; the symptom must invert (construction energy > 0, control-points/
-tick rising).
+**Rung 3 — the split under one roof** (`twoSourceRcl3Containers`): construction +
+upgrade both fed, construction favored (it already is, by value 70>50), `fill` held
+in band. This is the W43N23 reproduction; the symptom must invert (construction
+energy > 0, control-points/tick rising).
 
-**Rung 4 — scale & regression.** Remote mining (`remoteSource`) and the cold-start
-climb (RCL 1→3 time must not regress — `fill` starts low so consumers stay small
-and income is unblocked). Existing `twoSourceRcl3` harvest/haul probes stay green.
+**Rung 4 — scale & regression** (`remoteSource` + cold-start RCL 1→3 climb time must
+not regress; existing `twoSourceRcl3` probes stay green).
 
 Promotion rule: a rung is "done" only when its efficiency bar holds across the
-*variant* layouts at that rung, so the behavior is robust before it carries more
-weight above it.
+*variant* layouts at that rung.
 
 ## 10. Risks & open questions
 
-- **Hysteresis / actuator lag.** Spawning is slow, so even on the level we want a
-  setpoint *band* (separate grow/throttle thresholds) so the fleet doesn't thrash
-  around a single point. Size the band wider than one spawn cycle's worth of
-  swing.
+- **Hysteresis / actuator lag.** Even on the level, use a setpoint *band* (separate
+  grow/throttle thresholds, wider than one spawn cycle) so the fleet doesn't thrash.
 - **No storage yet (low RCL).** Before storage exists, "stored energy" = source
-  containers (and ground piles). `storeFill` must degrade gracefully and the band
-  scale with whatever capacity exists.
-- **Spawn-budget accounting.** "Spawn-bound" assumes we can read remaining spawn
-  capacity; sizing consumers beyond what spawn time allows must be a graceful cap,
-  not thrash.
-- **Build/upgrade weight** (§6) is the policy knob; keep it a single documented
-  constant/function.
+  containers (and ground piles). `storeFill` must degrade gracefully; the band
+  scales with whatever capacity exists.
+- **Income bounding vs. legitimate expansion.** Gating income on `fill` must not
+  permanently refuse a genuinely profitable remote when stores are merely
+  momentarily full — the band + the slow level signal should cover this, but it's
+  the thing to watch in Rung 4.
+- **Construction absorb scaling shape.** Linear in `fill`? Proportional to remaining
+  site work? Start simple (a `fill`-scaled multiple of the current 5) and tune.
 
 ## 11. One-line summary
 
-Treat the **stored-energy level as a thermostat**: the planner scales
-build/upgrade allocations with how full the reservoir is (and caps income when
-it's full), splitting between build and upgrade by weight; corps stay dumb and
-size themselves to their allocation; and one slow feedback loop balances
-mine-vs-build-vs-upgrade without any modeled "value."
+Treat the **stored-energy level as a thermostat**: gate income growth when the
+reservoir is full so the spawn frees ticks for the consumers the flow already
+budgets, and lift the construction absorb cap so building (already weighted above
+upgrading) can soak the surplus — one slow feedback loop, no modeled "value."

--- a/docs/GOD_POINTS_CHAIN_DESIGN.md
+++ b/docs/GOD_POINTS_CHAIN_DESIGN.md
@@ -1,12 +1,14 @@
-# Surplus Thermostat — Balancing Income vs. Build/Upgrade
+# Energy-Store Thermostat — Balancing Income vs. Build/Upgrade
 
 Status: **proposal / design-only** (no code yet). Companion to
 [`ECONOMIC_FRAMEWORK.md`](./ECONOMIC_FRAMEWORK.md).
 
-> Earlier drafts of this doc chased a "god-points" terminal-value model. We
-> dropped it: it modeled a value we'd have to invent and tune. This design keys
-> off **measured state** (stored energy) instead — simpler, and the desired
-> behavior falls out of one feedback loop.
+> Earlier drafts chased a "god-points" terminal-value model. We dropped it: it
+> modeled a value we'd have to invent and tune. This design keys off **measured
+> state** instead. And we control on the **stored-energy level**, not its rate of
+> change — the level is the integral of net flow, so it's naturally smooth and
+> matched to the slow spawn actuator. The desired behavior falls out of one
+> feedback loop.
 
 ## 1. The problem, in one screenshot
 
@@ -19,10 +21,10 @@ Room W43N23, established, 24h:
 | energy on construction | **0** |
 | control points | flat / ~0 |
 
-The colony harvests plenty and pours almost all of it back into *making more
-creeps* (haulers, remote-mining crews). The two activities that actually advance
-the empire — **upgrading** and **construction** — get nothing. A source-container
-site sat unbuilt for a very long time because no builder ever spawned.
+The colony harvests plenty and pours almost all of it into *making more creeps*
+(haulers, remote-mining crews). The two activities that actually advance the
+empire — **upgrading** and **construction** — get nothing. A source-container site
+sat unbuilt for a very long time because no builder ever spawned.
 
 ## 2. Root cause: the flow→corp gap, and an unregulated economy
 
@@ -46,46 +48,53 @@ Two concrete faults:
    energy-bound** — there is surplus energy — yet the colony keeps spending its
    scarce spawn time on more income instead of consuming what it already has.
 
-## 3. The idea: stored energy is the thermostat
+## 3. The idea: stored-energy *level* is the thermostat
 
 We are spawn-bound and energy-rich, so the quantity to regulate is **stored
-energy**. You already named the sensor: **container + storage levels**. One
-measured number drives the whole economy:
+energy**, and the gauge is **container + storage levels**.
+
+**Control on the level, not the rate.** A naive "surplus/tick" signal
+(`Δstores`) is noisy tick-to-tick, and spawning a creep is a slow actuator
+(hundreds of ticks to field a fleet). Driving a laggy actuator from a noisy
+derivative oscillates. The **level** is the integral of net flow — it already
+low-pass-filters the noise and moves on the same slow timescale as spawning. So
+we read the gauge and compare to a setpoint band:
 
 ```
-surplus/tick  =  rate stored energy is piling up
-              =  Δ(source containers + storage) over the planning window
+fill = storedEnergy(room) / storableCapacity(room)        # 0..1, smooth
 ```
 
-- **Surplus > 0** (stores filling): we collect more than we use → grow the
+- **`fill` high** (stores near full): we collect more than we use → grow the
   consumers (build/upgrade) to spend it, and stop adding income.
-- **Surplus < 0** (stores draining): consumers are outrunning income → shrink
-  consumers (or add income, if spawn budget allows).
-- **Surplus ≈ 0**: balanced. This is the "optimum that evenly consumes the
-  surplus" — it falls out, it isn't computed.
+- **`fill` low** (stores near empty): consumers are outrunning income → throttle
+  consumers (and/or add income, if spawn budget allows).
+- **`fill` in-band**: balanced — the "optimum that evenly consumes the surplus"
+  is the equilibrium the loop settles into, not a number we compute.
 
-No modeled value, no god points. Just a thermostat reading a real gauge.
+No modeled value, no god points, no differentiation of a noisy signal. Just a
+thermostat reading a slow, real gauge.
 
 ## 4. Three small changes (the whole design)
 
-### 4.1 Measure surplus
+### 4.1 Read the level
 
 A single cheap function, run each planning cycle:
 
 ```
-roomSurplus(room) -> energy/tick
+storeFill(room) -> 0..1     # stored energy / storable capacity
 ```
 
-From the stored-energy level and its short-window trend (source containers +
-storage; spawn/extension fill tells us income is "enough"). Real state, no
-estimation chain.
+From container + storage contents over their capacity. Smooth by construction —
+no trend/derivative needed. (We may keep the trend around later as a secondary
+tiebreak, but the **level is the primary control signal.**)
 
-### 4.2 Feed surplus into the consumer sinks
+### 4.2 Consumer demand scales with fill
 
-In the flow graph, set the **construction + controller sink demand = surplus**
-(split by a simple policy — see §6), instead of the current fixed/priority guess.
-The solver already routes energy to sinks; now it routes the *surplus* to the
-things that turn it into progress. This is the only change to the solver inputs.
+In the flow graph, set the **construction + controller sink demand as a function
+of `fill`** instead of a fixed/priority constant — e.g. demand rises as `fill`
+climbs above a low setpoint and saturates near full. The solver already routes
+energy to sinks; now it routes *more* of it to consumers exactly when the
+reservoir is backing up. This is the only change to the solver inputs.
 
 ### 4.3 Tighten the handoff — consumers size from their allocation
 
@@ -105,38 +114,45 @@ Now `getSpawnDemand` is a **pure function of the allocation** — the flow and t
 corps finally speak one language. Corps stay dumb: they don't decide *how much*,
 they only execute their funded size.
 
-### 4.4 Let surplus regulate income too
+### 4.4 Let fill regulate income too
 
-The same surplus number caps income: when stored energy is high, the colony
-already collects more than it uses, so **stop opening new haulers / remote
-mines**. Concretely, gate income growth (the marginal hauler, the next remote
-source) on `surplus <= 0`. One signal grows consumers *and* caps income — which
-is precisely what kills the 212K-into-creeps over-spawn.
+The same level caps income: when `fill` is high, the colony already collects more
+than it uses, so **stop opening new haulers / remote mines**. Gate income growth
+(the marginal hauler, the next remote source) on `fill` being above the high
+setpoint. One signal grows consumers *and* caps income — precisely what kills the
+212K-into-creeps over-spawn.
 
 ## 5. Why the behavior falls out
 
-A plain negative-feedback loop:
+A plain negative-feedback loop on a slow variable:
 
 ```
-stores fill → surplus>0 → consumer allocation grows → more build/upgrade WORK
-            → energy drains → surplus→0 → settles
+stores fill → fill high → consumer allocation grows → more build/upgrade WORK
+            → energy drains → fill returns to band → settles
 ```
 
 Because we're spawn-bound, the consumer WORK we can field is capped by spawn
 time, so the loop settles wherever the spawn budget balances income against
 consumption. The "right" amount of build/upgrade is an **equilibrium of the
-thermostat**, not a formula we maintain. Tuning is one or two constants (target
-store band, build/upgrade split), not a model.
+thermostat**, not a formula we maintain. Tuning is the setpoint band and the
+build/upgrade weights (§6) — a couple of constants, not a model.
 
-## 6. The one policy choice: splitting surplus
+## 6. The build/upgrade split: a weight, not a switch
 
-How to divide the surplus between construction and upgrading. Start simple:
+Ideally construction is just **weighted higher** so energy naturally prefers it,
+yet upgrading still draws flow where that makes more sense (e.g. construction
+queue is short but the controller is starving / near downgrade). This is the
+god-points routing idea applied narrowly to the split:
 
-- **Construction-first:** while construction sites exist, surplus goes to build;
-  otherwise to upgrade. (Matches "finish infrastructure, then pour into RCL.")
-- Alternative: a fixed ratio, or shift toward upgrade as RCL nears a target.
+```
+construction sink weight  >  controller sink weight
+```
 
-Pick construction-first to start; it's the least surprising and easy to change.
+The solver allocates the fill-driven consumer budget across both by weight, so
+both can receive energy simultaneously — construction just wins ties. Start with
+a weight high enough that it behaves like "construction-first" while sites exist,
+but keep it a tunable weight (not a hard gate) so upgrading is never fully
+starved. This is the one real policy knob.
 
 ## 7. What maps onto existing code
 
@@ -144,58 +160,98 @@ Pick construction-first to start; it's the least surprising and easy to change.
 | --- | --- | --- |
 | consumer crew size | RCL heuristic / dedicated-source floor | `WORK = allocation / rate` (pure) |
 | consumer ↔ flow | allocation field, mostly ignored | allocation is the *only* input |
-| consumer sink demand | fixed / priority constant | `= surplus` (measured) |
-| income growth | unbounded (income tier) | gated on `surplus <= 0` |
-| stored energy | unmonitored | the regulated variable (`roomSurplus`) |
+| consumer sink demand | fixed / priority constant | function of `storeFill` |
+| build vs upgrade | n/a (upgrade-only got energy by luck) | sink **weights** (construction > controller) |
+| income growth | unbounded (income tier) | gated on `fill` above high setpoint |
+| stored energy | unmonitored | the regulated variable (`storeFill`) |
 
 The spawn scheduler does **not** need its income tier ripped out for this to
 work: once consumer demand is real and bounded *and* income growth is gated on
-surplus, the scheduler's free spawn ticks naturally flow to the consumers. We can
+fill, the scheduler's free spawn ticks naturally flow to the consumers. We can
 revisit the tier later if needed, but it is not on the critical path here.
 
 ## 8. Migration plan (incremental, each step shippable + tested)
 
-1. **Add `roomSurplus(room)` + a probe.** Measure stored-energy trend and per-role
-   spawn share; establish the W43N23 baseline (construction 0, stores climbing).
-   No behavior change.
+1. **Add `storeFill(room)` + a probe.** Report stored energy, capacity, fill, and
+   per-role spawn share; establish the W43N23 baseline (construction 0, fill
+   climbing toward full). No behavior change.
 2. **Size consumers from their allocation.** Replace `UpgradingCorp`'s RCL
    heuristic and `ConstructionCorp`'s floor with allocation-driven sizing. With
    current allocations this alone should let build/upgrade grow. Gate behind
    tests + probe (construction energy > 0).
-3. **Drive consumer sink demand from surplus.** Feed `roomSurplus` into the
-   construction + controller sink demand, with the construction-first split.
-   Probe: stored energy holds a band; control-points/tick rises.
-4. **Gate income growth on surplus.** Stop opening marginal haulers / remote
-   mines while `surplus > 0`. Probe: energy-on-creeps share drops; no income
-   starvation at cold start.
+3. **Drive consumer sink demand from fill, split by weight.** Feed `storeFill`
+   into construction + controller sink demand; weight construction above
+   controller. Probe: fill holds its band; control-points/tick rises.
+4. **Gate income growth on fill.** Stop opening marginal haulers / remote mines
+   while `fill` is above the high setpoint. Probe: energy-on-creeps share drops;
+   no income starvation at cold start.
 
-## 9. Test plan
+## 9. Test plan — a graduated ladder
 
-- **Sim probe:** stored energy stays in a band (no overflow, no empty);
-  build + upgrade energy > 0; control-points/tick rising — the W43N23 symptom
-  inverts.
-- **Unit:** `roomSurplus` sign/magnitude from container deltas; consumer spawn
-  demand is a pure function of allocation (no hidden heuristic); income growth
-  gate fires only when `surplus > 0`.
-- **Cold-start regression:** RCL 1→3 climb time does not regress (surplus starts
-  ≤ 0, so consumers stay small and income is unblocked; bootstrap unchanged).
-- **No-regression:** existing `twoSourceRcl3` harvest/haul probes stay green.
+Build the test ladder bottom-up: **prove each corp in isolation doing one job
+well**, then combine corps and complicate the scenario one rung at a time. **Do
+not advance a rung until the one below is efficient and flexible** (handles
+asymmetric/swamp/variant layouts, not just the happy path). Each rung has a
+hard efficiency bar, not just "it runs."
+
+The existing scenario library (`test/integration/scenario/library.ts`:
+`singleSource`, `asymmetricTwoSource`, `swampSource`, `twoSourceRcl3Containers`,
+`remoteSource`, …) and `RoomBuilder` are the building blocks — most rungs reuse
+or lightly extend them.
+
+**Rung 0 — unit (pure functions, no sim).**
+`storeFill` from container/storage contents (graceful when no storage exists);
+consumer spawn demand is a pure function of allocation (no hidden heuristic);
+income gate fires only above the high setpoint; weighted split routes more to
+construction but never zero to upgrade.
+
+**Rung 1 — each corp alone, one job.** One corp, a scenario that isolates its
+function, an efficiency bar:
+- *UpgradingCorp* on a controller with a stocked container → controller progress
+  per energy at/near the WORK-rate ceiling; fleet size tracks its allocation.
+- *ConstructionCorp* with a stocked source/container and one site → site
+  completes; builder WORK tracks allocation; no idle builders.
+- *Income (miner+hauler)* on `singleSource` → source drained, no pile-up; across
+  `asymmetricTwoSource`/`swampSource` to prove flexibility.
+
+**Rung 2 — two corps, the handoff.** Income + one consumer, so the flow→corp
+allocation actually drives the consumer: `singleSourceRcl3` with a site (income →
+construction) and with a starving controller (income → upgrade). Bar: consumer
+energy > 0, `fill` doesn't run away, no income starvation.
+
+**Rung 3 — the split under one roof.** Income + construction + upgrade together
+(`twoSourceRcl3Containers`): the fill-driven budget splits by weight — both
+consumers fed, construction favored, `fill` held in band. This is the W43N23
+reproduction; the symptom must invert (construction energy > 0, control-points/
+tick rising).
+
+**Rung 4 — scale & regression.** Remote mining (`remoteSource`) and the cold-start
+climb (RCL 1→3 time must not regress — `fill` starts low so consumers stay small
+and income is unblocked). Existing `twoSourceRcl3` harvest/haul probes stay green.
+
+Promotion rule: a rung is "done" only when its efficiency bar holds across the
+*variant* layouts at that rung, so the behavior is robust before it carries more
+weight above it.
 
 ## 10. Risks & open questions
 
-- **Surplus window.** Container/storage deltas are noisy tick-to-tick; average
-  over a planning window (or smooth) so the thermostat doesn't oscillate.
+- **Hysteresis / actuator lag.** Spawning is slow, so even on the level we want a
+  setpoint *band* (separate grow/throttle thresholds) so the fleet doesn't thrash
+  around a single point. Size the band wider than one spawn cycle's worth of
+  swing.
 - **No storage yet (low RCL).** Before storage exists, "stored energy" = source
-  containers (and ground piles). Define the gauge to degrade gracefully there.
+  containers (and ground piles). `storeFill` must degrade gracefully and the band
+  scale with whatever capacity exists.
 - **Spawn-budget accounting.** "Spawn-bound" assumes we can read remaining spawn
-  capacity; sizing consumers beyond what spawn time allows just won't field — make
-  sure that's a graceful cap, not thrash.
-- **Build/upgrade split** (§6) is the one real policy knob; keep it a single
-  documented constant/function.
+  capacity; sizing consumers beyond what spawn time allows must be a graceful cap,
+  not thrash.
+- **Build/upgrade weight** (§6) is the policy knob; keep it a single documented
+  constant/function.
 
 ## 11. One-line summary
 
-Treat **stored energy as a thermostat**: the planner sets build/upgrade
-allocations from the measured surplus and caps income when stores are full; corps
-stay dumb and size themselves to their allocation; and one feedback loop balances
+Treat the **stored-energy level as a thermostat**: the planner scales
+build/upgrade allocations with how full the reservoir is (and caps income when
+it's full), splitting between build and upgrade by weight; corps stay dumb and
+size themselves to their allocation; and one slow feedback loop balances
 mine-vs-build-vs-upgrade without any modeled "value."

--- a/docs/GOD_POINTS_CHAIN_DESIGN.md
+++ b/docs/GOD_POINTS_CHAIN_DESIGN.md
@@ -160,19 +160,30 @@ consumers on their own.
 
 ## 8. Migration plan (incremental, each step shippable + tested)
 
-1. **`storeFill(room)` + a probe.** Report stored energy, capacity, fill, and
-   per-role spawn share; establish the W43N23 baseline (income-dominated spawn,
-   fill climbing, construction 0). No behavior change.
-2. **Lever 1 — gate income growth on `fill`.** Stop adding remote/transient and
-   marginal sources while `fill` is above the high setpoint. Probe: energy-on-creeps
-   share drops; consumers start getting spawn ticks; no income starvation at cold
-   start (`fill` starts low).
-3. **Lever 2 — scale construction absorb with `fill`.** Replace the fixed `=5`.
-   Probe: with sites present, construction energy > 0 and rises with `fill`;
-   controller still fed; `fill` holds its band.
-4. **Lever 3 — cleanup + optional `since` aging.** Drop the vestigial RCL path;
-   wire `since` as a starvation backstop. Probe: a long-waiting builder eventually
-   spawns even under (artificially) sustained income demand.
+Implemented constants (all in one fill band so the levers move together):
+`INCOME_THROTTLE_LOW = 0.5`, `INCOME_THROTTLE_HIGH = 0.9`, `INCOME_BUDGET_FLOOR =
+0.5` (income spawn-budget multiplier 1.0 → 0.5 across the band);
+`CONSTRUCTION_ABSORB_RATE = 5` → `CONSTRUCTION_ABSORB_MAX = 20` across the same
+band.
+
+1. **DONE — `storeFill(room)`** (`src/economy/storeFill.ts`). The level gauge
+   (storage + containers; 0 when no reservoir, so cold start is unaffected).
+   Rung-0 unit tests. No behavior change.
+2. **DONE — Lever 1, income throttle** (`incomeBudgetScaleForFill`, threaded via
+   `ColonyProblem.incomeBudgetScale` into `selectProducers`). Scales the mining
+   spawn-part budget down as `fill` rises, shedding marginal/remote sources first
+   (the spawn's best source is always kept). Rung-0 unit tests + an end-to-end
+   planner proof (far source shed at full fill). Integration regression guard
+   green (two-source RCL3, `fill≈0`, behavior unchanged).
+3. **DONE — Lever 2, construction absorb** (`constructionAbsorbForFill` at
+   `buildColonyProblem`). Lifts the absorb cap with `fill`. Rung-0 unit tests + an
+   end-to-end proof (surplus shifts controller→construction at full fill).
+4. **TODO — Lever 3, cleanup + optional `since` aging.** Drop the vestigial RCL
+   `targetUpgraders` path; optionally wire `since` as a starvation backstop.
+5. **TODO — full-loop demonstration.** An RCL4+storage scenario run to ~1500
+   ticks showing the *combined* loop: stored energy holds a band, construction +
+   upgrade energy > 0 and rising, income expansion stands down — the W43N23
+   symptom inverting in the live sim (not just the planner).
 
 ## 9. Test plan — a graduated ladder
 

--- a/docs/GOD_POINTS_CHAIN_DESIGN.md
+++ b/docs/GOD_POINTS_CHAIN_DESIGN.md
@@ -1,0 +1,201 @@
+# God-Points Chain — Design
+
+Status: **proposal / design-only** (no code yet). Companion to
+[`ECONOMIC_FRAMEWORK.md`](./ECONOMIC_FRAMEWORK.md).
+
+## 1. The problem, in one screenshot
+
+Room W43N23, established, 24h:
+
+| metric | value |
+| --- | --- |
+| energy harvested | 257K |
+| energy on creeps | **212K** (~82%) |
+| energy on construction | **0** |
+| control points | flat / ~0 |
+
+The colony harvests plenty and pours nearly all of it back into *making more
+creeps*. The two activities that actually advance the empire — **upgrading** and
+**construction** — get essentially nothing. A source-container site sat unbuilt
+for a very long time because no builder ever spawned.
+
+## 2. Root cause: two value systems that disagree
+
+We price the economy in **two unrelated places**:
+
+1. **Flow solver** (`flow/`, `ECONOMIC_FRAMEWORK.md`). Thinks correctly: it has
+   sinks with priorities (`construction: 70`, `controller: 60`) and routes
+   *energy* to them.
+2. **Spawn scheduler** (`spawn/SpawnScheduler.ts` + each corp's
+   `getSpawnDemand`). Decides which *creep* to build, using a **separate,
+   hardcoded** value scale where income is in an untouchable tier:
+   - miner `100`, hauler `90+` → `+1,000,000` "income tier"
+   - builder `95`, upgrader `90` → consumption tier, **no** income bonus
+
+Because the scheduler picks **one creep per spawn per tick**, and any income
+demand outranks every consumer by ~1e6, the builder/upgrader are structurally
+last in line *forever*. The flow can allocate energy to the construction sink,
+but the scheduler never spawns a builder to spend it. Worse: nothing tells the
+scheduler that the *Nth hauler* or *Mth remote mine* produces **zero** terminal
+value, so "build more income" always looks worth it → the over-spawn you see.
+
+**The two systems must become one, and that one must be priced in the only thing
+that actually matters.**
+
+## 3. The principle: god points are the only terminal value
+
+> The planner maximizes **god points**. Corps are simple; the planner sticks
+> them together and judges the whole chain by the god points it yields.
+
+- **God points** = progress on the only scoreboard the game keeps: **controller
+  upgrade progress (→ RCL/GCL)**, plus **construction** (structures that unlock
+  capacity, i.e. *future* god points). Everything else — mining, hauling,
+  reserving, spawning — has **no terminal value of its own**. It is worth
+  *exactly* the god points it enables downstream, and nothing more.
+- **Only two corps emit god points**: `UpgradingCorp` (controller progress) and
+  `ConstructionCorp` (build progress, valued as the discounted future capacity
+  it unlocks). Every other corp's value is *derived*, not declared.
+- **Corps stay dumb.** A corp knows only how to (a) `project()` its own per-tick
+  cost/throughput and (b) `work()`. It does **not** assert a priority number.
+  The **planner** owns all valuation and composition. (This deletes the
+  hardcoded `90/94/95/100` values — those are the smell we're removing.)
+
+## 4. The model
+
+### 4.1 A chain
+
+A chain is the path energy takes to become god points:
+
+```
+source ──(miner)──> pile ──(hauler)──> sink ──(consumer corp)──> god points
+                                         └─ controller  → UpgradingCorp
+                                         └─ construction → ConstructionCorp
+                                         └─ spawn/ext    → (enables the creeps
+                                                            the rest of the chain
+                                                            needs — recursive)
+```
+
+We already have the seed of this: `ChainEvaluator` stands up the real corps for a
+candidate spawn and sums **net energy delivered to the controller**, by calling
+each corp's `project()`. The change is to:
+
+1. Extend the chain's terminal from "energy at controller" to **god-points/tick**
+   at the consuming endpoints (controller **and** construction), and
+2. Use that same chain valuation to drive **ongoing spawn decisions**, not just
+   spawn *placement*.
+
+### 4.2 Marginal valuation (this is the whole fix)
+
+Every spawn candidate is scored by the **marginal god points per spawn-cost** it
+adds to the chain:
+
+```
+value(candidate) = Δ(god points/tick of the chain, with candidate) / spawn cost
+```
+
+- The **first miner** on a fresh source has enormous marginal value: it unlocks
+  the entire downstream chain (its energy can become god points). → spawns first.
+- The **first hauler** is similarly high: without it the energy strands. → next.
+- The **Nth hauler** beyond what the sink can actually consume adds **~0**
+  god points (the sink is saturated) → its marginal value collapses → it stops
+  being spawned. **This is the automatic cap on over-spawn.**
+- A **remote mine** is valued by the god points its *extra* energy unlocks
+  *after* paying its full freight (reserver + long haul + spawn build-time). Once
+  home consumption is saturated, that downstream value is ~0 and the remote stops
+  looking worth it. **This is the automatic cap on too many remote mines.**
+- A **builder/upgrader** is valued at the god points it *directly* emits. When
+  income is saturated and consumers are starved (today's W43N23), the consumer's
+  marginal value is the **highest** thing on the board → it finally spawns.
+
+The income tier (`1e6`) and the hardcoded consumer values both **disappear**.
+Ranking falls out of one number: marginal god points / cost.
+
+### 4.3 Where the numbers come from
+
+Nothing new for corps to learn — we already have `Corp.project() →
+{ costPerTick, throughput, spawnPartsPerTick }`. We add the terminal piece:
+
+- `UpgradingCorp.project()` reports god-points/tick = energy converted to
+  controller progress (1:1 today; controller-level multipliers later).
+- `ConstructionCorp.project()` reports god-points/tick = build progress, with
+  the built structure's future-capacity value discounted into a god-point-
+  equivalent (a tunable conversion, documented in one place).
+- Income corps report `throughput` (energy) as today; the **planner** turns that
+  energy into god points by following the chain to its consumer and reading the
+  consumer's conversion. Income corps never see "god points."
+
+## 5. How it maps onto the code we have
+
+| concern | today | after |
+| --- | --- | --- |
+| per-corp economics | `Corp.project()` | unchanged shape; upgrade+construction also report god-points/tick |
+| chain composition | `ChainEvaluator` / `hubNet` (placement only) | same composition, terminal extended to god points, reused for **spawn ranking** |
+| energy routing | flow solver sinks + priorities | unchanged; sink priority *derived from* the same god-point conversion so routing and spawning agree |
+| spawn ranking | `SpawnScheduler` hardcoded value + 1e6 income tier | **replaced** by marginal-god-point ranking emitted by the planner |
+| corp priorities | `value: 90/94/95/100` literals | **deleted** — corps stop asserting value |
+
+The spawn scheduler becomes a thin executor: the planner hands it a ranked list
+(or just the single best candidate) computed from chain marginal value; the
+scheduler only decides body size vs. available energy and whether to wait.
+
+## 6. Cold-start (the part that has bitten us)
+
+Marginal valuation handles cold-start *without a special case*, because when
+god-point throughput is **0**, the first miner/hauler have the highest marginal
+value on the board (they unlock the only path to any god points at all). The
+existing **bootstrap corp stays** for RCL 1 (300-energy rooms, where spending on
+the flow economy starves the single jack — see `FLOW_MIN_RCL`). Above that, the
+marginal model takes over. We must verify we don't regress the "must
+over-invest in income before any god points exist" early phase — see test plan.
+
+## 7. Migration plan (incremental, each step shippable + tested)
+
+1. **Instrument, don't change behavior.** Add god-points/tick to
+   `UpgradingCorp.project()` and `ConstructionCorp.project()`; add a sim probe
+   that reports chain **god-points/tick** and per-role spawn share. Establish the
+   W43N23 baseline (construction = 0) in the sim. *No economic change yet.*
+2. **One chain, end-to-end value.** Extend `ChainEvaluator` to score a chain in
+   god points (controller + construction endpoints). Keep it placement-only for
+   now; assert via unit tests that a saturated sink yields ~0 marginal value for
+   an extra hauler.
+3. **Bridge the scheduler.** Replace the consumer corps' hardcoded values with a
+   value derived from their chain marginal god points (income tier still intact).
+   This alone should let builders/upgraders break the starvation — smallest
+   user-visible win. Gate behind tests + the probe (construction > 0).
+4. **Unify ranking.** Move income corps onto the same marginal-god-point scale and
+   delete the `1e6` income tier. The planner emits the ranked spawn plan; the
+   scheduler becomes the thin executor. Heaviest step; do last, with the
+   cold-start regression suite green.
+5. **Align flow sink priorities** with the same conversion so routing and
+   spawning never disagree again.
+
+## 8. Test plan
+
+- **Probe (sim):** chain god-points/tick, energy split by role, construction
+  energy > 0, control-points/tick rising — the W43N23 symptom must invert.
+- **Unit:** marginal value of an extra hauler on a saturated sink ≈ 0; marginal
+  value of the first miner on a fresh source ≫ any consumer; remote-mine value
+  goes negative once home consumption is saturated.
+- **Cold-start regression:** RCL1→3 climb time does not regress vs. current
+  bootstrap behavior.
+- **No-regression:** existing `twoSourceRcl3` harvest/haul probes stay green.
+
+## 9. Risks & open questions
+
+- **Construction → god-point conversion** is a judgment call (how much is a future
+  extension "worth" now?). Keep it a single tunable constant with a documented
+  rationale; don't scatter it.
+- **Saturation signal.** "The sink can't consume more" must be a clean, cheap
+  read (consumer `project()` throughput cap), or the marginal calc gets fuzzy.
+- **CPU.** Re-scoring chains every spawn tick may be too costly; likely cache the
+  chain valuation and only re-score on structural change (new source/sink/RCL).
+- **Step 4 is the historically tricky one.** Steps 1–3 deliver the visible win
+  (construction un-starves) with the income tier still in place as a safety net;
+  only collapse the tier once the marginal model is proven in-sim.
+
+## 10. One-line summary
+
+Stop pricing the colony in energy and creep-counts. Price it in **god points**,
+let the **planner** value every creep by the marginal god points its chain
+yields, and the over-spawning, the starved builder, and the flat control-points
+curve all fix themselves — while the corps stay dumb.

--- a/docs/GOD_POINTS_CHAIN_DESIGN.md
+++ b/docs/GOD_POINTS_CHAIN_DESIGN.md
@@ -1,7 +1,12 @@
-# God-Points Chain — Design
+# Surplus Thermostat — Balancing Income vs. Build/Upgrade
 
 Status: **proposal / design-only** (no code yet). Companion to
 [`ECONOMIC_FRAMEWORK.md`](./ECONOMIC_FRAMEWORK.md).
+
+> Earlier drafts of this doc chased a "god-points" terminal-value model. We
+> dropped it: it modeled a value we'd have to invent and tune. This design keys
+> off **measured state** (stored energy) instead — simpler, and the desired
+> behavior falls out of one feedback loop.
 
 ## 1. The problem, in one screenshot
 
@@ -14,188 +19,183 @@ Room W43N23, established, 24h:
 | energy on construction | **0** |
 | control points | flat / ~0 |
 
-The colony harvests plenty and pours nearly all of it back into *making more
-creeps*. The two activities that actually advance the empire — **upgrading** and
-**construction** — get essentially nothing. A source-container site sat unbuilt
-for a very long time because no builder ever spawned.
+The colony harvests plenty and pours almost all of it back into *making more
+creeps* (haulers, remote-mining crews). The two activities that actually advance
+the empire — **upgrading** and **construction** — get nothing. A source-container
+site sat unbuilt for a very long time because no builder ever spawned.
 
-## 2. Root cause: two value systems that disagree
+## 2. Root cause: the flow→corp gap, and an unregulated economy
 
-We price the economy in **two unrelated places**:
+Two concrete faults:
 
-1. **Flow solver** (`flow/`, `ECONOMIC_FRAMEWORK.md`). Thinks correctly: it has
-   sinks with priorities (`construction: 70`, `controller: 60`) and routes
-   *energy* to them.
-2. **Spawn scheduler** (`spawn/SpawnScheduler.ts` + each corp's
-   `getSpawnDemand`). Decides which *creep* to build, using a **separate,
-   hardcoded** value scale where income is in an untouchable tier:
-   - miner `100`, hauler `90+` → `+1,000,000` "income tier"
-   - builder `95`, upgrader `90` → consumption tier, **no** income bonus
+1. **Consumers ignore their allocation.** The flow solver computes a controller
+   and construction allocation, then the corps **throw it away** and use ad-hoc
+   heuristics:
+   - `UpgradingCorp.plan()` sets upgrader count from an RCL rule
+     (`rcl<=2 ? 1 : 2`, capped at 3). It holds a flow-allocation field but does
+     not size from it.
+   - `ConstructionCorp` floors the builder to a dedicated-source guess, and then
+     the spawn scheduler's income tier buries it anyway.
 
-Because the scheduler picks **one creep per spawn per tick**, and any income
-demand outranks every consumer by ~1e6, the builder/upgrader are structurally
-last in line *forever*. The flow can allocate energy to the construction sink,
-but the scheduler never spawns a builder to spend it. Worse: nothing tells the
-scheduler that the *Nth hauler* or *Mth remote mine* produces **zero** terminal
-value, so "build more income" always looks worth it → the over-spawn you see.
+   So the flow and the corps speak different languages, and the consumer side
+   never grows to use available energy.
 
-**The two systems must become one, and that one must be priced in the only thing
-that actually matters.**
+2. **Nothing regulates income.** The spawn scheduler ranks income (miner/hauler)
+   in a `+1,000,000` tier above every consumer, and nothing tells it the *Nth*
+   hauler or *Mth* remote mine produces no benefit. We are **spawn-bound, not
+   energy-bound** — there is surplus energy — yet the colony keeps spending its
+   scarce spawn time on more income instead of consuming what it already has.
 
-## 3. The principle: god points are the only terminal value
+## 3. The idea: stored energy is the thermostat
 
-> The planner maximizes **god points**. Corps are simple; the planner sticks
-> them together and judges the whole chain by the god points it yields.
-
-- **God points** = progress on the only scoreboard the game keeps: **controller
-  upgrade progress (→ RCL/GCL)**, plus **construction** (structures that unlock
-  capacity, i.e. *future* god points). Everything else — mining, hauling,
-  reserving, spawning — has **no terminal value of its own**. It is worth
-  *exactly* the god points it enables downstream, and nothing more.
-- **Only two corps emit god points**: `UpgradingCorp` (controller progress) and
-  `ConstructionCorp` (build progress, valued as the discounted future capacity
-  it unlocks). Every other corp's value is *derived*, not declared.
-- **Corps stay dumb.** A corp knows only how to (a) `project()` its own per-tick
-  cost/throughput and (b) `work()`. It does **not** assert a priority number.
-  The **planner** owns all valuation and composition. (This deletes the
-  hardcoded `90/94/95/100` values — those are the smell we're removing.)
-
-## 4. The model
-
-### 4.1 A chain
-
-A chain is the path energy takes to become god points:
+We are spawn-bound and energy-rich, so the quantity to regulate is **stored
+energy**. You already named the sensor: **container + storage levels**. One
+measured number drives the whole economy:
 
 ```
-source ──(miner)──> pile ──(hauler)──> sink ──(consumer corp)──> god points
-                                         └─ controller  → UpgradingCorp
-                                         └─ construction → ConstructionCorp
-                                         └─ spawn/ext    → (enables the creeps
-                                                            the rest of the chain
-                                                            needs — recursive)
+surplus/tick  =  rate stored energy is piling up
+              =  Δ(source containers + storage) over the planning window
 ```
 
-We already have the seed of this: `ChainEvaluator` stands up the real corps for a
-candidate spawn and sums **net energy delivered to the controller**, by calling
-each corp's `project()`. The change is to:
+- **Surplus > 0** (stores filling): we collect more than we use → grow the
+  consumers (build/upgrade) to spend it, and stop adding income.
+- **Surplus < 0** (stores draining): consumers are outrunning income → shrink
+  consumers (or add income, if spawn budget allows).
+- **Surplus ≈ 0**: balanced. This is the "optimum that evenly consumes the
+  surplus" — it falls out, it isn't computed.
 
-1. Extend the chain's terminal from "energy at controller" to **god-points/tick**
-   at the consuming endpoints (controller **and** construction), and
-2. Use that same chain valuation to drive **ongoing spawn decisions**, not just
-   spawn *placement*.
+No modeled value, no god points. Just a thermostat reading a real gauge.
 
-### 4.2 Marginal valuation (this is the whole fix)
+## 4. Three small changes (the whole design)
 
-Every spawn candidate is scored by the **marginal god points per spawn-cost** it
-adds to the chain:
+### 4.1 Measure surplus
+
+A single cheap function, run each planning cycle:
 
 ```
-value(candidate) = Δ(god points/tick of the chain, with candidate) / spawn cost
+roomSurplus(room) -> energy/tick
 ```
 
-- The **first miner** on a fresh source has enormous marginal value: it unlocks
-  the entire downstream chain (its energy can become god points). → spawns first.
-- The **first hauler** is similarly high: without it the energy strands. → next.
-- The **Nth hauler** beyond what the sink can actually consume adds **~0**
-  god points (the sink is saturated) → its marginal value collapses → it stops
-  being spawned. **This is the automatic cap on over-spawn.**
-- A **remote mine** is valued by the god points its *extra* energy unlocks
-  *after* paying its full freight (reserver + long haul + spawn build-time). Once
-  home consumption is saturated, that downstream value is ~0 and the remote stops
-  looking worth it. **This is the automatic cap on too many remote mines.**
-- A **builder/upgrader** is valued at the god points it *directly* emits. When
-  income is saturated and consumers are starved (today's W43N23), the consumer's
-  marginal value is the **highest** thing on the board → it finally spawns.
+From the stored-energy level and its short-window trend (source containers +
+storage; spawn/extension fill tells us income is "enough"). Real state, no
+estimation chain.
 
-The income tier (`1e6`) and the hardcoded consumer values both **disappear**.
-Ranking falls out of one number: marginal god points / cost.
+### 4.2 Feed surplus into the consumer sinks
 
-### 4.3 Where the numbers come from
+In the flow graph, set the **construction + controller sink demand = surplus**
+(split by a simple policy — see §6), instead of the current fixed/priority guess.
+The solver already routes energy to sinks; now it routes the *surplus* to the
+things that turn it into progress. This is the only change to the solver inputs.
 
-Nothing new for corps to learn — we already have `Corp.project() →
-{ costPerTick, throughput, spawnPartsPerTick }`. We add the terminal piece:
+### 4.3 Tighten the handoff — consumers size from their allocation
 
-- `UpgradingCorp.project()` reports god-points/tick = energy converted to
-  controller progress (1:1 today; controller-level multipliers later).
-- `ConstructionCorp.project()` reports god-points/tick = build progress, with
-  the built structure's future-capacity value discounted into a god-point-
-  equivalent (a tunable conversion, documented in one place).
-- Income corps report `throughput` (energy) as today; the **planner** turns that
-  energy into god points by following the chain to its consumer and reading the
-  consumer's conversion. Income corps never see "god points."
+Make each consumer corp size its crew **purely from its sink allocation**:
 
-## 5. How it maps onto the code we have
+```
+desired WORK  ≈  allocatedEnergy/tick  /  per-WORK consumption rate
+```
+
+- **Delete** `UpgradingCorp`'s RCL heuristic; the upgrader fleet is whatever its
+  controller allocation funds (keep a small safety cap against a stale
+  allocation, and a floor while downgrade is imminent).
+- **Delete** `ConstructionCorp`'s dedicated-source over-floor; the builder fleet
+  is whatever its construction allocation funds.
+
+Now `getSpawnDemand` is a **pure function of the allocation** — the flow and the
+corps finally speak one language. Corps stay dumb: they don't decide *how much*,
+they only execute their funded size.
+
+### 4.4 Let surplus regulate income too
+
+The same surplus number caps income: when stored energy is high, the colony
+already collects more than it uses, so **stop opening new haulers / remote
+mines**. Concretely, gate income growth (the marginal hauler, the next remote
+source) on `surplus <= 0`. One signal grows consumers *and* caps income — which
+is precisely what kills the 212K-into-creeps over-spawn.
+
+## 5. Why the behavior falls out
+
+A plain negative-feedback loop:
+
+```
+stores fill → surplus>0 → consumer allocation grows → more build/upgrade WORK
+            → energy drains → surplus→0 → settles
+```
+
+Because we're spawn-bound, the consumer WORK we can field is capped by spawn
+time, so the loop settles wherever the spawn budget balances income against
+consumption. The "right" amount of build/upgrade is an **equilibrium of the
+thermostat**, not a formula we maintain. Tuning is one or two constants (target
+store band, build/upgrade split), not a model.
+
+## 6. The one policy choice: splitting surplus
+
+How to divide the surplus between construction and upgrading. Start simple:
+
+- **Construction-first:** while construction sites exist, surplus goes to build;
+  otherwise to upgrade. (Matches "finish infrastructure, then pour into RCL.")
+- Alternative: a fixed ratio, or shift toward upgrade as RCL nears a target.
+
+Pick construction-first to start; it's the least surprising and easy to change.
+
+## 7. What maps onto existing code
 
 | concern | today | after |
 | --- | --- | --- |
-| per-corp economics | `Corp.project()` | unchanged shape; upgrade+construction also report god-points/tick |
-| chain composition | `ChainEvaluator` / `hubNet` (placement only) | same composition, terminal extended to god points, reused for **spawn ranking** |
-| energy routing | flow solver sinks + priorities | unchanged; sink priority *derived from* the same god-point conversion so routing and spawning agree |
-| spawn ranking | `SpawnScheduler` hardcoded value + 1e6 income tier | **replaced** by marginal-god-point ranking emitted by the planner |
-| corp priorities | `value: 90/94/95/100` literals | **deleted** — corps stop asserting value |
+| consumer crew size | RCL heuristic / dedicated-source floor | `WORK = allocation / rate` (pure) |
+| consumer ↔ flow | allocation field, mostly ignored | allocation is the *only* input |
+| consumer sink demand | fixed / priority constant | `= surplus` (measured) |
+| income growth | unbounded (income tier) | gated on `surplus <= 0` |
+| stored energy | unmonitored | the regulated variable (`roomSurplus`) |
 
-The spawn scheduler becomes a thin executor: the planner hands it a ranked list
-(or just the single best candidate) computed from chain marginal value; the
-scheduler only decides body size vs. available energy and whether to wait.
+The spawn scheduler does **not** need its income tier ripped out for this to
+work: once consumer demand is real and bounded *and* income growth is gated on
+surplus, the scheduler's free spawn ticks naturally flow to the consumers. We can
+revisit the tier later if needed, but it is not on the critical path here.
 
-## 6. Cold-start (the part that has bitten us)
+## 8. Migration plan (incremental, each step shippable + tested)
 
-Marginal valuation handles cold-start *without a special case*, because when
-god-point throughput is **0**, the first miner/hauler have the highest marginal
-value on the board (they unlock the only path to any god points at all). The
-existing **bootstrap corp stays** for RCL 1 (300-energy rooms, where spending on
-the flow economy starves the single jack — see `FLOW_MIN_RCL`). Above that, the
-marginal model takes over. We must verify we don't regress the "must
-over-invest in income before any god points exist" early phase — see test plan.
+1. **Add `roomSurplus(room)` + a probe.** Measure stored-energy trend and per-role
+   spawn share; establish the W43N23 baseline (construction 0, stores climbing).
+   No behavior change.
+2. **Size consumers from their allocation.** Replace `UpgradingCorp`'s RCL
+   heuristic and `ConstructionCorp`'s floor with allocation-driven sizing. With
+   current allocations this alone should let build/upgrade grow. Gate behind
+   tests + probe (construction energy > 0).
+3. **Drive consumer sink demand from surplus.** Feed `roomSurplus` into the
+   construction + controller sink demand, with the construction-first split.
+   Probe: stored energy holds a band; control-points/tick rises.
+4. **Gate income growth on surplus.** Stop opening marginal haulers / remote
+   mines while `surplus > 0`. Probe: energy-on-creeps share drops; no income
+   starvation at cold start.
 
-## 7. Migration plan (incremental, each step shippable + tested)
+## 9. Test plan
 
-1. **Instrument, don't change behavior.** Add god-points/tick to
-   `UpgradingCorp.project()` and `ConstructionCorp.project()`; add a sim probe
-   that reports chain **god-points/tick** and per-role spawn share. Establish the
-   W43N23 baseline (construction = 0) in the sim. *No economic change yet.*
-2. **One chain, end-to-end value.** Extend `ChainEvaluator` to score a chain in
-   god points (controller + construction endpoints). Keep it placement-only for
-   now; assert via unit tests that a saturated sink yields ~0 marginal value for
-   an extra hauler.
-3. **Bridge the scheduler.** Replace the consumer corps' hardcoded values with a
-   value derived from their chain marginal god points (income tier still intact).
-   This alone should let builders/upgraders break the starvation — smallest
-   user-visible win. Gate behind tests + the probe (construction > 0).
-4. **Unify ranking.** Move income corps onto the same marginal-god-point scale and
-   delete the `1e6` income tier. The planner emits the ranked spawn plan; the
-   scheduler becomes the thin executor. Heaviest step; do last, with the
-   cold-start regression suite green.
-5. **Align flow sink priorities** with the same conversion so routing and
-   spawning never disagree again.
-
-## 8. Test plan
-
-- **Probe (sim):** chain god-points/tick, energy split by role, construction
-  energy > 0, control-points/tick rising — the W43N23 symptom must invert.
-- **Unit:** marginal value of an extra hauler on a saturated sink ≈ 0; marginal
-  value of the first miner on a fresh source ≫ any consumer; remote-mine value
-  goes negative once home consumption is saturated.
-- **Cold-start regression:** RCL1→3 climb time does not regress vs. current
-  bootstrap behavior.
+- **Sim probe:** stored energy stays in a band (no overflow, no empty);
+  build + upgrade energy > 0; control-points/tick rising — the W43N23 symptom
+  inverts.
+- **Unit:** `roomSurplus` sign/magnitude from container deltas; consumer spawn
+  demand is a pure function of allocation (no hidden heuristic); income growth
+  gate fires only when `surplus > 0`.
+- **Cold-start regression:** RCL 1→3 climb time does not regress (surplus starts
+  ≤ 0, so consumers stay small and income is unblocked; bootstrap unchanged).
 - **No-regression:** existing `twoSourceRcl3` harvest/haul probes stay green.
 
-## 9. Risks & open questions
+## 10. Risks & open questions
 
-- **Construction → god-point conversion** is a judgment call (how much is a future
-  extension "worth" now?). Keep it a single tunable constant with a documented
-  rationale; don't scatter it.
-- **Saturation signal.** "The sink can't consume more" must be a clean, cheap
-  read (consumer `project()` throughput cap), or the marginal calc gets fuzzy.
-- **CPU.** Re-scoring chains every spawn tick may be too costly; likely cache the
-  chain valuation and only re-score on structural change (new source/sink/RCL).
-- **Step 4 is the historically tricky one.** Steps 1–3 deliver the visible win
-  (construction un-starves) with the income tier still in place as a safety net;
-  only collapse the tier once the marginal model is proven in-sim.
+- **Surplus window.** Container/storage deltas are noisy tick-to-tick; average
+  over a planning window (or smooth) so the thermostat doesn't oscillate.
+- **No storage yet (low RCL).** Before storage exists, "stored energy" = source
+  containers (and ground piles). Define the gauge to degrade gracefully there.
+- **Spawn-budget accounting.** "Spawn-bound" assumes we can read remaining spawn
+  capacity; sizing consumers beyond what spawn time allows just won't field — make
+  sure that's a graceful cap, not thrash.
+- **Build/upgrade split** (§6) is the one real policy knob; keep it a single
+  documented constant/function.
 
-## 10. One-line summary
+## 11. One-line summary
 
-Stop pricing the colony in energy and creep-counts. Price it in **god points**,
-let the **planner** value every creep by the marginal god points its chain
-yields, and the over-spawning, the starved builder, and the flat control-points
-curve all fix themselves — while the corps stay dumb.
+Treat **stored energy as a thermostat**: the planner sets build/upgrade
+allocations from the measured surplus and caps income when stores are full; corps
+stay dumb and size themselves to their allocation; and one feedback loop balances
+mine-vs-build-vs-upgrade without any modeled "value."

--- a/src/economy/CorpPlanner.ts
+++ b/src/economy/CorpPlanner.ts
@@ -86,6 +86,14 @@ export interface ColonyProblem {
   sinks: PlannerSink[];
   /** Real walking distance between two positions (e.g. cached pathDistance). */
   dist: (a: Position, b: Position) => number;
+  /**
+   * Income spawn-part budget multiplier in (0, 1], from the stored-energy
+   * thermostat (see {@link incomeBudgetScaleForFill}). 1 = fund income fully
+   * (default); < 1 = stored energy is backing up, so shrink income's share of the
+   * scarce spawn-part budget and let the freed spawn ticks go to consumers.
+   * Absent → 1, so every existing caller and test is unchanged.
+   */
+  incomeBudgetScale?: number;
 }
 
 /** Canonical single value model (replaces mintValue/net-energy/effectiveNet/sink.value). */
@@ -174,6 +182,38 @@ function nearestSpawn(pos: Position, spawns: PlannerSpawn[], dist: ColonyProblem
   return best;
 }
 
+/** Below this fill, fund income fully; above INCOME_THROTTLE_HIGH, hold it at the floor. */
+export const INCOME_THROTTLE_LOW = 0.5;
+/** At/above this fill the reservoir is full enough that income is clearly over-allocated. */
+export const INCOME_THROTTLE_HIGH = 0.9;
+/** Income's spawn-part budget never drops below this share - the base economy keeps mining. */
+export const INCOME_BUDGET_FLOOR = 0.5;
+
+/**
+ * Income spawn-part budget multiplier from the stored-energy fill level (0..1).
+ *
+ * We are spawn-bound: the spawn's part-budget is the scarce resource, split
+ * between income (mining/hauling) and consumption (build/upgrade). A full
+ * reservoir is the signal that income is OVER-allocated that budget - the colony
+ * collects faster than it consumes - so we shrink income's share, freeing spawn
+ * parts (and thus spawn ticks) for the consumers that drain the surplus. This
+ * sheds the MARGINAL sources first (selectProducers fills the budget
+ * highest-net-per-part first and always keeps a spawn's best source), so the base
+ * economy is never starved - only far/remote expansion stands down.
+ *
+ * A smooth ramp on the (already smooth) level signal, so no hysteresis is needed:
+ *   fill <= LOW  -> 1.0    (climbing / draining: fund income fully)
+ *   fill >= HIGH -> FLOOR  (full: income at its floor, spawn parts to consumers)
+ * linear between. FLOOR > 0, so income is throttled, never cut off. fill = 0 (a
+ * bare room with no reservoir) returns 1, so cold start is unaffected.
+ */
+export function incomeBudgetScaleForFill(fill: number): number {
+  if (fill <= INCOME_THROTTLE_LOW) return 1;
+  if (fill >= INCOME_THROTTLE_HIGH) return INCOME_BUDGET_FLOOR;
+  const t = (fill - INCOME_THROTTLE_LOW) / (INCOME_THROTTLE_HIGH - INCOME_THROTTLE_LOW);
+  return 1 - t * (1 - INCOME_BUDGET_FLOOR);
+}
+
 /**
  * Phase 1 - PRODUCER SELECTION. Assign each source to its nearest spawn, drop the
  * unprofitable ones, and per spawn keep sources by net-energy-per-build-part until
@@ -200,8 +240,12 @@ function selectProducers(problem: ColonyProblem): CommissionedMiner[] {
     });
   }
 
-  // Per spawn, fill the mining build-time budget highest-value-first.
-  const budget = miningBudgetPerSpawn();
+  // Per spawn, fill the mining build-time budget highest-value-first. The budget
+  // shrinks when stored energy is backing up (incomeBudgetScale < 1): income is
+  // over-allocated the scarce spawn parts, so the marginal sources fall out of
+  // contention (the sort keeps the best ones, and the first source is always
+  // staffed below) and those parts free up for consumers.
+  const budget = miningBudgetPerSpawn() * (problem.incomeBudgetScale ?? 1);
   const bySpawn = new Map<string, SourceCandidate[]>();
   for (const c of candidates) {
     const list = bySpawn.get(c.spawn.id) ?? [];

--- a/src/economy/flowAdapter.ts
+++ b/src/economy/flowAdapter.ts
@@ -32,13 +32,17 @@ import {
   PlannerSpawn,
   SinkKind,
   DEFAULT_SINK_VALUE,
-  incomeBudgetScaleForFill
+  incomeBudgetScaleForFill,
+  INCOME_THROTTLE_LOW,
+  INCOME_THROTTLE_HIGH
 } from "./CorpPlanner";
 
 /** Guaranteed controller trickle (energy/tick) so it never downgrades / stalls. */
 export const ANTI_DOWNGRADE_RESERVE = 2;
-/** Energy/tick one active construction site can realistically absorb. */
+/** Base energy/tick construction absorbs while energy is scarce (reservoir low). */
 export const CONSTRUCTION_ABSORB_RATE = 5;
+/** Energy/tick construction can absorb when the reservoir is full (~2 full builders). */
+export const CONSTRUCTION_ABSORB_MAX = 20;
 
 /** Map a FlowGraph sink type to the planner's coarser sink kind. */
 function toSinkKind(type: SinkType): SinkKind | null {
@@ -79,6 +83,26 @@ export function detectTransientSources(): PlannerSource[] {
     }
   }
   return out;
+}
+
+/**
+ * Energy/tick the construction sink can absorb, scaled by stored-energy fill.
+ *
+ * The base rate is deliberately modest: while energy is scarce we don't
+ * over-invest in building ahead of the spawn/controller. But a full reservoir is
+ * surplus the colony is failing to spend, and construction is valued above the
+ * controller (DEFAULT_SINK_VALUE 70 > 50), so we lift the cap as stores fill -
+ * letting building (not just upgrading) soak the surplus, per the existing
+ * weight. Ramps BASE..MAX over the SAME fill band the income throttle uses, so
+ * the two levers move together: as income stands down, construction opens up. The
+ * controller's anti-downgrade reserve is filled before this absorb in any case,
+ * so a hungrier construction sink can never starve the controller below its floor.
+ */
+export function constructionAbsorbForFill(fill: number): number {
+  if (fill <= INCOME_THROTTLE_LOW) return CONSTRUCTION_ABSORB_RATE;
+  if (fill >= INCOME_THROTTLE_HIGH) return CONSTRUCTION_ABSORB_MAX;
+  const t = (fill - INCOME_THROTTLE_LOW) / (INCOME_THROTTLE_HIGH - INCOME_THROTTLE_LOW);
+  return CONSTRUCTION_ABSORB_RATE + t * (CONSTRUCTION_ABSORB_MAX - CONSTRUCTION_ABSORB_RATE);
 }
 
 /**
@@ -134,7 +158,7 @@ export function buildColonyProblem(
         kind === "spawn"
           ? Math.max(sink.demand, 1) // feed the spawn its overhead need
           : kind === "construction"
-            ? CONSTRUCTION_ABSORB_RATE
+            ? constructionAbsorbForFill(fill)
             : kind === "storage"
               ? Math.max(totalSupply, 1) // soak excess
               : Math.max(totalSupply, 1), // controller mops up the remainder

--- a/src/economy/flowAdapter.ts
+++ b/src/economy/flowAdapter.ts
@@ -23,6 +23,7 @@ import { pathDistance } from "../nodes/NodeNavigator";
 import { Position } from "../types/Position";
 import { minerOverhead, haulerOverhead } from "./primitives";
 import { detectRoomStocks, stockToTransientSource } from "./scavenge";
+import { storeFill } from "./storeFill";
 import {
   planColony,
   ColonyProblem,
@@ -30,7 +31,8 @@ import {
   PlannerSource,
   PlannerSpawn,
   SinkKind,
-  DEFAULT_SINK_VALUE
+  DEFAULT_SINK_VALUE,
+  incomeBudgetScaleForFill
 } from "./CorpPlanner";
 
 /** Guaranteed controller trickle (energy/tick) so it never downgrades / stalls. */
@@ -79,10 +81,30 @@ export function detectTransientSources(): PlannerSource[] {
   return out;
 }
 
+/**
+ * Colony stored-energy fill (0..1) for the income-budget thermostat: the fullest
+ * owned room's reservoir. Reads Game directly (live default), injectable for
+ * tests - mirrors {@link detectTransientSources}. Taking the MAX means any owned
+ * room backing up signals income is over-allocated spawn parts somewhere, so we
+ * throttle. No owned rooms / no Game → 0 (income unthrottled).
+ */
+export function colonyStoreFill(): number {
+  if (typeof Game === "undefined" || !Game.rooms) return 0;
+  let max = 0;
+  for (const roomName in Game.rooms) {
+    const room = Game.rooms[roomName];
+    if (!room.controller?.my) continue;
+    const fill = storeFill(room);
+    if (fill > max) max = fill;
+  }
+  return max;
+}
+
 export function buildColonyProblem(
   graph: FlowGraph,
   dist: ColonyProblem["dist"] = pathDistance,
-  transientSources: PlannerSource[] = detectTransientSources()
+  transientSources: PlannerSource[] = detectTransientSources(),
+  fill: number = colonyStoreFill()
 ): ColonyProblem {
   const spawns: PlannerSpawn[] = graph
     .getSinks("spawn")
@@ -120,7 +142,7 @@ export function buildColonyProblem(
     });
   }
 
-  return { spawns, sources, sinks, dist };
+  return { spawns, sources, sinks, dist, incomeBudgetScale: incomeBudgetScaleForFill(fill) };
 }
 
 /**
@@ -164,9 +186,10 @@ export function solveWithCorpPlanner(
   graph: FlowGraph,
   tick = 0,
   dist: ColonyProblem["dist"] = pathDistance,
-  transientSources: PlannerSource[] = detectTransientSources()
+  transientSources: PlannerSource[] = detectTransientSources(),
+  fill: number = colonyStoreFill()
 ): FlowSolution {
-  const problem = buildColonyProblem(graph, dist, transientSources);
+  const problem = buildColonyProblem(graph, dist, transientSources, fill);
   const plan = planColony(problem);
   publishRoster(plan);
 

--- a/src/economy/storeFill.ts
+++ b/src/economy/storeFill.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview storeFill - the colony's energy thermostat reading.
+ *
+ * ONE measured signal for balancing income against consumption (build/upgrade):
+ * how full the room's stored-energy reservoir is, 0..1. We deliberately read the
+ * LEVEL, not its per-tick derivative ("surplus/tick"): the level is the integral
+ * of net flow, so it is naturally smooth and moves on the same slow timescale as
+ * the spawn actuator it ultimately drives. A derivative signal is noisy tick-to-
+ * tick and, fed to a laggy actuator (spawning takes hundreds of ticks to field a
+ * fleet), would oscillate.
+ *
+ * Reservoir = storage + containers. Spawn/extensions are excluded on purpose:
+ * they are operating buffers that income keeps topped up, not surplus the colony
+ * is failing to consume. Energy backing up in containers/storage is exactly the
+ * "we collect more than we use" signal.
+ *
+ * @module economy/storeFill
+ */
+
+/**
+ * Fill level of the room's stored-energy reservoir, in [0, 1].
+ *
+ * - 1 → the reservoir is full: the colony collects more than it consumes, so
+ *   income growth should stand down and consumers (build/upgrade) should soak it.
+ * - 0 → empty (or no reservoir yet): nothing is backing up, so income is free to
+ *   grow and consumers should stay modest.
+ *
+ * Degrades gracefully before storage exists (RCL < 4): the gauge is then just the
+ * source/controller containers, whose smaller caps fill and empty faster but
+ * still signal a haul/consume backlog. With NO reservoir at all (a bare early
+ * room: no containers, no storage) capacity is 0 and we report 0 ("empty"), so a
+ * cold-start room never gates its income off.
+ */
+export function storeFill(room: Room): number {
+  const { energy, capacity } = storeLevels(room);
+  return capacity > 0 ? energy / capacity : 0;
+}
+
+/**
+ * The raw reservoir totals behind {@link storeFill}: stored energy and the
+ * capacity that holds it. Exposed for probes/telemetry that want the absolute
+ * numbers (e.g. "stores climbing toward full") alongside the normalised fill.
+ */
+export function storeLevels(room: Room): { energy: number; capacity: number } {
+  let energy = 0;
+  let capacity = 0;
+
+  const storage = room.storage;
+  if (storage) {
+    energy += storage.store[RESOURCE_ENERGY];
+    capacity += storage.store.getCapacity(RESOURCE_ENERGY) ?? 0;
+  }
+
+  const containers = room.find(FIND_STRUCTURES, {
+    filter: s => s.structureType === STRUCTURE_CONTAINER
+  }) as StructureContainer[];
+  for (const c of containers) {
+    energy += c.store[RESOURCE_ENERGY];
+    capacity += c.store.getCapacity(RESOURCE_ENERGY) ?? 0;
+  }
+
+  return { energy, capacity };
+}

--- a/test/unit/economy/CorpPlanner.test.ts
+++ b/test/unit/economy/CorpPlanner.test.ts
@@ -4,7 +4,11 @@ import {
   ColonyProblem,
   PlannerSource,
   PlannerSink,
-  PlannerSpawn
+  PlannerSpawn,
+  incomeBudgetScaleForFill,
+  INCOME_THROTTLE_LOW,
+  INCOME_THROTTLE_HIGH,
+  INCOME_BUDGET_FLOOR
 } from "../../../src/economy/CorpPlanner";
 import { netEnergy, carryPartsFor, miningBudgetPerSpawn, spawnPartsFor } from "../../../src/economy/primitives";
 import { Position } from "../../../src/types/Position";
@@ -291,3 +295,54 @@ describe("economy/CorpPlanner", () => {
 function allocOf(plan: ReturnType<typeof planColony>, sinkId: string): number {
   return plan.sinks.find(s => s.sinkId === sinkId)?.allocated ?? 0;
 }
+
+describe("income-budget thermostat (Lever 1)", () => {
+  describe("incomeBudgetScaleForFill", () => {
+    it("funds income fully when stores are low or empty (cold start is safe)", () => {
+      expect(incomeBudgetScaleForFill(0)).to.equal(1);
+      expect(incomeBudgetScaleForFill(INCOME_THROTTLE_LOW)).to.equal(1);
+    });
+
+    it("holds income at its floor once stores are full", () => {
+      expect(incomeBudgetScaleForFill(INCOME_THROTTLE_HIGH)).to.equal(INCOME_BUDGET_FLOOR);
+      expect(incomeBudgetScaleForFill(1)).to.equal(INCOME_BUDGET_FLOOR);
+    });
+
+    it("ramps monotonically down between the setpoints, never leaving [FLOOR, 1]", () => {
+      let prev = 1 + 1e-9;
+      for (let f = 0; f <= 1.0001; f += 0.05) {
+        const s = incomeBudgetScaleForFill(f);
+        expect(s).to.be.at.most(prev + 1e-9); // non-increasing
+        expect(s).to.be.within(INCOME_BUDGET_FLOOR, 1);
+        prev = s;
+      }
+    });
+  });
+
+  describe("selectProducers honours incomeBudgetScale", () => {
+    const base = {
+      spawns: [spawn("S", 0)],
+      sinks: [sink("ctrl", "controller", 0, 50, 1000)]
+    };
+    // Several cheap near sources: at full budget the spawn staffs them all.
+    const many = [source("a", 6), source("b", 8), source("c", 10), source("d", 12), source("e", 14)];
+    const count = (scale?: number) =>
+      planColony(problem({ ...base, sources: many, incomeBudgetScale: scale })).miners.length;
+
+    it("scale=1 reproduces the unthrottled baseline (omitted field)", () => {
+      expect(count(1)).to.equal(count(undefined));
+      expect(count(1)).to.be.greaterThan(1); // the layout actually staffs several
+    });
+
+    it("a vanishing scale sheds every marginal source but keeps the spawn's best", () => {
+      // Budget -> 0, yet selectProducers always staffs a spawn's single best source.
+      expect(count(1e-6)).to.equal(1);
+    });
+
+    it("throttling never increases the miner count (monotone shedding)", () => {
+      expect(count(1)).to.be.at.least(count(0.5));
+      expect(count(0.5)).to.be.at.least(count(0.1));
+      expect(count(0.1)).to.be.at.least(count(1e-6));
+    });
+  });
+});

--- a/test/unit/economy/flowAdapter.test.ts
+++ b/test/unit/economy/flowAdapter.test.ts
@@ -2,9 +2,14 @@ import { expect } from "chai";
 import { FlowGraph } from "../../../src/flow/FlowGraph";
 import { NodeNavigator } from "../../../src/nodes/NodeNavigator";
 import { createNode, Node, NodeResource } from "../../../src/nodes/Node";
-import { solveWithCorpPlanner } from "../../../src/economy/flowAdapter";
+import {
+  solveWithCorpPlanner,
+  constructionAbsorbForFill,
+  CONSTRUCTION_ABSORB_RATE,
+  CONSTRUCTION_ABSORB_MAX
+} from "../../../src/economy/flowAdapter";
 import { netEnergy } from "../../../src/economy/primitives";
-import { PlannerSource } from "../../../src/economy/CorpPlanner";
+import { PlannerSource, INCOME_THROTTLE_LOW, INCOME_THROTTLE_HIGH } from "../../../src/economy/CorpPlanner";
 import { Position } from "../../../src/types/Position";
 
 const ROOM = "W0N0";
@@ -113,5 +118,31 @@ describe("economy/flowAdapter - CorpPlanner as the FlowSolution authority", () =
     const ctrlAlloc = sol.sinkAllocations.find(a => a.sinkType === "controller");
     expect(ctrlAlloc, "controller is present").to.not.be.undefined;
     expect(ctrlAlloc!.allocated).to.be.greaterThan(1.9); // reserve protected even vs the spawn
+  });
+});
+
+describe("constructionAbsorbForFill (Lever 2)", () => {
+  it("stays at the modest base while energy is scarce (cold start unchanged)", () => {
+    expect(constructionAbsorbForFill(0)).to.equal(CONSTRUCTION_ABSORB_RATE);
+    expect(constructionAbsorbForFill(INCOME_THROTTLE_LOW)).to.equal(CONSTRUCTION_ABSORB_RATE);
+  });
+
+  it("opens up to the max once stores are full (building soaks the surplus)", () => {
+    expect(constructionAbsorbForFill(INCOME_THROTTLE_HIGH)).to.equal(CONSTRUCTION_ABSORB_MAX);
+    expect(constructionAbsorbForFill(1)).to.equal(CONSTRUCTION_ABSORB_MAX);
+  });
+
+  it("ramps monotonically up over the same band the income throttle uses", () => {
+    let prev = CONSTRUCTION_ABSORB_RATE - 1e-9;
+    for (let f = 0; f <= 1.0001; f += 0.05) {
+      const a = constructionAbsorbForFill(f);
+      expect(a).to.be.at.least(prev - 1e-9); // non-decreasing
+      expect(a).to.be.within(CONSTRUCTION_ABSORB_RATE, CONSTRUCTION_ABSORB_MAX);
+      prev = a;
+    }
+    // The base is below a single 2-WORK builder's 10/tick - that throttle is why
+    // building stalled; the full-reservoir cap clears two builders' worth.
+    expect(CONSTRUCTION_ABSORB_RATE).to.be.lessThan(10);
+    expect(CONSTRUCTION_ABSORB_MAX).to.be.at.least(20);
   });
 });

--- a/test/unit/economy/flowAdapter.test.ts
+++ b/test/unit/economy/flowAdapter.test.ts
@@ -119,6 +119,40 @@ describe("economy/flowAdapter - CorpPlanner as the FlowSolution authority", () =
     expect(ctrlAlloc, "controller is present").to.not.be.undefined;
     expect(ctrlAlloc!.allocated).to.be.greaterThan(1.9); // reserve protected even vs the spawn
   });
+
+  // The two levers, proven end-to-end at the planner level (no sim): the same
+  // graph, solved at empty vs full reservoir, must reshape the plan.
+  it("Lever 1: at full fill, throttled income sheds the marginal far source (base kept)", () => {
+    // near (cheap) + far-but-profitable (d=200): at empty reservoir the budget
+    // affords both; at full reservoir the halved budget no longer affords the far
+    // one, so it sheds while the spawn's best (near) source is always kept.
+    const graph = graphOf([homeNode(5), sourceNode("near", 15), sourceNode("far", 205)]);
+    const low = solveWithCorpPlanner(graph, 0, manhattan, [], 0);
+    const full = solveWithCorpPlanner(graph, 0, manhattan, [], 0.95);
+
+    expect(low.miners.map(m => m.sourceId).sort()).to.deep.equal(["source-far", "source-near"]);
+    expect(full.miners.map(m => m.sourceId)).to.deep.equal(["source-near"]);
+  });
+
+  it("Lever 2: at full fill, construction absorbs the surplus instead of spilling to the controller", () => {
+    // Ample cheap supply (3 near sources, none shed) and a build site present. At
+    // empty reservoir construction is capped at the modest base and the controller
+    // mops up the surplus; at full reservoir construction opens up and claims it
+    // (value 70 > 50), per the existing weight.
+    const graph = graphOf([homeNode(5), sourceNode("a", 12), sourceNode("b", 16), sourceNode("c", 20)]);
+    graph.addConstructionSite("site-1", "home", at(8), 5000);
+    graph.buildEdges();
+
+    const low = solveWithCorpPlanner(graph, 0, manhattan, [], 0);
+    const full = solveWithCorpPlanner(graph, 0, manhattan, [], 0.95);
+    const cAlloc = (s: typeof low) => s.sinkAllocations.find(a => a.sinkType === "construction")?.allocated ?? 0;
+    const ctrlAlloc = (s: typeof low) => s.sinkAllocations.find(a => a.sinkType === "controller")?.allocated ?? 0;
+
+    expect(cAlloc(low)).to.be.closeTo(CONSTRUCTION_ABSORB_RATE, 1e-6); // capped at the base
+    expect(cAlloc(full)).to.be.greaterThan(cAlloc(low) + 1); // opens up materially
+    expect(cAlloc(full)).to.be.within(CONSTRUCTION_ABSORB_RATE, CONSTRUCTION_ABSORB_MAX);
+    expect(ctrlAlloc(full)).to.be.lessThan(ctrlAlloc(low)); // surplus shifted build-ward
+  });
 });
 
 describe("constructionAbsorbForFill (Lever 2)", () => {

--- a/test/unit/economy/storeFill.test.ts
+++ b/test/unit/economy/storeFill.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import { setupGlobals, FIND_STRUCTURES, STRUCTURE_CONTAINER, RESOURCE_ENERGY } from "../mock";
+import { storeFill, storeLevels } from "../../../src/economy/storeFill";
+
+setupGlobals();
+
+/** A store keyed by resource, with a capacity, mimicking a Screeps Store. */
+function store(energy: number, capacity: number): any {
+  return {
+    [RESOURCE_ENERGY]: energy,
+    getCapacity: (_r: string) => capacity
+  };
+}
+
+/** A fake container at energy/capacity. */
+function container(energy: number, capacity = 2000): any {
+  return { structureType: STRUCTURE_CONTAINER, store: store(energy, capacity) };
+}
+
+/**
+ * A minimal fake Room exposing only what storeFill reads: `storage` and
+ * `find(FIND_STRUCTURES, {filter})`. Containers are returned through find();
+ * storage is the direct property.
+ */
+function roomWith(opts: { containers?: any[]; storage?: any }): Room {
+  const structures = [...(opts.containers ?? [])];
+  return {
+    storage: opts.storage,
+    find: (type: number, filterOpts?: any) => {
+      if (type !== FIND_STRUCTURES) return [];
+      return filterOpts?.filter ? structures.filter(filterOpts.filter) : structures;
+    }
+  } as any;
+}
+
+describe("storeFill - the energy thermostat reading", () => {
+  it("reports 0 ('empty') for a bare room with no reservoir", () => {
+    // A cold-start room must never read 'full', or income would gate itself off.
+    const room = roomWith({});
+    expect(storeFill(room)).to.equal(0);
+    expect(storeLevels(room)).to.deep.equal({ energy: 0, capacity: 0 });
+  });
+
+  it("reads container-only reservoirs before storage exists (RCL < 4)", () => {
+    const room = roomWith({ containers: [container(500, 2000), container(1500, 2000)] });
+    // 2000 / 4000 = 0.5
+    expect(storeFill(room)).to.be.closeTo(0.5, 1e-9);
+  });
+
+  it("reports full when the reservoir is full", () => {
+    const room = roomWith({ containers: [container(2000, 2000)] });
+    expect(storeFill(room)).to.equal(1);
+  });
+
+  it("includes storage in both energy and capacity", () => {
+    const room = roomWith({
+      containers: [container(0, 2000)],
+      storage: { store: store(100000, 1000000) }
+    });
+    const { energy, capacity } = storeLevels(room);
+    expect(energy).to.equal(100000);
+    expect(capacity).to.equal(1002000);
+    expect(storeFill(room)).to.be.closeTo(100000 / 1002000, 1e-9);
+  });
+
+  it("ignores non-container structures returned by find()", () => {
+    const wall = { structureType: "constructedWall", store: store(9999, 9999) };
+    const room = roomWith({ containers: [container(1000, 2000), wall] });
+    // Only the real container counts: 1000 / 2000 = 0.5
+    expect(storeFill(room)).to.be.closeTo(0.5, 1e-9);
+  });
+});

--- a/test/unit/mock.ts
+++ b/test/unit/mock.ts
@@ -180,6 +180,8 @@ export const STRUCTURE_STORAGE = 'storage';
 export const STRUCTURE_CONTAINER = 'container';
 export const STRUCTURE_CONTROLLER = 'controller';
 
+export const RESOURCE_ENERGY = 'energy';
+
 export const OK = 0;
 export const ERR_NOT_IN_RANGE = -9;
 export const ERR_NOT_ENOUGH_ENERGY = -6;
@@ -225,6 +227,8 @@ export function setupGlobals(): void {
   (global as any).STRUCTURE_STORAGE = STRUCTURE_STORAGE;
   (global as any).STRUCTURE_CONTAINER = STRUCTURE_CONTAINER;
   (global as any).STRUCTURE_CONTROLLER = STRUCTURE_CONTROLLER;
+
+  (global as any).RESOURCE_ENERGY = RESOURCE_ENERGY;
 
   (global as any).OK = OK;
   (global as any).ERR_NOT_IN_RANGE = ERR_NOT_IN_RANGE;


### PR DESCRIPTION
## What & why

W43N23 was spending ~82% of harvested energy making more creeps (haulers, remote mines) with **0 on construction** and flat control points. Root cause, verified in code:

- **Income monopolises spawn time** — `spawnPriority` puts income at `+1e6` and `scheduleSpawn` returns on the first affordable demand, so while income demand is present (and unbounded remote/transient sources keep it present) the flow-budgeted consumers below it never get a spawn tick.
- **Construction is throttled** — `CONSTRUCTION_ABSORB_RATE = 5` sits *below* a single 2-WORK builder's 10/tick, so surplus spills past construction (valued 70) into the controller (50).
- Consumers already size from their allocation, and the 70>50 build/upgrade weight already exists — those were not the bug.

## The mechanism: stored energy as a thermostat

We are **spawn-bound, not energy-bound**, so a full reservoir means the scarce *spawn-part* budget is over-allocated to income. Control on the **level** (smooth, matched to the slow spawn actuator), not a noisy `Δ/tick`:

- **`storeFill(room)`** — reservoir fill 0..1 (storage + containers; 0 with no reservoir, so cold start is unaffected).
- **Lever 1 — income throttle** (`incomeBudgetScaleForFill`, threaded via `ColonyProblem.incomeBudgetScale` into `selectProducers`): scales the mining spawn-part budget down as fill rises, shedding **marginal/remote sources first** (the spawn's best source is always kept), freeing spawn ticks for consumers.
- **Lever 2 — construction absorb** (`constructionAbsorbForFill`): lifts the absorb cap 5→20 over the **same fill band**, so as income stands down, building soaks the surplus per the existing weight.

Both levers are inert below 50% fill, so cold-start and the existing economy are unchanged.

## Tests

- Rung-0 unit tests for `storeFill`, `incomeBudgetScaleForFill`, `constructionAbsorbForFill`.
- **End-to-end planner proofs**: the same graph solved at empty vs. full reservoir sheds the marginal far source (Lever 1) and shifts surplus controller→construction (Lever 2).
- Full unit suite **454 passing**, type-check clean, build emits, and the two-source RCL3 integration probe is green (confirms no behavior change at low fill).

## Not yet included (follow-ups)

- Lever 3: drop the vestigial RCL upgrader path; optionally wire the dormant `since` anti-starvation aging as a backstop.
- A full-loop RCL4 + pre-filled-storage sim demonstration (storage fills too slowly from empty to engage the thermostat within a test).

Design rationale: `docs/GOD_POINTS_CHAIN_DESIGN.md`.

https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP

---
_Generated by [Claude Code](https://claude.ai/code/session_011LPsKVLbh8BcFPyuzz9NzP)_