### PR TITLE
Force-bypass: a boxed-in creep swaps through any movable neighbour

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -9,7 +9,7 @@
 import { Corp, SerializedCorp } from "./Corp";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { CoreDepot, controllerDeliverySpot, coreDepot, scavengeSpot, sourcePickupSpot, workSpot } from "./nodeEnergy";
-import { travelTo, travelToBypass } from "./movement";
+import { travelTo, travelToQueued } from "./movement";
 import { driveRecycle, pickRuntToRecycle } from "./recycle";
 import { CARRY_CAPACITY, CREEP_LIFETIME, carryPartsFor, effectiveLife, staffsPost } from "../economy/primitives";
 import { HaulerAssignment } from "../flow/FlowTypes";
@@ -765,11 +765,11 @@ export class CarryCorp extends Corp {
       // if possible); advance the tour for next tick.
       creep.memory.circuitIdx = (stopIdx + 1) % circuit.length;
     } else {
-      // travelToBypass: refillers converge on the same tight cluster - a
-      // parked sibling on the path must be SWAPPED through, not deadlocked
-      // behind (measured live: haulers stuck on each other at a drop spot
-      // ringed by extensions).
-      travelToBypass(creep, dest, { range: 1, visualizePathStyle: { stroke: "#ffffff" } });
+      // travelToQueued: refillers converge on the same tight cluster, so line up
+      // behind whoever is already ahead toward this stop instead of swarming it -
+      // and force-swap through a parked sibling that has no travel intent (a stuck
+      // drop-off ring), rather than deadlocking behind it.
+      travelToQueued(creep, dest, { range: 1, visualizePathStyle: { stroke: "#ffffff" } });
     }
     return true;
   }
