### PR TITLE
Rescue critically-decaying structures mid-build (container expiry)

### DIFF
--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -13,7 +13,13 @@ import { travelTo } from "./movement";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { Squad, SquadPlan, splitIntoMembers } from "./Squad";
 import { buildTankerBody, buildUpgraderBody } from "../spawn/BodyBuilder";
-import { pickRepairTarget, wantsMaintenanceBuilder, REPAIR_TO } from "./repair";
+import {
+  pickRepairTarget,
+  pickCriticalRepairTarget,
+  wantsCriticalRecovery,
+  wantsMaintenanceBuilder,
+  REPAIR_TO
+} from "./repair";
 import { MAX_BUILDERS } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
@@ -1182,6 +1188,20 @@ export class ConstructionCorp extends Corp {
   }
 
   /**
+   * A structure decayed into the critical band (about to expire) that a builder
+   * must rescue even while construction sites are outstanding, or null when the
+   * room's decaying structures are all healthier than the critical gate.
+   */
+  private findCriticalRepairTarget(room: Room): StructureContainer | StructureRoad | null {
+    return pickCriticalRepairTarget(this.roomRepairables(room));
+  }
+
+  /** Whether a mid-diversion builder should keep repairing (see wantsCriticalRecovery). */
+  private wantsCriticalRecovery(room: Room): boolean {
+    return wantsCriticalRecovery(this.roomRepairables(room));
+  }
+
+  /**
    * Maintain decaying structures when there is nothing to build. Containers fuel
    * the builder themselves (they hold energy), so maintenance needs no tanker;
    * roads hold nothing, so a road target sends the builder to the nearest energy
@@ -1247,6 +1267,26 @@ export class ConstructionCorp extends Corp {
     // most decayed container) instead of standing idle.
     const sites = room.find(FIND_MY_CONSTRUCTION_SITES);
     if (sites.length === 0) {
+      delete creep.memory.repairingCritical;
+      this.doMaintenance(creep, room);
+      return;
+    }
+
+    // EMERGENCY REPAIR outranks building: ordinary maintenance is gated off
+    // entirely while any site exists (the builder builds one site at a time and
+    // only maintains a fully-built room), so a structure that decays past the
+    // critical gate mid-build would head to expiry with nothing repairing it.
+    // Divert the crew to rescue it, latched with hysteresis (repair up out of the
+    // idle-maintenance band before resuming) so it doesn't thrash between a far
+    // site and the container each tick it dips past the start gate.
+    if (creep.memory.repairingCritical) {
+      if (this.wantsCriticalRecovery(room)) {
+        this.doMaintenance(creep, room);
+        return;
+      }
+      delete creep.memory.repairingCritical;
+    } else if (this.findCriticalRepairTarget(room)) {
+      creep.memory.repairingCritical = true;
       this.doMaintenance(creep, room);
       return;
     }

--- a/src/corps/repair.ts
+++ b/src/corps/repair.ts
@@ -32,6 +32,40 @@ export const REPAIR_TO = 0.99;
  */
 export const REPAIR_SPAWN_BELOW = 0.6;
 
