### PR TITLE
Simplify upgrader strategy to always use containerFed mode

### DIFF
--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -11,7 +11,7 @@ import { controllerInputSpot, controllerParkingTiles } from "./nodeEnergy";
 import { travelToBypass } from "./movement";
 import { driveRecycle } from "./recycle";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
-import { UpgraderStrategy, buildUpgraderBody } from "../spawn/BodyBuilder";
+import { buildUpgraderBody } from "../spawn/BodyBuilder";
 import { CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
@@ -82,9 +82,6 @@ export class UpgradingCorp extends Corp {
    * Specifies the energy rate allocated to this controller.
    */
   private sinkAllocation: SinkAllocation | null = null;
-
-  /** Last chosen supply strategy, so a switch is logged once rather than every tick. */
-  private lastStrategy: UpgraderStrategy | null = null;
 
   public constructor(nodeId: string, spawnId: string, customId?: string) {
     super("upgrading", nodeId, customId);
@@ -297,35 +294,6 @@ export class UpgradingCorp extends Corp {
   }
 
   /**
-   * Declare this corp's spawn demand for the scheduler.
-   *
-   * The upgrader is what drives RCL progress, so its demand is blocking when no
-   * upgrader exists. Its value comes from the flow solution's controller-sink
-   * priority, and it is sized to the allocated energy rate (but can be spawned
-   * small and scaled up). It does not produce income - the scheduler's
-   * wait-for-blocking logic is what lets it accumulate energy against a steady
-   * trickle of mining demand.
-   */
-  /**
-   * Decide how upgraders are fed, EXPLICITLY: "containerFed" when a container or
-   * link sits at the controller (a per-tick buffer), otherwise "mobile". This one
-   * choice drives both the body shape (WORK-heavy vs CARRY-heavy) and the runt
-   * policy, so the corp commits to a single coherent strategy instead of mixing
-   * conflicting signals. Logged on change so the active strategy is visible.
-   */
-  private getUpgraderStrategy(controller: StructureController): UpgraderStrategy {
-    const buffers = controller.pos.findInRange(FIND_STRUCTURES, 3, {
-      filter: s => s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_LINK
-    });
-    const strategy: UpgraderStrategy = buffers.length > 0 ? "containerFed" : "mobile";
-    if (strategy !== this.lastStrategy) {
-      console.log(`[Upgrading] ${this.id} strategy=${strategy} (controller buffers: ${buffers.length})`);
-      this.lastStrategy = strategy;
-    }
-    return strategy;
-  }
-
-  /**
    * Project the economics of upgrading the scene's controller with the energy
    * allocated to this corp: an upgrader sized to that energy, costed over the
    * life left after walking out to the controller. It is a pure consumer, so it
@@ -335,8 +303,10 @@ export class UpgradingCorp extends Corp {
     const allocated = this.sinkAllocation?.allocated ?? 0;
     if (allocated <= 0 || !scene.controllerPos) return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
 
-    // Virtual mode has no vision of buffers, so assume the mobile (no-container)
-    // strategy - the conservative, CARRY-heavier body.
+    // Virtual planning estimate: the upgrader is a pure consumer (throughput 0),
+    // so this only sizes its cost/part footprint for the planner. Keep the
+    // conservative CARRY-heavier estimate here - the realized body (built WORK-heavy
+    // in getSpawnDemand) is cheaper per WORK, so this never UNDER-budgets a source.
     const body = buildUpgraderBody(scene.energyCapacity, Math.max(1, Math.ceil(allocated)), "mobile");
     if (body.cost === 0) return { costPerTick: 0, throughput: 0, spawnPartsPerTick: 0 };
 
@@ -345,11 +315,19 @@ export class UpgradingCorp extends Corp {
     return { costPerTick: body.cost / usefulLife, throughput: 0, spawnPartsPerTick: body.body.length / usefulLife };
   }
 
+  /**
+   * Declare this corp's spawn demand for the scheduler.
+   *
+   * The upgrader is what drives RCL progress, so its demand is blocking when no
+   * upgrader exists. Its value comes from the flow solution's controller-sink
+   * priority, and it is sized to the allocated energy rate (but can be spawned
+   * small and scaled up). It does not produce income - the scheduler's
+   * wait-for-blocking logic is what lets it accumulate energy against a steady
+   * trickle of mining demand.
+   */
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {
-    // Commit to a supply strategy up front; body shape and runt policy follow it.
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
     const controller = spawn?.room.controller;
-    const strategy: UpgraderStrategy = controller ? this.getUpgraderStrategy(controller) : "mobile";
 
     // SUPPLY BEFORE DEMAND: don't fund flow upgraders until the room's delivery
     // loop exists (a real hauler in the field). At cold start the first miner
@@ -378,7 +356,7 @@ export class UpgradingCorp extends Corp {
     // a single small upgrader cannot consume a whole source. Size the COUNT to
     // the allocation, so consumption scales with supply (this is what lets a
     // second source actually help instead of being wasted).
-    const affordableWork = Math.max(1, buildUpgraderBody(ctx.energyCapacity, 99, strategy).workParts);
+    const affordableWork = Math.max(1, buildUpgraderBody(ctx.energyCapacity, 99, "containerFed").workParts);
     // Cap the count as a safety bound: should a stale/over-large allocation slip
     // through, we never spawn a swarm of upgraders. The plan keeps `allocated`
     // bounded by real supply in normal operation. ALSO bounded by the parking
@@ -393,17 +371,16 @@ export class UpgradingCorp extends Corp {
 
     const remainingWork = allocated - current * affordableWork;
     const desiredWork = Math.max(1, Math.min(affordableWork, Math.ceil(remainingWork)));
-    const desired = buildUpgraderBody(ctx.energyCapacity, desiredWork, strategy);
-    // Runt policy follows the strategy. targetCount is sized assuming each
-    // upgrader is the full affordableWork; a runt permanently occupies one of the
-    // few slots and the controller under-consumes its allocation for that creep's
-    // whole 1500-tick life. In containerFed mode the buffer feeds the controller
-    // while the spawn fills, so EVERY upgrader (including the first) holds out for
-    // a full-size body - waiting tens of ticks for a 4-WORK creep beats fielding a
-    // 1-WORK one forever. In mobile mode there is no buffer, so the first upgrader
-    // still spawns small to keep the controller alive immediately.
-    const minWork = strategy === "containerFed" ? affordableWork : 1;
-    const min = buildUpgraderBody(ctx.energyCapacity, minWork, strategy);
+    const desired = buildUpgraderBody(ctx.energyCapacity, desiredWork, "containerFed");
+    // Runt policy: a runt permanently occupies one of the few parking slots and the
+    // controller under-consumes its allocation for that creep's whole 1500-tick life.
+    // A SCALING upgrader (current > 0) therefore holds out for its full intended
+    // share - there is always energy at the input tile to feed it, so waiting for a
+    // proper body beats fielding a runt forever. Only the FIRST upgrader may spawn
+    // small (down to 1 WORK) so the controller starts upgrading immediately at cold
+    // start instead of waiting for the spawn to fill a full body.
+    const minWork = current === 0 ? 1 : desiredWork;
+    const min = buildUpgraderBody(ctx.energyCapacity, minWork, "containerFed");
     if (min.cost === 0) return []; // room cannot afford even a minimal upgrader
 
     return [
@@ -425,7 +402,7 @@ export class UpgradingCorp extends Corp {
         minCost: min.cost,
         since: 0,
         bodyParam: desiredWork,
-        bodyStrategy: strategy
+        bodyStrategy: "containerFed"
       }
     ];
   }

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -15,7 +15,7 @@
  * @module corps/nodeEnergy
  */
 
-import { travelTo } from "./movement";
+import { travelToBypass } from "./movement";
 
 /** A store-bearing structure a hauler can deposit into or draw from. */
 type StoreStructure = StructureContainer | StructureStorage | StructureSpawn | StructureExtension | StructureLink;
@@ -328,8 +328,12 @@ export function workSpot(creep: Creep, spot: EnergySpot, mode: "collect" | "depo
   // tile short, common in remote mining where there is no container).
   const range = mode === "collect" && !spot.waitClear ? 1 : spot.structure ? 1 : 2;
   if (creep.pos.getRangeTo(spot.pos) > range) {
-    // travelTo so a hauler crossing into a remote room doesn't bounce on the border.
-    travelTo(creep, spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
+    // travelToBypass so a hauler that just dropped on the controller pile and is now
+    // ringed by parked upgraders can SWAP through one to escape on its way back to
+    // pick up - without it the ring walls the hauler in on the input tile and it
+    // never leaves (the trapped-on-the-pile symptom). Away from the ring there is no
+    // yielding creep to swap, so this falls back to the border-bounce-safe travelTo.
+    travelToBypass(creep, spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
     return 0;
   }
 

--- a/test/unit/corps/scavengePickup.test.ts
+++ b/test/unit/corps/scavengePickup.test.ts
@@ -74,7 +74,9 @@ describe("workSpot scavenging (withdraw from a tombstone/ruin)", () => {
     const calls = { moveTo: 0, withdraw: 0, lastMoveRange: undefined as number | undefined };
     const self = { x, y };
     return {
+      name: "scav",
       pos: {
+        roomName: "W0N0",
         getRangeTo: (t: { x: number; y: number }) => cheby(self, t),
         findInRange: () => []
       },

--- a/test/unit/corps/workSpot.test.ts
+++ b/test/unit/corps/workSpot.test.ts
@@ -19,11 +19,13 @@ function makeCreep(x: number, y: number, piles: Pile[]) {
   const calls = { moveTo: 0, pickup: 0, lastMoveRange: undefined as number | undefined };
   const self = { x, y };
   const pos = {
+    roomName: "W0N0",
     getRangeTo: (t: { x: number; y: number }) => cheby(self, t),
     findInRange: (_type: number, range: number, opts?: { filter?: (p: Pile) => boolean }) =>
       piles.filter(p => cheby(self, p.pos) <= range && (!opts?.filter || opts.filter(p)))
   };
   const creep = {
+    name: "hauler",
     pos,
     store: { energy: 0 } as Record<string, number>,
     moveTo: (_t: unknown, o?: { range?: number }) => {

--- a/test/unit/harness/spawnDecision.ts
+++ b/test/unit/harness/spawnDecision.ts
@@ -129,8 +129,8 @@ export function decideNextSpawn(situation: SpawnSituation): SpawnDecision {
   // room-aware logic - notably the upgrader's "no flow upgrader until a hauler is
   // delivering" gate (roomHasHauler scans room.find(FIND_MY_CREEPS)) and the
   // hauler's yieldsToBuild (reads room.memory). Without it those paths were
-  // silently skipped and the gate never exercised. No controller is provided, so
-  // the upgrader uses its mobile strategy.
+  // silently skipped and the gate never exercised. No controller is provided; the
+  // upgrader always gets the WORK-heavy fed-in-place body regardless.
   const fakeSpawn = {
     id: SPAWN_ID,
     spawning: false,

--- a/test/unit/harness/upgraderFleet.test.ts
+++ b/test/unit/harness/upgraderFleet.test.ts
@@ -23,11 +23,12 @@ describe("upgrader fleet (spawn harness)", () => {
   });
 
   it("fields fewer, bigger upgraders as capacity rises (same allocation)", () => {
-    // A bigger room builds bigger bodies, so the same 10 e/tick allocation is
-    // covered by fewer upgraders - 5 x 2 WORK at 550, but 3 (4+4+2) at 800.
+    // An upgrader is fed in place from its input tile, so it gets the WORK-heavy
+    // body. The same 10 e/tick allocation is covered by 3 (4+4+2 WORK) at 550 and
+    // fewer still (bigger bodies) at 800.
     const small = simulateUpgraderFleet({ energyCapacity: 550, allocated: 10 });
     const big = simulateUpgraderFleet({ energyCapacity: 800, allocated: 10 });
-    expect(small.workParts).to.deep.equal([2, 2, 2, 2, 2]);
+    expect(small.workParts).to.deep.equal([4, 4, 2]);
     expect(big.count).to.be.lessThan(small.count);
     expect(big.totalWork, "still consumes the whole allocation").to.equal(10);
   });

--- a/test/unit/harness/upgraderHarness.ts
+++ b/test/unit/harness/upgraderHarness.ts
@@ -106,7 +106,8 @@ export function simulateUpgraderFleet(scenario: UpgraderScenario): UpgraderFleet
       name: ROOM,
       energyAvailable,
       energyCapacityAvailable: energyCapacity,
-      // No controller -> the corp uses its mobile (no-buffer) strategy.
+      // No controller object in this harness; upgraders always get the WORK-heavy
+      // fed-in-place body regardless, so the count/sizing is what is under test.
       controller: undefined,
       memory: dedicatedBuild ? { dedicatedBuildSourceId: "src-build" } : {},
       find: (type: number) => {


### PR DESCRIPTION
## Summary
This PR removes the dynamic upgrader strategy selection logic and commits to a single "containerFed" strategy for all upgraders. The previous code attempted to choose between "containerFed" (when buffers exist at the controller) and "mobile" (when they don't), but this added complexity without clear benefit.

## Key Changes

- **Removed dynamic strategy selection**: Deleted `getUpgraderStrategy()` method and `lastStrategy` field that previously detected controller buffers and switched strategies
- **Hardcoded containerFed strategy**: All upgrader body building now uses `"containerFed"` directly, which produces WORK-heavy bodies optimized for in-place feeding
- **Simplified runt policy**: Changed minimum work calculation from strategy-dependent logic to a simpler rule: first upgrader (current === 0) can spawn with 1 WORK, subsequent upgraders hold out for their full intended share
- **Updated planning estimate**: Modified `projectEconomics()` comment to clarify that the conservative "mobile" estimate is kept for virtual planning only, while realized bodies are built WORK-heavy
- **Fixed hauler escape path**: Changed `workSpot()` to use `travelToBypass()` instead of `travelTo()`, allowing haulers trapped by parked upgraders to swap through them and escape
- **Updated test expectations**: Adjusted upgrader fleet test to expect the new WORK-heavy body distribution (3 upgraders with [4,4,2] WORK instead of 5 with [2,2,2,2,2])
- **Clarified test harnesses**: Updated comments in test files to reflect that upgraders always get the fed-in-place body regardless of controller presence

## Implementation Details

The change assumes that upgraders will always have energy available at their input tile (the controller position), making the WORK-heavy "containerFed" body optimal. This simplifies the spawn decision logic while the `travelToBypass()` fix ensures haulers can still deliver energy efficiently even when surrounded by parked upgraders.

https://claude.ai/code/session_01EjDqnN782rmkQgT5qZCdPG