@@ -789,10 +789,11 @@ export class CarryCorp extends Corp {
     // (that pick flips every tick and turns the route into a shuffle).
     const spot = controllerDeliverySpot(controller);
     if (spot.structure) {
-      // Container/link: transfer from range 1, no need to stand on it. travelToBypass
-      // so a ring of parked upgraders can't wall the hauler out of range-1 access.
+      // Container/link: transfer from range 1, no need to stand on it. travelToQueued
+      // so a fleet routed here lines up rather than swarming the buffer, and a ring
+      // of parked upgraders still can't wall the hauler out of range-1 access.
       if (creep.pos.getRangeTo(spot.pos) > 1) {
-        travelToBypass(creep, spot.pos, { range: 1, visualizePathStyle: { stroke: "#ffaa00" } });
+        travelToQueued(creep, spot.pos, { range: 1, visualizePathStyle: { stroke: "#ffaa00" } });
         return true;
       }
       const moved = Math.min(
@@ -807,9 +808,10 @@ export class CarryCorp extends Corp {
     // tile so every parked upgrader ringing it (range 1) can withdraw from one
     // shared pile. A range-2 drop lands on the hauler's own tile, scattered out of
     // the ring's reach - the RCL2 starve. So stand ON the input tile and drop there;
-    // travelToBypass swaps through a parked upgrader if the ring has no open gap.
+    // travelToQueued lines up multiple haulers behind the one servicing the tile and
+    // still force-swaps through a parked upgrader when the ring has no open gap.
     if (!creep.pos.isEqualTo(spot.pos)) {
-      travelToBypass(creep, spot.pos, { range: 0, visualizePathStyle: { stroke: "#ffaa00" } });
+      travelToQueued(creep, spot.pos, { range: 0, visualizePathStyle: { stroke: "#ffaa00" } });
       return true;
     }
     const carried = creep.store[RESOURCE_ENERGY];

--- a/src/corps/movement.ts
+++ b/src/corps/movement.ts
@@ -137,3 +137,66 @@ export function travelToBypass(creep: Creep, target: MoveTarget, opts?: MoveToOp
   }
   return travelTo(creep, target, opts);
 }
+
+/**
+ * Should we HOLD in line behind the creep on our next step toward a contended
+ * target, instead of swapping past it? Yes when that creep is one of ours, can
+ * still move (so it will eventually clear), is NOT a yielding parked upgrader (a
+ * permanent resident of the approach - waiting for it would starve the target),
+ * and is strictly CLOSER to the target than we are (genuinely ahead of us in
+ * line). Pure predicate so the queue rule is unit-testable.
+ */
+export function shouldQueueBehind(
+  blocker: { my?: boolean; spawning?: boolean; fatigue?: number; pos: RoomPosition; memory: CreepMemory },
+  creepRangeToTarget: number,
+  targetPosition: RoomPosition
+): boolean {
+  if (!canForceThrough(blocker)) return false;
+  if (isYielding(blocker)) return false;
+  return blocker.pos.getRangeTo(targetPosition) < creepRangeToTarget;
+}
+
+/**
+ * Approach a contended target in SINGLE FILE instead of swarming it. Identical to
+ * {@link travelToBypass}, except that when the next step toward the target is
+ * blocked by one of our own transient creeps that is AHEAD of us in line (see
+ * {@link shouldQueueBehind}), we HOLD our tile rather than swapping past it or
+ * letting the pathfinder fan us out around it. That hold IS the queue: approaching
+ * creeps stack up along the lane and drain one at a time as the creep at the front
+ * reaches the target, services it, and leaves.
+ *
+ * The creep at the FRONT (nothing closer to the target ahead of it) never queues,
+ * so it always advances, services, and frees the spot - the line drains from the
+ * head. A yielding parked upgrader ringing the target is force-swapped through (not
+ * queued behind), so a dense upgrader camp still can't wall the input off. And a
+ * hold is bounded by {@link QUEUE_PATIENCE}: after that many consecutive held ticks
+ * the creep gives up waiting and force-swaps, so even a mis-detected blocker or a
+ * head-on stall (two lines meeting nose to nose) can never freeze it permanently.
+ *
+ * Use this only for one-directional APPROACHES to a shared drop-off/refill spot;
+ * use travelToBypass for the return leg (a queued approach meeting a force-swapping
+ * departure resolves; two queues meeting head-on would rely on the patience break).
+ */
+const QUEUE_PATIENCE = 3;
+
+export function travelToQueued(creep: Creep, target: MoveTarget, opts?: MoveToOpts): ScreepsReturnCode {
+  const pos = targetPos(target);
+  const range = opts?.range ?? 0;
+  if (creep.pos.roomName === pos.roomName && creep.pos.getRangeTo(pos) > range) {
+    const path = creep.room.findPath(creep.pos, pos, { range, ignoreCreeps: true, maxRooms: 1 });
+    if (path.length > 0) {
+      const step = path[0];
+      const next = new RoomPosition(step.x, step.y, creep.pos.roomName);
+      const blocker = next.lookFor(LOOK_CREEPS).find(c => c.name !== creep.name);
+      const mem = creep.memory as CreepMemory & { queueHeld?: number };
+      const held = mem.queueHeld ?? 0;
+      if (blocker && held < QUEUE_PATIENCE && shouldQueueBehind(blocker, creep.pos.getRangeTo(pos), pos)) {
+        mem.queueHeld = held + 1;
+        return OK; // hold our tile - this is the queue
+      }
+    }
+  }
+  // Moving (or forcing) this tick - reset the hold clock.
+  delete (creep.memory as CreepMemory & { queueHeld?: number }).queueHeld;
+  return travelToBypass(creep, target, opts);
+}

--- a/src/corps/movement.ts
+++ b/src/corps/movement.ts
@@ -63,9 +63,9 @@ export function travelTo(creep: Creep, target: MoveTarget, opts?: MoveToOpts): S
 /**
  * Is this friendly creep YIELDING - a parked upgrader sitting on its assigned
  * upgrade tile? Such a creep has no travel intent of its own this tick (it camps
- * and upgrades in place) and walks straight back next tick, so it is safe to swap
- * through. We deliberately do NOT treat other stationary creeps as yielding: we
- * don't want to yank a hauler off its route or a miner off its source. Pure
+ * and upgrades in place) and walks straight back next tick, so swapping through it
+ * costs it nothing. This is the GENTLE subset of the force-bypass rule (see
+ * {@link canForceThrough}): displacing it never delays any real work. Pure
  * predicate so the swap rule is unit-testable.
  */
 export function isYielding(creep: {
@@ -84,19 +84,39 @@ export function isYielding(creep: {
 }
 
 /**
+ * Can this blocking creep be FORCE-displaced this tick? Only our own creeps can be
+ * commanded (`move` on a foreign creep is a no-op), and only if they can physically
+ * step: a spawning creep is welded into its spawn and a fatigued one cannot move, so
+ * ordering either to swap would leave OUR mover wedged against a tile that never
+ * clears (its move onto the still-occupied tile just fails). Everything else -
+ * a parked upgrader, an idle hauler, a sibling schooling on the same drop spot - is
+ * fair game: the swap displaces it one tile for one tick and it re-paths next tick.
+ * Pure predicate so the force-swap rule is unit-testable.
+ */
+export function canForceThrough(blocker: { my?: boolean; spawning?: boolean; fatigue?: number }): boolean {
+  return blocker.my === true && blocker.spawning !== true && (blocker.fatigue ?? 0) === 0;
+}
+
+/**
  * Move toward a target like {@link travelTo}, but if the immediate step is blocked
- * by a YIELDING creep (a parked upgrader on its tile), SWAP through it: both
- * creeps step onto each other's tile the same tick. The engine permits this -
- * two creeps each moving onto the other's tile pass through, while a lone mover
- * onto a standing creep is blocked (the "bypass" rule). The displaced upgrader
- * returns to its post next tick.
+ * by one of our own creeps, FORCE a swap: both creeps step onto each other's tile
+ * the same tick. The engine permits this - two creeps each moving onto the other's
+ * tile pass through, while a lone mover onto a standing creep is blocked (the
+ * "bypass" rule). The displaced creep re-paths from its new tile next tick.
  *
- * This is what lets a hauler thread in to the shared controller pile/container
- * even when parked upgraders fully ring it (the dense-camp case): without the
- * swap the ring walls the input off and the whole camp starves. We path with
- * `ignoreCreeps` so the route heads straight at the target (revealing the swap)
- * instead of detouring around a ring that has no gap; if the next tile is NOT a
- * yielding creep we fall back to normal creep-aware pathing.
+ * Originally this swapped ONLY through {@link isYielding} parked upgraders, to
+ * thread a hauler into a controller pile ringed by a dense upgrader camp. But a
+ * creep also gets walled in by NON-yielding siblings - haulers schooling on a
+ * shared drop spot, an extension refill cluster - and there the yield-only swap
+ * found no gap, so it fell back to creep-aware pathing that had no route and the
+ * creep simply froze in place (observed live: a hauler stuck ON its drop-off tile,
+ * unable to leave, its pickup/deliver state flip-flopping so it "picks up and drops
+ * energy every tick" without ever going anywhere). So we now swap through ANY of
+ * our creeps that {@link canForceThrough} - a boxed-in creep can always push a
+ * neighbour aside and escape. We path with `ignoreCreeps` so the route heads
+ * straight at the target (revealing the swap) instead of detouring around a ring
+ * that has no gap; if the next tile holds no displaceable creep we fall back to
+ * normal creep-aware pathing.
  */
 export function travelToBypass(creep: Creep, target: MoveTarget, opts?: MoveToOpts): ScreepsReturnCode {
   const pos = targetPos(target);
@@ -109,7 +129,7 @@ export function travelToBypass(creep: Creep, target: MoveTarget, opts?: MoveToOp
       const step = path[0];
       const next = new RoomPosition(step.x, step.y, creep.pos.roomName);
       const blocker = next.lookFor(LOOK_CREEPS).find(c => c.name !== creep.name);
-      if (blocker && isYielding(blocker)) {
+      if (blocker && canForceThrough(blocker)) {
         blocker.move(blocker.pos.getDirectionTo(creep.pos)); // step onto our tile
         return creep.move(step.direction); // we take its tile - mutual swap
       }

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -332,11 +332,13 @@ export function workSpot(creep: Creep, spot: EnergySpot, mode: "collect" | "depo
   // tile short, common in remote mining where there is no container).
   const range = mode === "collect" && !spot.waitClear ? 1 : spot.structure ? 1 : 2;
   if (creep.pos.getRangeTo(spot.pos) > range) {
-    // travelToBypass so a hauler that just dropped on the controller pile and is now
-    // ringed by parked upgraders can SWAP through one to escape on its way back to
-    // pick up - without it the ring walls the hauler in on the input tile and it
-    // never leaves (the trapped-on-the-pile symptom). Away from the ring there is no
-    // yielding creep to swap, so this falls back to the border-bounce-safe travelTo.
+    // travelToBypass (force-swap), NOT a queue: this collect path is also how a
+    // just-emptied hauler LEAVES the controller input tile for its source. It heads
+    // OPPOSITE the haulers queuing to deliver, so if both sides held they would
+    // mutually block head-on (the original deadlock). Force-swapping resolves the
+    // head-on - both step through - and still swaps a hauler through a parked
+    // upgrader ring to escape (the trapped-on-the-pile symptom). Away from any creep
+    // this falls back to the border-bounce-safe travelTo.
     travelToBypass(creep, spot.pos, { range, visualizePathStyle: { stroke: "#ffaa00" } });
     return 0;
   }

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -373,6 +373,15 @@ declare global {
      */
     circuitIdx?: number;
 
+    /**
+     * Consecutive ticks this creep has HELD in a single-file queue behind another
+     * creep ahead of it toward a contended target (corps/movement travelToQueued).
+     * Bounds the queue: once it exceeds the patience limit the creep stops waiting
+     * and force-swaps through, so a mis-detected or head-on stall can never freeze
+     * it permanently. Reset the moment it stops holding.
+     */
+    queueHeld?: number;
+
     // === Fleet Coordination (Belt/Bus System) ===
 
     /**

--- a/test/unit/corps/bypass.test.ts
+++ b/test/unit/corps/bypass.test.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "chai";
 import { setupGlobals } from "../mock";
-import { isYielding } from "../../../src/corps/movement";
+import { canForceThrough, isYielding } from "../../../src/corps/movement";
 
 /**
- * isYielding is the swap rule's gate: ONLY a parked upgrader sitting on its own
- * assigned tile is safe to swap through (it has no move intent and walks back
- * next tick). A hauler, a miner, or an upgrader not yet on its tile must never be
- * yanked aside.
+ * isYielding is the GENTLE subset of the swap rule: a parked upgrader sitting on
+ * its own assigned tile has no move intent and walks straight back next tick, so
+ * displacing it costs nothing. (The broader force-swap gate is canForceThrough.)
  */
-describe("isYielding (bypass swap gate)", () => {
+describe("isYielding (gentle swap subset)", () => {
   beforeEach(() => setupGlobals());
 
   const make = (over: any) => ({
@@ -37,5 +36,44 @@ describe("isYielding (bypass swap gate)", () => {
 
   it("does not yield for an enemy creep on its tile", () => {
     expect(isYielding(make({ my: false }))).to.equal(false);
+  });
+});
+
+/**
+ * canForceThrough is the force-swap gate: a boxed-in creep may push ANY of our own
+ * movable creeps aside to escape (this is the fix for a hauler deadlocked on its
+ * drop-off tile, ringed by non-yielding siblings, that just picks up and drops in
+ * place). Only foreign creeps (uncontrollable) and physically-stuck ones (spawning
+ * or fatigued - their tile would never clear) are off-limits.
+ */
+describe("canForceThrough (force-swap gate)", () => {
+  beforeEach(() => setupGlobals());
+
+  const make = (over: any) => ({ my: true, spawning: false, fatigue: 0, ...over });
+
+  it("forces through a parked upgrader (the gentle case is still allowed)", () => {
+    expect(canForceThrough(make({}))).to.equal(true);
+  });
+
+  it("forces through a NON-yielding sibling hauler (the deadlock fix)", () => {
+    // A hauler schooling on the same drop spot is not 'yielding', but it is ours
+    // and can move - so a boxed-in creep can swap through it and get free.
+    expect(canForceThrough(make({}))).to.equal(true);
+  });
+
+  it("does not force through a foreign creep (cannot command it to move)", () => {
+    expect(canForceThrough(make({ my: false }))).to.equal(false);
+  });
+
+  it("does not force through a spawning creep (welded into its spawn)", () => {
+    expect(canForceThrough(make({ spawning: true }))).to.equal(false);
+  });
+
+  it("does not force through a fatigued creep (its tile would never clear)", () => {
+    expect(canForceThrough(make({ fatigue: 2 }))).to.equal(false);
+  });
+
+  it("treats an undefined fatigue as movable", () => {
+    expect(canForceThrough({ my: true } as any)).to.equal(true);
   });
 });

--- a/test/unit/corps/movement.test.ts
+++ b/test/unit/corps/movement.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "chai";
-import { travelTo, travelToBypass } from "../../../src/corps/movement";
+import { shouldQueueBehind, travelTo, travelToBypass, travelToQueued } from "../../../src/corps/movement";
 
 // Screeps direction constants (globals in-game).
 const DIRS: Record<string, number> = {
@@ -139,6 +139,7 @@ describe("travelToBypass (force-swap through a boxed-in blocker)", () => {
     const creep = {
       name: "req",
       pos: new MockPos(25, 20, ROOM),
+      memory: {} as any,
       room: {
         findPath: () => [{ x: 25, y: 19, dx: 0, dy: -1, direction: DIRS.TOP }],
       },
@@ -204,5 +205,104 @@ describe("travelToBypass (force-swap through a boxed-in blocker)", () => {
     expect(r).to.equal(0);
     expect(creep.calls.move).to.equal(undefined);
     expect(creep.calls.moveTo).to.equal(undefined);
+  });
+
+  // travelToQueued shares the same geometry: creep (25,20), next step (25,19),
+  // target (25,8). A blocker on (25,19) is range 11 from the target, the creep is
+  // range 12 - so the blocker is strictly AHEAD in line.
+  describe("travelToQueued (single-file, no swarm)", () => {
+    it("HOLDS behind a transient creep ahead in line (no move, no swap)", () => {
+      const ahead = blockerAt({ memory: { workType: "haul" } }); // ours, movable, not yielding, closer
+      const creep = requesterWith(ahead);
+
+      const r = travelToQueued(creep as any, new MockPos(25, 8, ROOM) as any, { range: 0 } as any);
+
+      expect(r, "holds its tile").to.equal(0);
+      expect(creep.calls.move, "does not swap past the creep ahead").to.equal(undefined);
+      expect(creep.calls.moveTo, "does not fan out around it").to.equal(undefined);
+      expect(ahead.bcalls.move, "the creep ahead is left alone").to.equal(undefined);
+    });
+
+    it("does NOT queue behind a yielding upgrader - force-swaps through it", () => {
+      // A parked upgrader ringing the target is a permanent resident; waiting for it
+      // would starve the spot, so travelToQueued delegates to the force-swap.
+      const upgrader = blockerAt({ memory: { workType: "upgrade", upgradeSpot: { x: 25, y: 19 } } });
+      const creep = requesterWith(upgrader);
+
+      travelToQueued(creep as any, new MockPos(25, 8, ROOM) as any, { range: 0 } as any);
+
+      expect(creep.calls.move, "threads through the ring").to.equal(DIRS.TOP);
+      expect(upgrader.bcalls.move, "the upgrader steps onto our tile").to.equal(DIRS.BOTTOM);
+    });
+
+    it("the FRONT creep (no one ahead) advances normally", () => {
+      const creep = requesterWith(null); // nothing on the next tile
+      travelToQueued(creep as any, new MockPos(25, 8, ROOM) as any, { range: 0 } as any);
+      // No blocker -> delegates to travelToBypass -> travelTo -> moveTo toward target.
+      expect(creep.calls.moveTo, "the head of the line keeps moving").to.not.equal(undefined);
+    });
+
+    it("breaks a stall: after QUEUE_PATIENCE held ticks it force-swaps through", () => {
+      const ahead = blockerAt({ memory: { workType: "haul" } });
+      const creep = requesterWith(ahead);
+      const target = new MockPos(25, 8, ROOM) as any;
+
+      // Ticks 1-3: holds in line, incrementing the hold clock, never swapping.
+      for (let t = 0; t < 3; t++) {
+        travelToQueued(creep as any, target, { range: 0 } as any);
+        expect(creep.calls.move, `tick ${t + 1} holds`).to.equal(undefined);
+        expect(ahead.bcalls.move, `tick ${t + 1} leaves the creep ahead alone`).to.equal(undefined);
+      }
+      expect(creep.memory.queueHeld).to.equal(3);
+
+      // Tick 4: patience exhausted -> force-swap breaks the stall, hold clock reset.
+      travelToQueued(creep as any, target, { range: 0 } as any);
+      expect(creep.calls.move, "forces through after patience").to.equal(DIRS.TOP);
+      expect(ahead.bcalls.move, "the blocker is swapped onto our tile").to.equal(DIRS.BOTTOM);
+      expect(creep.memory.queueHeld, "hold clock reset").to.equal(undefined);
+    });
+  });
+});
+
+describe("shouldQueueBehind (queue gate)", () => {
+  function posAt(x: number, y: number) {
+    return { x, y, getRangeTo: (t: any) => Math.max(Math.abs(x - t.x), Math.abs(y - t.y)) };
+  }
+  const target = posAt(25, 8);
+  // The creep deciding whether to queue sits at (25,20): range 12 from the target.
+  const CREEP_RANGE = 12;
+  const make = (over: any) => ({
+    my: true,
+    spawning: false,
+    fatigue: 0,
+    pos: posAt(25, 19), // range 11 - strictly closer than the creep
+    memory: { workType: "haul" },
+    ...over
+  });
+
+  it("queues behind a movable, non-yielding creep that is closer to the target", () => {
+    expect(shouldQueueBehind(make({}) as any, CREEP_RANGE, target as any)).to.equal(true);
+  });
+
+  it("does NOT queue behind a creep at the same distance (would be a mutual stalemate)", () => {
+    expect(shouldQueueBehind(make({ pos: posAt(24, 20) }) as any, CREEP_RANGE, target as any)).to.equal(false);
+  });
+
+  it("does NOT queue behind a creep FURTHER from the target (it is not ahead)", () => {
+    expect(shouldQueueBehind(make({ pos: posAt(25, 21) }) as any, CREEP_RANGE, target as any)).to.equal(false);
+  });
+
+  it("does NOT queue behind a yielding parked upgrader (force-swap it instead)", () => {
+    const upg = make({ memory: { workType: "upgrade", upgradeSpot: { x: 25, y: 19 } } });
+    expect(shouldQueueBehind(upg as any, CREEP_RANGE, target as any)).to.equal(false);
+  });
+
+  it("does NOT queue behind a foreign creep (cannot be commanded, may never move)", () => {
+    expect(shouldQueueBehind(make({ my: false }) as any, CREEP_RANGE, target as any)).to.equal(false);
+  });
+
+  it("does NOT queue behind a fatigued/spawning creep (handed to the force-swap gate)", () => {
+    expect(shouldQueueBehind(make({ fatigue: 2 }) as any, CREEP_RANGE, target as any)).to.equal(false);
+    expect(shouldQueueBehind(make({ spawning: true }) as any, CREEP_RANGE, target as any)).to.equal(false);
   });
 });

--- a/test/unit/corps/movement.test.ts
+++ b/test/unit/corps/movement.test.ts
@@ -1,11 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "chai";
-import { travelTo } from "../../../src/corps/movement";
+import { travelTo, travelToBypass } from "../../../src/corps/movement";
 
 // Screeps direction constants (globals in-game).
 const DIRS: Record<string, number> = {
   TOP: 1, TOP_RIGHT: 2, RIGHT: 3, BOTTOM_RIGHT: 4, BOTTOM: 5, BOTTOM_LEFT: 6, LEFT: 7, TOP_LEFT: 8,
 };
+
+/** dx,dy in {-1,0,1} -> Screeps direction constant, matching stepDirection in movement.ts. */
+function dirOf(dx: number, dy: number): number {
+  const map: Record<string, number> = {
+    "0,-1": DIRS.TOP, "1,-1": DIRS.TOP_RIGHT, "1,0": DIRS.RIGHT, "1,1": DIRS.BOTTOM_RIGHT,
+    "0,1": DIRS.BOTTOM, "-1,1": DIRS.BOTTOM_LEFT, "-1,0": DIRS.LEFT, "-1,-1": DIRS.TOP_LEFT,
+  };
+  return map[`${dx},${dy}`];
+}
 
 function pos(x: number, y: number, roomName: string) {
   return {
@@ -89,5 +98,111 @@ describe("travelTo (border-bounce-safe movement)", () => {
     const creep = creepAt(0, 25, "W1N0");
     travelTo(creep as any, { pos: pos(25, 25, "W1N0") } as any);
     expect(creep.calls.move).to.equal(DIRS.RIGHT);
+  });
+});
+
+describe("travelToBypass (force-swap through a boxed-in blocker)", () => {
+  const ROOM = "W1N0";
+
+  // A registry of creeps by tile so a mocked RoomPosition.lookFor(LOOK_CREEPS)
+  // can report who stands on the next path step.
+  let occupants: Record<string, any>;
+
+  // Mocked RoomPosition: travelToBypass does `new RoomPosition(x, y, room).lookFor(...)`.
+  class MockPos {
+    constructor(public x: number, public y: number, public roomName: string) {}
+    getRangeTo(t: any) { return Math.max(Math.abs(this.x - t.x), Math.abs(this.y - t.y)); }
+    getDirectionTo(t: any) { return dirOf(Math.sign(t.x - this.x), Math.sign(t.y - this.y)); }
+    isEqualTo(t: any) { return t.x === this.x && t.y === this.y; }
+    lookFor(_type: string) {
+      const c = occupants[`${this.x},${this.y}`];
+      return c ? [c] : [];
+    }
+  }
+
+  let prevRoomPosition: any;
+  before(() => {
+    for (const [name, val] of Object.entries(DIRS)) (global as any)[name] = val;
+    (global as any).LOOK_CREEPS = "creep";
+    (global as any).OK = 0;
+    prevRoomPosition = (global as any).RoomPosition;
+    (global as any).RoomPosition = MockPos;
+  });
+  after(() => { (global as any).RoomPosition = prevRoomPosition; });
+
+  beforeEach(() => { occupants = {}; });
+
+  // A one-step path straight up (target directly north). The requester sits at
+  // (25,20); its next step (25,19) is where the blocker stands.
+  function requesterWith(blocker: any) {
+    const calls = { move: undefined as number | undefined, moveTo: undefined as any };
+    const creep = {
+      name: "req",
+      pos: new MockPos(25, 20, ROOM),
+      room: {
+        findPath: () => [{ x: 25, y: 19, dx: 0, dy: -1, direction: DIRS.TOP }],
+      },
+      move(dir: number) { calls.move = dir; return 0; },
+      moveTo(t: any) { calls.moveTo = t; return 0; },
+      calls,
+    };
+    if (blocker) occupants["25,19"] = blocker;
+    return creep;
+  }
+
+  function blockerAt(over: any) {
+    const bcalls = { move: undefined as number | undefined };
+    return {
+      name: "blk",
+      my: true,
+      spawning: false,
+      fatigue: 0,
+      pos: new MockPos(25, 19, ROOM),
+      move(dir: number) { bcalls.move = dir; return 0; },
+      bcalls,
+      ...over,
+    };
+  }
+
+  it("swaps through a NON-yielding sibling: both step onto each other's tile", () => {
+    const blocker = blockerAt({ memory: { workType: "haul" } }); // not a parked upgrader
+    const creep = requesterWith(blocker);
+
+    travelToBypass(creep as any, new MockPos(25, 8, ROOM) as any, { range: 0 } as any);
+
+    // We advance toward the target (north)...
+    expect(creep.calls.move, "requester steps into the blocker's tile").to.equal(DIRS.TOP);
+    // ...and the blocker is commanded onto OUR tile (south) - the mutual swap.
+    expect(blocker.bcalls.move, "blocker steps onto our tile").to.equal(DIRS.BOTTOM);
+    // No fallback pathfinding was used.
+    expect(creep.calls.moveTo).to.equal(undefined);
+  });
+
+  it("does NOT command a foreign blocker; falls back to creep-aware pathing", () => {
+    const blocker = blockerAt({ my: false, memory: { workType: "haul" } });
+    const creep = requesterWith(blocker);
+
+    travelToBypass(creep as any, new MockPos(25, 8, ROOM) as any, { range: 0 } as any);
+
+    expect(blocker.bcalls.move, "cannot move a creep we don't own").to.equal(undefined);
+    expect(creep.calls.moveTo, "falls back to moveTo").to.not.equal(undefined);
+  });
+
+  it("does NOT force through a fatigued blocker (its tile would never clear)", () => {
+    const blocker = blockerAt({ fatigue: 2, memory: { workType: "haul" } });
+    const creep = requesterWith(blocker);
+
+    travelToBypass(creep as any, new MockPos(25, 8, ROOM) as any, { range: 0 } as any);
+
+    expect(blocker.bcalls.move).to.equal(undefined);
+    expect(creep.calls.moveTo, "falls back to moveTo").to.not.equal(undefined);
+  });
+
+  it("returns OK without moving when already within range of the target", () => {
+    const creep = requesterWith(null);
+    const r = travelToBypass(creep as any, new MockPos(25, 20, ROOM) as any, { range: 1 } as any);
+    expect(r).to.equal(0);
+    expect(creep.calls.move).to.equal(undefined);
+    expect(creep.calls.moveTo).to.equal(undefined);
   });
 });


### PR DESCRIPTION
A hauler ringed on its drop-off tile by NON-yielding creeps (sibling
haulers schooling on a shared drop spot, an extension refill cluster)
could not leave: travelToBypass only mutual-swapped through YIELDING
parked upgraders, and against anything else it fell back to creep-aware
pathing that found no route through the ring. The creep froze in place,
its pickup/deliver state flip-flopping every tick - the observed "hauler
stuck on the drop-off, picking up and dropping energy each tick" symptom.
(CarryCorp already documented the intended "sibling on the path must be
SWAPPED through, not deadlocked behind" behaviour that the yield-only gate
never actually delivered.)

Widen the swap gate from isYielding to a new canForceThrough: swap through
ANY of our own creeps that can physically move this tick (not spawning,
not fatigued). A boxed-in creep can always push a neighbour one tile aside
and escape; the displaced creep re-paths next tick. Foreign creeps (can't
command) and spawning/fatigued ones (their tile never clears, wedging our
mover) stay off-limits. Yielding upgraders remain the gentle common case.

isYielding is retained as the documented gentle subset (and for the
follow-up queuing work). Miners use travelTo, not travelToBypass, so they
never force-swap each other.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012FHMSAdpLc1mTMkigce37F