+/**
+ * A structure this decayed is close enough to expiry that a builder repairs it
+ * EVEN with construction work outstanding. Ordinary maintenance is gated off
+ * entirely while any construction site exists (the builder builds, one site at a
+ * time, and only maintains once the room is fully built) - so during a long
+ * build-out a container that dips below the idle start gate keeps decaying with
+ * nothing coming to repair it, all the way to expiry. Below this critical
+ * fraction the value flips: a container is worth 5000 energy to rebuild plus the
+ * mining it strands, far more than the marginal delay to a build, so the build
+ * crew diverts to save it. Set below REPAIR_SPAWN_BELOW so it only fires for
+ * genuinely endangered structures, not routine dips.
+ */
+export const REPAIR_CRITICAL = 0.3;
+
+/**
+ * The most-decayed structure below the critical fraction, or null if none is
+ * that low. The trigger for a build crew to divert onto emergency repair.
+ */
+export function pickCriticalRepairTarget<T extends Repairable>(structures: T[]): T | null {
+  return pickRepairTarget(structures, REPAIR_CRITICAL);
+}
+
+/**
+ * Whether a builder mid-diversion should keep repairing rather than resume
+ * building: it started on a critical structure and holds the diversion until
+ * nothing is left in the idle-maintenance band (REPAIR_SPAWN_BELOW), comfortably
+ * clear of the critical gate. The hysteresis (start at REPAIR_CRITICAL, release
+ * at REPAIR_SPAWN_BELOW) stops the crew thrashing between a far site and the
+ * container each time the structure dips a hair past the start gate.
+ */
+export function wantsCriticalRecovery(structures: Repairable[]): boolean {
+  return structures.some(s => s.hits < s.hitsMax * REPAIR_SPAWN_BELOW);
+}
+
 interface Repairable {
   hits: number;
   hitsMax: number;

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -324,6 +324,15 @@ declare global {
     recycling?: boolean;
 
     /**
+     * A builder is mid-diversion: it left its construction work to rescue a
+     * structure that decayed into the critical band (about to expire), and
+     * keeps repairing until that structure clears the danger band before
+     * resuming the build. The latch gives the diversion hysteresis so the
+     * crew doesn't thrash between a far site and the container each tick.
+     */
+    repairingCritical?: boolean;
+
+    /**
      * ID of the SpawningCorp that spawned this creep.
      */
     spawnedBy?: string;

--- a/test/grid/cells/construction.ts
+++ b/test/grid/cells/construction.ts
@@ -481,6 +481,69 @@ export function buildConstructionT2Cells(): GridCell[] {
         }),
       ],
     },
+
+    {
+      // Emergency repair OUTRANKS building. Ordinary maintenance is gated off
+      // entirely while ANY construction site exists (the builder builds one
+      // site at a time and only maintains a fully-built room), so a container
+      // that decays into the CRITICAL band mid-build heads to expiry with
+      // nothing coming to repair it. The build crew must DIVERT to rescue it.
+      // Here a source container is staged at 8% hits (critical) alongside an
+      // outstanding extension site; the staged 10-WORK builder must repair the
+      // container out of the danger band BEFORE finishing the build. Without
+      // the divert the builder finishes the extension and the 8% container
+      // just keeps decaying - "hits climb past 30%" times out.
+      id: "cons-repair-critical-during-build",
+      tier: 2,
+      avenue: "construction",
+      window: 150,
+      rooms: { home: twoSourceRoom },
+      bot: { x: 25, y: 25 },
+      controller: { level: 3 },
+      structures: [
+        { type: "container", x: 15, y: 29, energy: 2000, hits: 20000 }, // A: 8% - about to expire
+        { type: "container", x: 35, y: 29, energy: 0 },
+        { type: "container", x: 24, y: 24, energy: 2000 }, // depot fuel
+        ...EXT_POS.slice(0, 5).map((p) => ({ type: "extension", x: p.x, y: p.y, energy: 50 })),
+      ],
+      creeps: [
+        {
+          name: "cb1",
+          x: 15,
+          y: 28,
+          body: ["work", "work", "work", "work", "work", "work", "work", "work", "work", "work", "carry", "carry", "carry", "carry", "move", "move"],
+          energy: 200,
+        },
+        ...quiet(),
+      ],
+      memory: {
+        creeps: {
+          cb1: { workType: "build", corpId: "building-$room()-construction", working: true },
+        },
+      },
+      async stage(ctx) {
+        // A persistent extension site so the room is unambiguously "building".
+        await ctx.db["rooms.objects"].insert({
+          type: "constructionSite",
+          room: ctx.room(),
+          x: 27,
+          y: 29,
+          user: ctx.userId,
+          structureType: "extension",
+          progress: 0,
+          progressTotal: 3000,
+        });
+      },
+      assertions: [
+        eventually("the room is building (an extension site exists)", (s) =>
+          s.objects().some((o: any) => o.type === "constructionSite" && o.structureType === "extension")
+        ),
+        eventually("the critical container is rescued out of the danger band (past 30%)", (s) => {
+          const a = s.objects().find((o: any) => o.type === "container" && o.x === 15 && o.y === 29);
+          return !!a && (a.hits ?? 0) > 75000;
+        }),
+      ],
+    },
   ];
 }
 

--- a/test/unit/corps/repair.test.ts
+++ b/test/unit/corps/repair.test.ts
@@ -1,5 +1,13 @@
 import { expect } from "chai";
