### PR TITLE
Add anti-starvation aging to spawn scheduler

### DIFF
--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -37,6 +37,13 @@ const FLOW_MIN_RCL = 2;
  * Run the demand-driven spawn scheduler for all owned spawns.
  */
 export function runSpawnScheduling(registry: CorpRegistry): void {
+  // First tick each still-unmet demand was seen, persisted across ticks so the
+  // scheduler can age a chronically-outranked demand (see scheduleSpawn's
+  // anti-starvation backstop). Pruned below for the spawns we actually evaluate.
+  const firstSeen = Memory.spawnDemandFirstSeen ?? (Memory.spawnDemandFirstSeen = {});
+  const seenThisTick = new Set<string>();
+  const evaluatedSpawns = new Set<string>();
+
   for (const roomName in Game.rooms) {
     const room = Game.rooms[roomName];
     if (!room.controller?.my) continue;
@@ -51,7 +58,11 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
     for (const spawn of spawns) {
       const spawningCorp = registry.spawningCorps[spawn.id];
       if (!spawningCorp) continue;
+      // Skip a busy spawn WITHOUT touching its demand timers: a room whose spawn
+      // is forever occupied with income is exactly where a starved builder must
+      // keep ageing, so don't reset its clock just because we can't act this tick.
       if (spawn.spawning) continue;
+      evaluatedSpawns.add(spawn.id);
 
       const demandCtx: SpawnDemandContext = {
         energyCapacity: room.energyCapacityAvailable,
@@ -59,6 +70,14 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
       };
 
       const demands = collectDemands(registry, spawn.id, demandCtx);
+      // Stamp each demand's first-seen tick (carrying forward a prior one) so the
+      // scheduler sees how long it has been waiting.
+      for (const d of demands) {
+        const key = `${spawn.id}:${d.buyerCorpId}:${d.role}`;
+        seenThisTick.add(key);
+        const first = firstSeen[key] ?? (firstSeen[key] = Game.time);
+        d.since = first;
+      }
       if (demands.length === 0) continue;
 
       const ctx: ScheduleContext = {
@@ -82,6 +101,14 @@ export function runSpawnScheduling(registry: CorpRegistry): void {
         d.bodyStrategy
       );
     }
+  }
+
+  // Drop timers for demands that no longer appear at a spawn we evaluated this
+  // tick (the creep was spawned, or the work went away), resetting their age.
+  // Only for evaluated spawns, so a skipped (busy) spawn keeps its timers intact.
+  for (const key in firstSeen) {
+    const spawnId = key.slice(0, key.indexOf(":"));
+    if (evaluatedSpawns.has(spawnId) && !seenThisTick.has(key)) delete firstSeen[key];
   }
 }
 

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -173,6 +173,42 @@ export function spawnPriority(demand: SpawnDemand): number {
 }
 
 /**
+ * Ticks a demand may go unmet before anti-starvation lifts it above the income
+ * tier for one spawn. Long enough that it never disturbs the normal income-first
+ * ordering during a healthy ramp (income demands clear in far fewer ticks), short
+ * enough that a chronically-outranked consumer (a builder whose room is busy
+ * spawning remote income every tick) is not stranded forever - the bug this fixes:
+ * the bot places a construction site, but the value-95 builder never wins a spawn
+ * slot against the +1e6 income tier, so the site sits unbuilt indefinitely.
+ */
+const STARVATION_THRESHOLD = 300;
+
+/**
+ * Priority a starved demand is lifted to: strictly ABOVE the income tiers (1e6 +
+ * blocking 1e4), so a demand ignored past the threshold gets exactly ONE
+ * guaranteed spawn. It is a one-shot: once the creep exists the demand stops
+ * reappearing and its age resets, so this preempts a critical income creep for at
+ * most a single tick after a long starvation - the whole point of the backstop.
+ */
+const STARVED_TIER = 3_000_000;
+
+/**
+ * Anti-starvation boost for a demand the director has been seeing for too long.
+ * `since` is the first tick the demand was observed (0 when unstamped - the pure
+ * unit/harness paths leave it 0, so they are unaffected). Returns 0 until the
+ * demand has waited {@link STARVATION_THRESHOLD} ticks, then {@link STARVED_TIER}.
+ */
+export function starvationBoost(demand: SpawnDemand, tick: number): number {
+  if (demand.since <= 0) return 0;
+  return tick - demand.since >= STARVATION_THRESHOLD ? STARVED_TIER : 0;
+}
+
+/** Spawn priority including the anti-starvation age boost - the value the scheduler ranks on. */
+function effectivePriority(demand: SpawnDemand, tick: number): number {
+  return spawnPriority(demand) + starvationBoost(demand, tick);
+}
+
+/**
  * Choose the single best creep to spawn now, or return null to spawn nothing
  * this tick (either there is no demand, or it is worth waiting for the spawn to
  * fill).
@@ -206,7 +242,11 @@ export function scheduleSpawn(demands: SpawnDemand[], ctx: ScheduleContext): Sch
   // raw value and get funded with nothing to pick up.
   const eligible = withMinerPrecedence(demands);
 
-  const ranked = [...eligible].sort((a, b) => spawnPriority(b) - spawnPriority(a));
+  // Rank on EFFECTIVE priority (base tier + anti-starvation age boost). A demand
+  // that has waited past the threshold is lifted above the income tier, so the
+  // walk below reaches it - affordable and on top - before any blocking income
+  // demand can hold the spawn, giving the long-starved creep its one guaranteed slot.
+  const ranked = [...eligible].sort((a, b) => effectivePriority(b, ctx.tick) - effectivePriority(a, ctx.tick));
 
   // Set once we pass a blocking demand we cannot afford yet but the room can
   // eventually build. From then on we decline to spend the dribble on

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -97,6 +97,16 @@ declare global {
     lastPlanningTick?: number;
 
     /**
+     * First tick each still-unmet spawn demand was observed, keyed by
+     * "spawnId:buyerCorpId:role". The SpawnDirector stamps it so the scheduler
+     * can age a demand: a consumption creep (e.g. a builder) that is continuously
+     * outranked by the income tier eventually clears it via anti-starvation. An
+     * entry is dropped once its demand stops appearing (the creep was spawned, or
+     * the work is gone), resetting the timer.
+     */
+    spawnDemandFirstSeen?: { [key: string]: number };
+
+    /**
      * Tick when last survey phase was run.
      */
     lastSurveyTick?: number;

--- a/test/unit/spawn/SpawnScheduler.test.ts
+++ b/test/unit/spawn/SpawnScheduler.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import {
   scheduleSpawn,
   spawnPriority,
+  starvationBoost,
   SpawnDemand,
   ScheduleContext,
 } from "../../../src/spawn/SpawnScheduler";
@@ -263,6 +264,41 @@ describe("SpawnScheduler", () => {
       const urgent = demand({ role: "hauler", value: 90, blocking: true, producesIncome: true, groupId: "A", groupStarted: true });
       const scaling = demand({ role: "miner", value: 90, blocking: false, producesIncome: true, groupId: "A", groupStarted: true });
       expect(spawnPriority(urgent)).to.be.greaterThan(spawnPriority(scaling));
+    });
+  });
+
+  describe("anti-starvation aging", () => {
+    it("does not boost an unstamped demand (since=0) or one within the threshold", () => {
+      const fresh = demand({ role: "builder", value: 95 }); // since defaults to 0
+      expect(starvationBoost(fresh, 100_000)).to.equal(0);
+      const stampedRecent = demand({ role: "builder", value: 95, since: 1000 });
+      expect(starvationBoost(stampedRecent, 1200)).to.equal(0); // 200 < 300 threshold
+    });
+
+    it("a long-starved builder is lifted above the income tier after the threshold", () => {
+      const starvedBuilder = demand({ role: "builder", value: 95, since: 1000 });
+      const income = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "A" });
+      const tick = 1000 + 300; // exactly the threshold
+      const eff = (d: SpawnDemand): number => spawnPriority(d) + starvationBoost(d, tick);
+      expect(eff(starvedBuilder)).to.be.greaterThan(eff(income));
+    });
+
+    it("scheduleSpawn picks a long-starved consumer over an affordable blocking income demand", () => {
+      // Reproduces the stuck-construction bug: a value-95 builder that the income
+      // tier has out-ranked for >300 ticks finally wins its one spawn slot.
+      const tick = 5000;
+      const builder = demand({ role: "builder", value: 95, minCost: 200, desiredCost: 300, since: tick - 300 });
+      const miner = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "A", minCost: 200, desiredCost: 300, since: tick });
+      const result = scheduleSpawn([miner, builder], ctx({ energyAvailable: 300, energyCapacity: 300, tick }));
+      expect(result?.demand.role).to.equal("builder");
+    });
+
+    it("without starvation the income demand still wins (no regression)", () => {
+      const tick = 5000;
+      const builder = demand({ role: "builder", value: 95, minCost: 200, desiredCost: 300, since: tick - 10 });
+      const miner = demand({ role: "miner", value: 100, blocking: true, producesIncome: true, groupId: "A", minCost: 200, desiredCost: 300, since: tick });
+      const result = scheduleSpawn([builder, miner], ctx({ energyAvailable: 300, energyCapacity: 300, tick }));
+      expect(result?.demand.role).to.equal("miner");
     });
   });
 });