-import { pickRepairTarget, wantsMaintenanceBuilder, REPAIR_TO, REPAIR_SPAWN_BELOW } from "../../../src/corps/repair";
+import {
+  pickRepairTarget,
+  pickCriticalRepairTarget,
+  wantsCriticalRecovery,
+  wantsMaintenanceBuilder,
+  REPAIR_TO,
+  REPAIR_SPAWN_BELOW,
+  REPAIR_CRITICAL,
+} from "../../../src/corps/repair";
 
 const c = (hits: number, hitsMax = 250000) => ({ hits, hitsMax });
 
@@ -49,6 +57,34 @@ describe("corps/repair", () => {
       expect(wantsMaintenanceBuilder([midRepair], true)).to.equal(true);
       // once at the ceiling, retire even with a builder present
       expect(wantsMaintenanceBuilder([c(250000)], true)).to.equal(false);
+    });
+  });
+
+  describe("pickCriticalRepairTarget (emergency divert gate)", () => {
+    it("is null while everything is healthier than the critical gate", () => {
+      const justAbove = c(Math.ceil(250000 * REPAIR_CRITICAL) + 1); // just above 30%
+      expect(pickCriticalRepairTarget([justAbove, c(200000)])).to.equal(null);
+    });
+    it("returns the most-decayed structure once one crosses the critical gate", () => {
+      const critical = c(20000); // 8% - about to expire
+      const dipped = c(Math.floor(250000 * REPAIR_SPAWN_BELOW) - 1); // ~60%, below idle gate but not critical
+      expect(pickCriticalRepairTarget([dipped, critical])).to.equal(critical);
+    });
+    it("ranks by fraction across mixed scales (a critical road outranks a dipped container)", () => {
+      const road = { hits: 1000, hitsMax: 5000 }; // 20% - critical
+      const container = c(100000); // 40% - not critical
+      expect(pickCriticalRepairTarget([container, road])).to.equal(road);
+    });
+  });
+
+  describe("wantsCriticalRecovery (divert hysteresis)", () => {
+    it("holds the diversion until nothing remains in the idle-maintenance band", () => {
+      // Repaired past the critical gate but still under the idle start gate -> keep going.
+      const stillLow = c(Math.floor(250000 * REPAIR_SPAWN_BELOW) - 1);
+      expect(wantsCriticalRecovery([stillLow])).to.equal(true);
+      // Once clear of the idle band, release the diversion and resume building.
+      const recovered = c(Math.floor(250000 * REPAIR_SPAWN_BELOW) + 1);
+      expect(wantsCriticalRecovery([recovered])).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Ordinary container/road maintenance is gated off entirely while a room has
ANY construction site: the ConstructionCorp builder builds one site at a
time and only maintains a fully-built room (runBuilder repairs solely when
sites.length === 0). So during a long build-out - a slow room, a remote
room mining while its own container decays - a structure that drops into
the danger band keeps decaying with nothing coming to repair it, all the
way to expiry. Measured on a grid repro: an owned room actively building
left an 8% container unrepaired for the whole window; a container is worth
5000 energy to rebuild plus the mining it strands.

Fix: emergency repair now outranks building. Below a CRITICAL fraction
(0.3, under the idle-maintenance start gate so it only fires for genuinely
endangered structures) the build crew DIVERTS to rescue the worst structure
before resuming its site. The diversion is latched on the creep
(repairingCritical) with hysteresis - start at REPAIR_CRITICAL, release once
nothing is left in the idle-maintenance band (REPAIR_SPAWN_BELOW) - so the
crew doesn't thrash between a far site and the container each tick it dips
past the start gate. It reuses the builder already fielded for the sites
(no new spawn) and self-fuels through the existing doMaintenance path.

- repair.ts: REPAIR_CRITICAL, pickCriticalRepairTarget, wantsCriticalRecovery
  (pure, unit-tested).
- ConstructionCorp.runBuilder: divert-to-rescue branch ahead of building.
- Memory: CreepMemory.repairingCritical latch.
- Grid: cons-repair-critical-during-build pins the divert (was red without
  the fix - the 8% container never climbed past 30%; now rescued @64).
- Existing repair/build/road construction cells stay green; 11 repair unit
  tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HoVxpSqnogQTPhdT4XmUXz