### PR DESCRIPTION
## Summary
Implements an anti-starvation mechanism in the spawn scheduler to prevent consumer creeps (like builders) from being indefinitely starved by higher-priority income demands. A demand that goes unmet for 300+ ticks is temporarily boosted above the income tier to guarantee it gets exactly one spawn slot.

## Key Changes
- **New starvation tracking in Memory**: Added `spawnDemandFirstSeen` to track when each demand was first observed, keyed by `spawnId:buyerCorpId:role`
- **Anti-starvation boost function**: `starvationBoost()` returns a priority boost (`STARVED_TIER = 3,000,000`) once a demand has waited `STARVATION_THRESHOLD = 300` ticks
- **Effective priority calculation**: New `effectivePriority()` function combines base spawn priority with the starvation boost
- **Scheduler ranking update**: `scheduleSpawn()` now ranks demands by effective priority instead of base priority, allowing starved demands to surface
- **Demand age management**: `SpawnDirector.runSpawnScheduling()` maintains first-seen timestamps and cleans them up when demands disappear (creep spawned or work completed)
- **Comprehensive test coverage**: Added tests verifying unstamped demands are unaffected, starved demands beat income tiers, and the scheduler correctly picks starved consumers

## Implementation Details
- The `since` field on `SpawnDemand` carries the first-seen tick from Memory, defaulting to 0 for unstamped demands (unit/harness paths)
- Starvation boost is a one-shot: once a creep spawns, the demand stops reappearing and its timer resets, so it preempts a critical income creep for at most one tick
- Busy spawns are skipped without touching their demand timers, allowing starved demands to keep aging even when the spawn is occupied with income work
- Only evaluated spawns have their timers pruned, preserving aging for demands at skipped spawns

https://claude.ai/code/session_01LkY92NwQumWrPaVXBxAC8D