### PR TITLE
Bank surplus in storage instead of piling it at the controller

### DIFF
--- a/docs/specs/03-storage-drawdown.md
+++ b/docs/specs/03-storage-drawdown.md
@@ -1,9 +1,13 @@
 # 03 — Storage draw-down (spend the bank when income dips)
 
-**Status:** not started. The deposit half exists (haulers bank up to
-`STORAGE_BANK = 10000` in a storage depot, CarryCorp); withdrawal is currently
-only implicit (the tender refills extensions from the depot). Nothing feeds the
-*controller or builders* from the bank when income collapses.
+**Status:** withdrawal not started; the deposit half now works. As of the
+storage-hauler-routing change the planner caps the controller at
+`STORAGE_UPGRADE_TARGET` once a room has a storage (`flowAdapter.ts`) and routes
+the surplus to the storage sink, which CarryCorp delivers as a first-class `storage`
+circuit (`deliverToStorage`) with no spill ceiling — so the bank actually
+accumulates the expansion CAPEX instead of stalling at `STORAGE_BANK = 10000`.
+Withdrawal is still only implicit (the tender refills extensions from the depot);
+nothing feeds the *controller or builders* from the bank when income collapses.
 **Priority:** P1.
 
 ## Goal

--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -821,6 +821,20 @@ export class CarryCorp extends Corp {
     const controller = room.controller;
     if (!controller) return false;
 
+    // STORAGE-FIRST HUB: once a dedicated controller feeder is relaying the bank
+    // to the controller, the long-range haulers stop at the storage and the feeder
+    // runs the short last leg (owner 2026-07-11: "storage is primary, dedicated
+    // feeder for controller"). Deposit into the bank instead of hauling all the way
+    // to the controller. Fall THROUGH to direct delivery only when the bank is
+    // missing or physically full, so energy is never stranded and a dead feeder
+    // (flag cleared) reverts to direct hauling.
+    if (room.memory.controllerFeederActive) {
+      const bank = room.storage;
+      if (bank && bank.my && bank.store.getFreeCapacity(RESOURCE_ENERGY) > 0) {
+        return this.deliverToStorage(creep, room);
+      }
+    }
+
     // The controller node resolves its own input spot (upgrader container, else the
     // shared drop tile the camping upgraders ring - see nodeEnergy). The hauler just
     // routes there and deposits; no chasing whichever upgrader has the most room

--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -33,7 +33,7 @@ export { pickRuntToRecycle };
  * Sinks are classified by their flow `toId`: a "controller-*" destination is the
  * controller; anything else (spawn/extension network) is treated as the spawn.
  */
-export type LocalSink = "spawn" | "controller" | "founding";
+export type LocalSink = "spawn" | "controller" | "founding" | "storage";
 
 /**
  * Free capacity (energy) in the spawn network at or above which a hauler diverts
@@ -165,9 +165,10 @@ export function pickSinkByAllocation(
   // circuit. CROSS-ROOM construction (the expansion FOUNDING, spec 06) is the
   // exception: tankers are intra-room apparatus, so a route that crosses a border
   // has no tanker shortcut and the hauler runs it like any other circuit.
-  const flows: Record<LocalSink, number> = { spawn: 0, controller: 0, founding: 0 };
+  const flows: Record<LocalSink, number> = { spawn: 0, controller: 0, founding: 0, storage: 0 };
   for (const a of assignments) {
     if (a.toId.startsWith("controller-")) flows.controller += a.flowRate;
+    else if (a.toId.startsWith("storage-")) flows.storage += a.flowRate;
     else if (a.toId.startsWith("construction-")) {
       if (foundingSinks.has(a.toId)) flows.founding += a.flowRate;
     } else flows.spawn += a.flowRate;
@@ -179,7 +180,7 @@ export function pickSinkByAllocation(
   let best: LocalSink = "spawn";
   let bestScore = Infinity;
   let anyPositive = false;
-  for (const sink of ["spawn", "controller", "founding"] as const) {
+  for (const sink of ["spawn", "controller", "founding", "storage"] as const) {
     if (flows[sink] <= 0) continue;
     anyPositive = true;
     const score = (delivered[sink] ?? 0) / flows[sink];
@@ -340,7 +341,15 @@ export class CarryCorp extends Corp {
       // the home circuit. Fixed for the whole trip, so no mid-route thrash.
       const homeSink = creep.memory.homeSink as LocalSink;
       creep.memory.deliverSinkId = homeSink !== "spawn" && this.spawnNetworkCritical(room) ? "spawn" : homeSink;
-      creep.say(creep.memory.deliverSinkId === "controller" ? "→ctrl" : creep.memory.deliverSinkId === "founding" ? "→found" : "→spawn");
+      creep.say(
+        creep.memory.deliverSinkId === "controller"
+          ? "→ctrl"
+          : creep.memory.deliverSinkId === "founding"
+          ? "→found"
+          : creep.memory.deliverSinkId === "storage"
+          ? "→bank"
+          : "→spawn"
+      );
     }
 
     // A clean bus: it fills completely at its source stop, then runs the route and
@@ -567,9 +576,10 @@ export class CarryCorp extends Corp {
    * cross-room founding; local construction is excluded - tankers serve it). */
   private flowsBySink(): Record<LocalSink, number> {
     const founding = this.foundingSinkIds();
-    const flows: Record<LocalSink, number> = { spawn: 0, controller: 0, founding: 0 };
+    const flows: Record<LocalSink, number> = { spawn: 0, controller: 0, founding: 0, storage: 0 };
     for (const a of this.haulerAssignments) {
       if (a.toId.startsWith("controller-")) flows.controller += a.flowRate;
+      else if (a.toId.startsWith("storage-")) flows.storage += a.flowRate;
       else if (a.toId.startsWith("construction-")) {
         if (founding.has(a.toId)) flows.founding += a.flowRate;
       } else flows.spawn += a.flowRate;
@@ -647,7 +657,35 @@ export class CarryCorp extends Corp {
   private tryDeliverTo(creep: Creep, room: Room, sink: LocalSink): boolean {
     if (sink === "controller") return this.deliverToController(creep, room);
     if (sink === "founding") return this.deliverToFounding(creep);
+    if (sink === "storage") return this.deliverToStorage(creep, room);
     return this.deliverToSpawn(creep, room);
+  }
+
+  /**
+   * Bank a load in the room's storage. This is the deposit half of the storage
+   * bank: the flow planner routes the surplus here (surplus the controller no
+   * longer mops up once a storage exists - see flowAdapter's STORAGE_UPGRADE_TARGET),
+   * so the hauler drives to the storage and dumps everything into it. The energy
+   * is then distributed LOCALLY from the depot - the extension tender already
+   * refills the spawn/extensions from it (coreDepot), and the spawn-critical
+   * override still tops a hungry spawn first. Unlike deliverToSpawn's small bridge
+   * bank (STORAGE_BANK, then spill to the controller), this keeps filling the
+   * storage so it can accumulate the expansion capital the trigger saves toward.
+   *
+   * Returns false when the route has vanished (no storage) or the bank is
+   * physically full, so deliverEnergy spills the load to the spawn/controller.
+   */
+  private deliverToStorage(creep: Creep, room: Room): boolean {
+    const storage = room.storage;
+    if (!storage || !storage.my) return false; // route gone; caller re-assigns / falls back
+    if (storage.store.getFreeCapacity(RESOURCE_ENERGY) === 0) return false; // bank full: spill to consumers
+    if (creep.pos.getRangeTo(storage) > 1) {
+      travelTo(creep, storage, { range: 1, visualizePathStyle: { stroke: "#ffffff" } });
+      return true;
+    }
+    const moved = Math.min(creep.store[RESOURCE_ENERGY], storage.store.getFreeCapacity(RESOURCE_ENERGY));
+    if (creep.transfer(storage, RESOURCE_ENERGY) === OK) this.recordProduction(moved);
+    return true;
   }
 
   /**

--- a/src/corps/ControllerFeederCorp.ts
+++ b/src/corps/ControllerFeederCorp.ts
@@ -1,0 +1,231 @@
+/**
+ * @fileoverview ControllerFeederCorp - a LOCAL MOVER (type "moving") that relays
+ * energy from the room's storage BANK to the controller's upgrade input, so the
+ * long-range haulers deliver to ONE central destination - the storage - and this
+ * dedicated feeder runs the short last leg to the parked upgraders.
+ *
+ * The controller analogue of ExtensionTenderCorp (which relays the depot ->
+ * spawn/extensions). Once a room has a storage, the flow planner routes the
+ * surplus into the bank (flowAdapter's STORAGE_UPGRADE_TARGET) and CarryCorp
+ * deposits controller-bound loads into the storage rather than hauling all the way
+ * to the controller (deliverToController defers to the feeder while it is active).
+ * The feeder keeps the controller input spot - the upgrader container, or the
+ * shared drop pile before one is built - topped from the bank, and the upgraders
+ * draw from it exactly as before, so their stock-grounded sizing is unchanged: the
+ * feeder REPLACES the direct haul, it does not change how fast the controller is
+ * upgraded.
+ *
+ * @module corps/ControllerFeederCorp
+ */
+
+import { Corp, SerializedCorp } from "./Corp";
+import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
+import { Position } from "../types/Position";
+import { CoreDepot, coreDepot, controllerInputSpot } from "./nodeEnergy";
+import { travelTo, travelToBypass } from "./movement";
+import { carryPartsFor } from "../economy/primitives";
+import { STORAGE_UPGRADE_TARGET } from "../economy/flowAdapter";
+
+export interface SerializedControllerFeederCorp extends SerializedCorp {
+  spawnId: string;
+}
+
+/**
+ * Energy the feeder keeps staged at the controller input. Matched to a container's
+ * worth so the upgraders' stock-grounded sizing (UpgradingCorp.controllerSideStock)
+ * is the SAME as it was under direct hauling - the feeder replaces the haul, it does
+ * not change how fast the controller upgrades. A bare drop pile (before a container
+ * is built) is held to the same target so it cannot grow unbounded.
+ */
+const CONTROLLER_FEED_TARGET = 2000;
+
+/**
+ * ControllerFeederCorp fields one feeder that shuttles storage -> controller input.
+ */
+export class ControllerFeederCorp extends Corp {
+  private spawnId: string;
+
+  public constructor(nodeId: string, spawnId: string, customId?: string) {
+    super("moving", nodeId, customId);
+    this.spawnId = spawnId;
+  }
+
+  public getSpawnId(): string {
+    return this.spawnId;
+  }
+
+  /** Rebind to the commission's CURRENT spawn (commission-owned; never let it go stale). */
+  public setSpawnId(spawnId: string): void {
+    this.spawnId = spawnId;
+  }
+
+  public getPosition(): Position {
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    const controller = spawn?.room.controller;
+    if (controller) return { x: controller.pos.x, y: controller.pos.y, roomName: controller.pos.roomName };
+    if (spawn) return { x: spawn.pos.x, y: spawn.pos.y, roomName: spawn.pos.roomName };
+    return { x: 25, y: 25, roomName: this.nodeId.split("-")[0] };
+  }
+
+  private getFeeders(): Creep[] {
+    const creeps: Creep[] = [];
+    for (const name in Game.creeps) {
+      const c = Game.creeps[name];
+      if (c.memory.corpId === this.id && c.memory.workType === "feed" && !c.spawning) creeps.push(c);
+    }
+    return creeps;
+  }
+
+  public getCreepCount(): number {
+    return this.getFeeders().length;
+  }
+
+  /** True once a flow miner is producing in the room (income before infrastructure). */
+  private roomHasMiner(room: Room): boolean {
+    for (const name in Game.creeps) {
+      const c = Game.creeps[name];
+      if (
+        c.room.name === room.name &&
+        c.memory.workType === "harvest" &&
+        (c.memory.corpId ?? "").startsWith("mining-")
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Energy already staged at the controller input: its container/link plus piles. */
+  private controllerStock(controller: StructureController, inputPos: RoomPosition): number {
+    let stock = 0;
+    const buffer = controller.pos.findInRange(FIND_STRUCTURES, 3, {
+      filter: s => s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_LINK
+    })[0] as StructureContainer | StructureLink | undefined;
+    if (buffer) stock += buffer.store[RESOURCE_ENERGY];
+    for (const r of inputPos.findInRange(FIND_DROPPED_RESOURCES, 1)) {
+      if (r.resourceType === RESOURCE_ENERGY) stock += r.amount;
+    }
+    return stock;
+  }
+
+  public work(tick: number): void {
+    this.lastActivityTick = tick;
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    if (!spawn) return;
+    const room = spawn.room;
+    const controller = room.controller;
+    if (!controller) return;
+
+    const depot = coreDepot(room);
+    const feeders = this.getFeeders();
+    // Signal the haulers: while a storage bank exists AND a feeder is alive to run
+    // the last leg, controller-bound loads stop at the bank (CarryCorp defers to us).
+    // If the feeder dies the flag clears and haulers resume delivering to the
+    // controller directly, so a dead feeder never starves upgrading.
+    room.memory.controllerFeederActive = !!(room.storage && room.storage.my) && feeders.length > 0;
+
+    for (const creep of feeders) this.runFeeder(creep, controller, depot);
+  }
+
+  /**
+   * A feeder shuttles bank -> controller input: fill up at the storage, top the
+   * controller input to CONTROLLER_FEED_TARGET, reload when empty. It only flips
+   * state on full/empty, so it makes complete trips rather than dithering.
+   */
+  private runFeeder(creep: Creep, controller: StructureController, depot: CoreDepot | null): void {
+    if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) creep.memory.working = false;
+    if (!creep.memory.working && creep.store.getFreeCapacity() === 0) creep.memory.working = true;
+
+    if (creep.memory.working) {
+      const input = controllerInputSpot(controller);
+      // Topped up: hold the load near the input so the next drain is served at once
+      // (do not overfill - a bare pile would otherwise grow without bound).
+      if (this.controllerStock(controller, input.pos) >= CONTROLLER_FEED_TARGET) {
+        if (creep.pos.getRangeTo(input.pos) > 2) travelTo(creep, input.pos, { range: 2 });
+        return;
+      }
+      if (input.structure) {
+        // Container/link: transfer from range 1. travelToBypass so a ring of parked
+        // upgraders cannot wall the feeder out of range-1 access.
+        if (creep.pos.getRangeTo(input.pos) > 1) {
+          travelToBypass(creep, input.pos, { range: 1, visualizePathStyle: { stroke: "#ffff88" } });
+          return;
+        }
+        const moved = Math.min(
+          creep.store[RESOURCE_ENERGY],
+          input.structure.store.getFreeCapacity(RESOURCE_ENERGY) ?? creep.store[RESOURCE_ENERGY]
+        );
+        if (creep.transfer(input.structure, RESOURCE_ENERGY) === OK) this.recordProduction(moved);
+        return;
+      }
+      // Bare tile (no container yet): drop ON the input tile so every parked upgrader
+      // ringing it can withdraw from the one shared pile (mirrors CarryCorp's drop).
+      if (!creep.pos.isEqualTo(input.pos)) {
+        travelToBypass(creep, input.pos, { range: 0, visualizePathStyle: { stroke: "#ffff88" } });
+        return;
+      }
+      const carried = creep.store[RESOURCE_ENERGY];
+      if (creep.drop(RESOURCE_ENERGY) === OK) this.recordProduction(carried);
+      return;
+    }
+
+    // Reload from the bank (fall back to a nearby drop pile if the depot is dry).
+    if (depot && depot.store[RESOURCE_ENERGY] > 0) {
+      if (creep.withdraw(depot, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+        travelTo(creep, depot, { range: 1, visualizePathStyle: { stroke: "#ffff88" } });
+      }
+      return;
+    }
+    if (depot && !creep.pos.isNearTo(depot)) travelTo(creep, depot, { range: 1 });
+  }
+
+  /**
+   * Demand one feeder once a storage bank exists and the room produces energy.
+   * NON-blocking infrastructure: until it spawns, room.memory.controllerFeederActive
+   * stays false and the haulers feed the controller directly, so nothing is starved.
+   * Sized to sustain the upgrade target over the bank->controller round trip.
+   */
+  public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {
+    const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
+    if (!spawn) return [];
+    const room = spawn.room;
+    const controller = room.controller;
+    if (!controller) return [];
+    if (!(room.storage && room.storage.my)) return []; // no bank yet -> haulers feed the controller directly
+    if (!this.roomHasMiner(room)) return []; // infrastructure follows income
+    if (this.getFeeders().length >= 1) return []; // one feeder per room is enough
+
+    // Balanced 1:1 body sized to sustain the upgrade target over the round trip
+    // (the feeder travels, unlike the parked extension tender). The storage sits by
+    // the spawn, so the spawn->controller distance approximates the bank->controller leg.
+    const distance = spawn.pos.getRangeTo(controller.pos);
+    const PART_PAIR = 100; // CARRY + MOVE
+    const maxCarry = Math.max(1, Math.min(Math.floor(ctx.energyCapacity / PART_PAIR), 25));
+    const carry = Math.max(1, Math.min(Math.ceil(carryPartsFor(STORAGE_UPGRADE_TARGET, distance) * 1.2), maxCarry));
+
+    return [
+      {
+        buyerCorpId: this.id,
+        role: "feeder",
+        // Infrastructure tier: just below the extension tender (96), above upgrading -
+        // it must exist for the upgraders it serves, but never ahead of the producers.
+        value: 95,
+        blocking: false, // infra, not income: haulers feed the controller directly until it spawns
+        producesIncome: false,
+        desiredCost: carry * PART_PAIR,
+        minCost: Math.min(carry, 2) * PART_PAIR,
+        since: 0,
+        bodyParam: carry
+      }
+    ];
+  }
+
+  public serialize(): SerializedControllerFeederCorp {
+    return { ...super.serialize(), spawnId: this.spawnId };
+  }
+
+  public deserialize(data: SerializedControllerFeederCorp): void {
+    super.deserialize(data);
+    this.spawnId = data.spawnId ?? this.spawnId;
+  }
+}

--- a/src/corps/SpawningCorp.ts
+++ b/src/corps/SpawningCorp.ts
@@ -119,7 +119,7 @@ export class SpawningCorp extends Corp {
    * that to an actual body and a spawnCreep call.
    */
   public executeSpawn(
-    role: "miner" | "hauler" | "upgrader" | "builder" | "scout" | "tanker" | "reserver" | "claimer",
+    role: "miner" | "hauler" | "upgrader" | "builder" | "scout" | "tanker" | "feeder" | "reserver" | "claimer",
     buyerCorpId: string,
     energyBudget: number,
     tick: number,
@@ -136,7 +136,10 @@ export class SpawningCorp extends Corp {
     const bodyCost = this.calculateBodyCost(body);
     if (spawn.room.energyAvailable < bodyCost) return false;
 
-    const workTypeMap: Record<string, "harvest" | "haul" | "tank" | "upgrade" | "build" | "scout" | "reserve" | "claim"> = {
+    const workTypeMap: Record<
+      string,
+      "harvest" | "haul" | "tank" | "feed" | "upgrade" | "build" | "scout" | "reserve" | "claim"
+    > = {
       miner: "harvest",
       hauler: "haul",
       upgrader: "upgrade",
@@ -149,7 +152,12 @@ export class SpawningCorp extends Corp {
       // builder). That is a different job from a hauler, which does long-range
       // INTER-node transport - even though both are CARRY+MOVE creeps. Keep them
       // distinct so the economy can reason about (and instrument) each.
-      tanker: "tank"
+      tanker: "tank",
+      // A feeder is the controller's dedicated intra-node mover: it relays energy
+      // from the storage bank to the controller input. Its own workType keeps it
+      // distinct from the extension tender (both are "moving" corps) for
+      // instrumentation and orphan re-adoption.
+      feeder: "feed"
     };
     const name = `${role}-${buyerCorpId.slice(-6)}-${tick}`;
     // Drain in refill-circuit order (owner directive): spawning empties the
@@ -177,7 +185,7 @@ export class SpawningCorp extends Corp {
    * Build a body for the given role that costs at most `energyBudget`.
    */
   private buildBodyForRole(
-    role: "miner" | "hauler" | "upgrader" | "builder" | "scout" | "tanker" | "reserver" | "claimer",
+    role: "miner" | "hauler" | "upgrader" | "builder" | "scout" | "tanker" | "feeder" | "reserver" | "claimer",
     energyBudget: number,
     bodyParam?: number,
     haulerRatio?: HaulerRatio,
@@ -194,6 +202,16 @@ export class SpawningCorp extends Corp {
       case "tanker":
         // Pure CARRY+MOVE feeder; bodyParam is the desired CARRY parts.
         return buildTankerBody(bodyParam ?? 4, energyBudget, false).body;
+      case "feeder": {
+        // The controller feeder SHUTTLES storage <-> controller, so unlike the
+        // parked extension tender it must move at load speed - a balanced 1:1
+        // CARRY:MOVE body (bodyParam = desired CARRY parts).
+        const carry = Math.max(1, Math.min(bodyParam ?? 4, Math.floor(energyBudget / 100), 25));
+        const feederBody: BodyPartConstant[] = [];
+        for (let i = 0; i < carry; i++) feederBody.push(CARRY);
+        for (let i = 0; i < carry; i++) feederBody.push(MOVE);
+        return feederBody;
+      }
       case "scout":
         return [MOVE];
       case "reserver":

--- a/src/corps/kinds/controllerFeederKind.ts
+++ b/src/corps/kinds/controllerFeederKind.ts
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview controllerFeederKind - ControllerFeederCorp as a registered
+ * CorpKind: an auxiliary local mover, the controller analogue of the extension
+ * tender (docs/specs/00-corp-framework.md).
+ *
+ * Auxiliary shape, like the extension tender. propose() commissions one feeder
+ * corp per spawn room unconditionally; the trigger ("a storage bank exists and the
+ * room produces energy") lives at RUNTIME in getSpawnDemand(), which reads live
+ * structures and creeps - a corp with no bank demands nothing and costs nothing.
+ *
+ * @module corps/kinds/controllerFeederKind
+ */
+
+import { Commission, corpIdFor } from "../../economy/Commission";
+import { CorpKind } from "../../economy/CorpKind";
+import { ColonyProblem } from "../../economy/CorpPlanner";
+import { SerializedCorp } from "../Corp";
+import { ControllerFeederCorp, SerializedControllerFeederCorp } from "../ControllerFeederCorp";
+
+/** The feeder commission's binding: which home room, which spawn. */
+export interface ControllerFeederAssignment {
+  roomName: string;
+  spawnId: string;
+}
+
+export const controllerFeederKind: CorpKind<ControllerFeederCorp> = {
+  kind: "controllerFeeder",
+  runOrder: 41, // local mover, right after the extension tender (40)
+
+  propose(problem: ColonyProblem): Commission[] {
+    const homeSpawnByRoom = new Map<string, string>();
+    for (const s of problem.spawns) {
+      if (!homeSpawnByRoom.has(s.pos.roomName)) {
+        homeSpawnByRoom.set(s.pos.roomName, s.id);
+      }
+    }
+    return [...homeSpawnByRoom].map(([roomName, spawnId]) => ({
+      corpId: corpIdFor("controllerFeeder", roomName),
+      kind: "controllerFeeder",
+      shape: "auxiliary",
+      // Off-budget: a feeder MOVES energy already produced (bank -> controller),
+      // priced by the SpawnDirector's infrastructure tier, not the planner.
+      consumes: { spawnPartsPerTick: 0 },
+      produces: { valuePerTick: 0 },
+      assignment: { roomName, spawnId } as ControllerFeederAssignment
+    }));
+  },
+
+  materialize(c: Commission, existing: ControllerFeederCorp | undefined): ControllerFeederCorp {
+    const a = c.assignment as ControllerFeederAssignment;
+    if (existing) {
+      existing.setSpawnId(a.spawnId); // commission-owned: never let it go stale
+      return existing;
+    }
+    return new ControllerFeederCorp(`${a.roomName}-controllerFeeder`, a.spawnId);
+  },
+
+  run(corp: ControllerFeederCorp, tick: number): void {
+    corp.work(tick);
+  },
+
+  serializeCorp(corp: ControllerFeederCorp): SerializedControllerFeederCorp {
+    return corp.serialize();
+  },
+
+  deserializeCorp(data: SerializedCorp): ControllerFeederCorp {
+    const d = data as SerializedControllerFeederCorp;
+    const corp = new ControllerFeederCorp(d.nodeId, d.spawnId, d.id);
+    corp.deserialize(d);
+    return corp;
+  },
+
+  body(_role: string, bodyParam: number | undefined, energyBudget: number): BodyPartConstant[] {
+    // Balanced 1:1 CARRY:MOVE shuttle (bodyParam = desired CARRY parts). Mirrors
+    // SpawningCorp.buildBodyForRole's "feeder" case for the framework spawn path.
+    const carry = Math.max(1, Math.min(bodyParam ?? 4, Math.floor(energyBudget / 100), 25));
+    const body: BodyPartConstant[] = [];
+    for (let i = 0; i < carry; i++) body.push(CARRY);
+    for (let i = 0; i < carry; i++) body.push(MOVE);
+    return body;
+  }
+};

--- a/src/economy/flowAdapter.ts
+++ b/src/economy/flowAdapter.ts
@@ -40,6 +40,43 @@ import { commissionsFromPlan } from "./commissionPlan";
 /** Guaranteed controller trickle (energy/tick) so it never downgrades / stalls. */
 export const ANTI_DOWNGRADE_RESERVE = 2;
 
+/**
+ * Energy/tick the planner keeps routing to the controller ONCE THE ROOM HAS A
+ * STORAGE bank; everything above this banks in the storage instead of piling at
+ * the controller drop-off (owner 2026-07-11: "once we have a storage, that should
+ * be a good destination for a lot of drop-offs, and we deliver it locally from
+ * there"). This is the deposit half of the storage bank: the durable storage - not
+ * the controller - soaks the surplus, so it can accumulate the expansion CAPEX the
+ * capital trigger saves toward (bankedEnergy reads storage; STORAGE_BANK spill to
+ * the controller otherwise capped it at 10k, below EXPANSION_CAPEX).
+ *
+ * It is the tuning knob for the upgrade-vs-bank balance: raise it to favour faster
+ * RCL, lower it to save harder. Below this rate the controller still mops up ALL
+ * income (its capacity exceeds the supply, so nothing is left to bank), so a lean
+ * single/2-source room upgrades exactly as before and only genuine surplus banks.
+ * Comfortably above the anti-downgrade reserve so upgrading always makes progress.
+ * Without a storage there is nowhere durable to bank surplus, so the controller
+ * keeps absorbing the whole remainder (pre-storage behaviour is unchanged).
+ */
+export const STORAGE_UPGRADE_TARGET = 15;
+
+/**
+ * Routing capacity for a controller sink. Uncapped (mops up the remainder) until
+ * the controller's room has a storage bank, then bounded to {@link
+ * STORAGE_UPGRADE_TARGET} so the surplus banks in storage. Pure over the set of
+ * storage-bearing rooms so it is unit-testable without Game.
+ */
+export function controllerRoutingCapacity(
+  sink: { position: Position },
+  totalSupply: number,
+  roomsWithStorage: ReadonlySet<string>
+): number {
+  if (roomsWithStorage.has(sink.position.roomName)) {
+    return Math.max(STORAGE_UPGRADE_TARGET, ANTI_DOWNGRADE_RESERVE);
+  }
+  return Math.max(totalSupply, 1);
+}
+
 /** Ticks over which the agenda's funding need amortizes into a flow rate. */
 export const FUND_HORIZON = 50;
 
@@ -228,6 +265,13 @@ export function buildColonyProblem(
   sources.push(...transientSources);
   const totalSupply = sources.reduce((sum, s) => sum + s.rate, 0);
 
+  // Rooms whose bank is built: their controller stops mopping up the surplus so
+  // the storage can soak it (see controllerRoutingCapacity / STORAGE_UPGRADE_TARGET).
+  const roomsWithStorage = new Set<string>();
+  for (const sink of graph.getSinks()) {
+    if (sink.type === "storage") roomsWithStorage.add(sink.position.roomName);
+  }
+
   const sinks: PlannerSink[] = [];
   for (const sink of graph.getSinks()) {
     const kind = toSinkKind(sink.type);
@@ -266,7 +310,7 @@ export function buildColonyProblem(
             Math.max(minedSupply, 1)
           : kind === "storage"
           ? Math.max(totalSupply, 1) // soak excess
-          : Math.max(totalSupply, 1), // controller mops up the remainder
+          : controllerRoutingCapacity(sink, totalSupply, roomsWithStorage), // controller: mops up the remainder, unless a storage banks the surplus
       reserve: kind === "controller" ? ANTI_DOWNGRADE_RESERVE : undefined
     });
   }

--- a/src/execution/CommissionHost.ts
+++ b/src/execution/CommissionHost.ts
@@ -34,6 +34,7 @@ import { scoutKind, setSpawningCorpResolver } from "../corps/kinds/scoutKind";
 import { reservationKind } from "../corps/kinds/reservationKind";
 import { claimKind } from "../corps/kinds/claimKind";
 import { extensionTenderKind } from "../corps/kinds/extensionTenderKind";
+import { controllerFeederKind } from "../corps/kinds/controllerFeederKind";
 import { harvestKind } from "../corps/kinds/harvestKind";
 import { carryKind } from "../corps/kinds/carryKind";
 import { upgradeKind } from "../corps/kinds/upgradeKind";
@@ -54,6 +55,7 @@ const KINDS: CorpKind[] = [
   reservationKind as never,
   claimKind as never,
   extensionTenderKind as never,
+  controllerFeederKind as never,
   constructionKind as never
 ];
 

--- a/src/execution/OrphanRescue.ts
+++ b/src/execution/OrphanRescue.ts
@@ -73,13 +73,24 @@ const ROLE_KIND: Record<string, string> = {
   build: "construction",
   reserve: "reservation",
   scout: "scout",
-  tank: "tender"
+  tank: "tender",
+  feed: "controllerFeeder"
 };
 
 /** Every live corp id this tick: the union of what each runner claims creeps by. */
 function liveCorpIds(registry: CorpRegistry): Set<string> {
   const ids = new Set<string>();
-  for (const kind of ["harvest", "carry", "upgrade", "construction", "scout", "reservation", "claim", "tender"]) {
+  for (const kind of [
+    "harvest",
+    "carry",
+    "upgrade",
+    "construction",
+    "scout",
+    "reservation",
+    "claim",
+    "tender",
+    "controllerFeeder"
+  ]) {
     const corps = commissionedCorpsOfKind<Corp>(kind);
     for (const id in corps) ids.add(corps[id].id);
   }

--- a/src/execution/SpawnDirector.ts
+++ b/src/execution/SpawnDirector.ts
@@ -27,6 +27,7 @@ import { CorpRegistry } from "./CorpRunner";
 import { commissionedCorpsOfKind } from "./CommissionHost";
 import { ReservationCorp } from "../corps/ReservationCorp";
 import { ExtensionTenderCorp } from "../corps/ExtensionTenderCorp";
+import { ControllerFeederCorp } from "../corps/ControllerFeederCorp";
 import { HarvestCorp } from "../corps/HarvestCorp";
 import { CarryCorp } from "../corps/CarryCorp";
 import { UpgradingCorp } from "../corps/UpgradingCorp";
@@ -212,6 +213,13 @@ export function collectDemands(registry: CorpRegistry, spawnId: string, ctx: Spa
   const tenderCorps = commissionedCorpsOfKind<ExtensionTenderCorp>("tender");
   for (const id in tenderCorps) {
     const c = tenderCorps[id];
+    if (c.getSpawnId() === spawnId && !c.retiring) demands.push(...c.getSpawnDemand(ctx));
+  }
+  // Controller feeders live in the commission store (framework-ported); their
+  // feeders compete here on the same value-ranked infrastructure tier as tenders.
+  const controllerFeederCorps = commissionedCorpsOfKind<ControllerFeederCorp>("controllerFeeder");
+  for (const id in controllerFeederCorps) {
+    const c = controllerFeederCorps[id];
     if (c.getSpawnId() === spawnId && !c.retiring) demands.push(...c.getSpawnDemand(ctx));
   }
   // Reservation corps live in the commission store (framework-ported), but

--- a/src/spawn/SpawnScheduler.ts
+++ b/src/spawn/SpawnScheduler.ts
@@ -27,7 +27,16 @@
  */
 
 /** Roles the scheduler knows how to rank and size. */
-export type SpawnRole = "miner" | "hauler" | "upgrader" | "builder" | "scout" | "tanker" | "reserver" | "claimer";
+export type SpawnRole =
+  | "miner"
+  | "hauler"
+  | "upgrader"
+  | "builder"
+  | "scout"
+  | "tanker"
+  | "feeder"
+  | "reserver"
+  | "claimer";
 
 /**
  * A request for one creep, declared by a producing corp.

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -273,6 +273,16 @@ declare global {
      * tender can never deadlock the colony).
      */
     extensionTenderActive?: boolean;
+
+    /**
+     * True while a storage bank exists AND a live controller feeder is relaying it
+     * to the controller input. Set by ControllerFeederCorp, read by CarryCorp: when
+     * set, controller-bound loads stop at the storage (the feeder runs the short
+     * last leg to the upgraders); when the feeder dies it clears and haulers resume
+     * delivering to the controller directly (so a dead feeder never starves
+     * upgrading).
+     */
+    controllerFeederActive?: boolean;
   }
 
   /**
@@ -294,7 +304,7 @@ declare global {
      * - repair: Structure repair
      * - scout: Room scouting
      */
-    workType?: "harvest" | "haul" | "tank" | "upgrade" | "build" | "repair" | "scout" | "reserve" | "claim";
+    workType?: "harvest" | "haul" | "tank" | "feed" | "upgrade" | "build" | "repair" | "scout" | "reserve" | "claim";
 
     /**
      * Target ID for current task.

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -402,14 +402,14 @@ declare global {
      * hungry that tick), then held for the whole trip so it never thrashes
      * mid-route. Cleared when the load is emptied.
      */
-    deliverSinkId?: "spawn" | "controller" | "founding";
+    deliverSinkId?: "spawn" | "controller" | "founding" | "storage";
 
     /**
      * The hauler's PERMANENT delivery circuit, assigned once for life in
      * proportion to the flow solver's per-sink allocations. This is its default
      * destination every trip (overridden only to top up a hungry spawn).
      */
-    homeSink?: "spawn" | "controller" | "founding";
+    homeSink?: "spawn" | "controller" | "founding" | "storage";
 
     /** An upgrader's assigned parking tile (ringing the controller input spot);
      * it camps here, withdraws from the single input, and upgrades in place. */

--- a/test/unit/corps/CarryCorp.behavior.test.ts
+++ b/test/unit/corps/CarryCorp.behavior.test.ts
@@ -199,6 +199,27 @@ describe("CarryCorp behaviour (trivial scenarios)", () => {
       expect(ratio).to.be.closeTo(3, 0.4, "controller should get ~3x the spawn's loads");
     });
 
+    it("routes storage-bound flow to the bank (storage), not the spawn circuit", () => {
+      const toStorage = [{ toId: "storage-ssss", flowRate: 6 }];
+      expect(pickSinkByAllocation(toStorage, {})).to.equal("storage");
+    });
+
+    it("keeps storage-bound flow as its own circuit alongside the spawn", () => {
+      // Equal spawn/storage flow -> the fleet splits ~evenly between the two,
+      // rather than storage being folded into the spawn circuit.
+      const assignments = [
+        { toId: "spawn-aaaa", flowRate: 4 },
+        { toId: "storage-ssss", flowRate: 4 }
+      ];
+      const delivered: Record<string, number> = { spawn: 0, controller: 0, construction: 0, storage: 0 };
+      for (let i = 0; i < 80; i += 1) {
+        delivered[pickSinkByAllocation(assignments, delivered)] += 1;
+      }
+      expect(delivered.storage).to.be.greaterThan(0, "storage gets its share");
+      expect(delivered.spawn).to.be.greaterThan(0, "spawn keeps its share");
+      expect(delivered.storage / delivered.spawn).to.be.closeTo(1, 0.4);
+    });
+
     it("never routes haulers to construction (tankers feed builders)", () => {
       const assignments = [
         { toId: "construction-ssss", flowRate: 5 },

--- a/test/unit/economy/flowAdapter.test.ts
+++ b/test/unit/economy/flowAdapter.test.ts
@@ -27,6 +27,12 @@ function homeNode(spawnX: number): Node {
   return n;
 }
 
+function homeNodeWithStorage(spawnX: number): Node {
+  const n = homeNode(spawnX);
+  n.resources.push({ type: "storage", id: "storage-0", position: at(spawnX) } as NodeResource);
+  return n;
+}
+
 function graphOf(nodes: Node[]): FlowGraph {
   return new FlowGraph(nodes, new NodeNavigator(nodes, []));
 }
@@ -65,6 +71,37 @@ describe("economy/flowAdapter - CorpPlanner as the FlowSolution authority", () =
     expect(sol.haulers.filter(h => h.fromId === "source-s1").length).to.be.greaterThan(0);
     expect(sol.haulers.filter(h => h.fromId === "source-s2").length).to.be.greaterThan(0);
     expect(sol.isSustainable).to.equal(true);
+  });
+
+  it("banks the surplus in storage instead of the controller once a storage exists", () => {
+    // 3 sources = 30 e/tick. spawn takes its ~10 overhead; the controller is now
+    // capped at STORAGE_UPGRADE_TARGET (15) because the room has a storage bank, so
+    // the remaining ~5 banks in storage rather than piling at the controller.
+    const graph = graphOf([
+      homeNodeWithStorage(5),
+      sourceNode("s1", 15),
+      sourceNode("s2", 25),
+      sourceNode("s3", 35)
+    ]);
+    const sol = solveWithCorpPlanner(graph, 0, manhattan);
+
+    const ctrl = sol.sinkAllocations.find(a => a.sinkType === "controller")!;
+    const store = sol.sinkAllocations.find(a => a.sinkType === "storage")!;
+    expect(ctrl.allocated).to.be.closeTo(15, 1e-9); // capped at the upgrade target
+    expect(store.allocated).to.be.closeTo(5, 1e-9); // the surplus banks
+    // a hauler actually carries energy into the storage bank
+    expect(sol.haulers.some(h => h.toId.startsWith("storage-"))).to.equal(true);
+  });
+
+  it("leaves the controller mopping up the surplus when there is no storage", () => {
+    // Same 30 e/tick supply, no storage: the controller absorbs everything past the
+    // spawn overhead exactly as before (nothing banked). Guards the storage gate.
+    const graph = graphOf([homeNode(5), sourceNode("s1", 15), sourceNode("s2", 25), sourceNode("s3", 35)]);
+    const sol = solveWithCorpPlanner(graph, 0, manhattan);
+
+    const ctrl = sol.sinkAllocations.find(a => a.sinkType === "controller")!;
+    expect(ctrl.allocated).to.be.closeTo(20, 1e-9); // 30 supply - 10 spawn overhead
+    expect(sol.sinkAllocations.some(a => a.sinkType === "storage")).to.equal(false);
   });
 
   it("skips a source whose real distance makes it unprofitable", () => {

--- a/test/unit/framework/controllerFeederKind.test.ts
+++ b/test/unit/framework/controllerFeederKind.test.ts
@@ -1,0 +1,221 @@
+/**
+ * ControllerFeederCorp on the corp framework (proof ladder rungs 1-4,
+ * docs/specs/00-corp-framework.md). The controller analogue of the extension
+ * tender: a dedicated local mover that relays the storage bank to the controller
+ * input. Its runtime trigger (rung 3) fires only once a storage bank exists AND a
+ * flow miner is producing (infrastructure follows income).
+ */
+
+import { expect } from "chai";
+import { setupGlobals, Game, Memory } from "../mock";
+import { Position } from "../../../src/types/Position";
+import { ColonyProblem } from "../../../src/economy/CorpPlanner";
+import {
+  CorpStore,
+  deserializeStore,
+  materializeCommissions,
+  registerCorpKind,
+  resetCorpKinds,
+  runCommissionedCorps,
+  serializeStore
+} from "../../../src/economy/CorpKind";
+import { planCommissions } from "../../../src/economy/commissionPlan";
+import { ControllerFeederCorp } from "../../../src/corps/ControllerFeederCorp";
+import { controllerFeederKind } from "../../../src/corps/kinds/controllerFeederKind";
+import { describeCorpKindConformance } from "./conformance";
+
+const HOME = "W1N1";
+
+function installGlobals(): void {
+  setupGlobals();
+  (Game as { map: unknown }).map = { getRoomTerrain: () => ({ get: () => 0 }) };
+  const g = global as unknown as Record<string, unknown>;
+  g.CARRY = "carry";
+  g.MOVE = "move";
+  g.FIND_STRUCTURES = 107;
+  g.FIND_MY_STRUCTURES = 108;
+  g.FIND_MY_SPAWNS = 112;
+  g.FIND_DROPPED_RESOURCES = 106;
+  g.STRUCTURE_EXTENSION = "extension";
+  g.STRUCTURE_SPAWN = "spawn";
+  g.STRUCTURE_CONTAINER = "container";
+  g.STRUCTURE_STORAGE = "storage";
+  g.STRUCTURE_LINK = "link";
+  g.RESOURCE_ENERGY = "energy";
+}
+installGlobals();
+
+const at = (x: number, y = 0): Position => ({ x, y, roomName: HOME });
+const world: ColonyProblem = {
+  spawns: [{ id: "spawn1", pos: { x: 25, y: 25, roomName: HOME } }],
+  sources: [{ id: "src1", nodeId: "n1", pos: at(10), rate: 10, maxMiners: 1 }],
+  sinks: [{ id: "ctrl", kind: "controller", pos: at(5), value: 50, capacity: 1000 }],
+  dist: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y)
+};
+
+function resetWorld(): void {
+  installGlobals();
+  Game.creeps = {};
+  Game.rooms = {};
+  Game.time = 12345;
+  Game.getObjectById = () => null;
+  (Memory as Record<string, unknown>).creeps = {};
+}
+
+/** A room with (optionally) a storage bank and a producing flow miner. */
+function installRoom(withStorage: boolean, withMiner: boolean): void {
+  Game.creeps = {}; // fresh fleet each install so a prior miner never leaks in
+  const cheb = (a: { x: number; y: number }, b: { x: number; y: number }): number =>
+    Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+  const storage = withStorage
+    ? {
+        structureType: "storage",
+        my: true,
+        pos: { x: 26, y: 25, roomName: HOME },
+        store: { energy: 5000, getFreeCapacity: () => 995000, getUsedCapacity: () => 5000 }
+      }
+    : undefined;
+  const controllerPos = { x: 40, y: 25, roomName: HOME };
+  const controller = { my: true, level: 4, pos: controllerPos };
+  const spawnPos = {
+    x: 25,
+    y: 25,
+    roomName: HOME,
+    findInRange: () => [],
+    getRangeTo: (p: { x: number; y: number }) => cheb({ x: 25, y: 25 }, p)
+  };
+  const spawn = { id: "spawn1", pos: spawnPos } as Record<string, unknown>;
+  const room = {
+    name: HOME,
+    controller,
+    storage,
+    memory: {},
+    find: (type: number) => (type === 112 ? [spawn] : [])
+  };
+  spawn.room = room;
+  Game.rooms[HOME] = room;
+  Game.getObjectById = (id: string) => (id === "spawn1" ? spawn : null);
+  if (withMiner) {
+    Game.creeps.miner1 = {
+      name: "miner1",
+      spawning: false,
+      room: { name: HOME },
+      memory: { workType: "harvest", corpId: "mining-src1" }
+    };
+  }
+}
+
+describe("controller-feeder kind on the corp framework (rungs 2-4)", () => {
+  beforeEach(() => {
+    resetCorpKinds();
+    resetWorld();
+    registerCorpKind(controllerFeederKind as never);
+  });
+  after(() => {
+    resetCorpKinds();
+    resetWorld();
+  });
+
+  it("rung 2 - PLAN: one feeder commission per spawn room", () => {
+    const { commissions } = planCommissions(world);
+    const f = commissions.filter(c => c.kind === "controllerFeeder");
+    expect(f).to.have.length(1);
+    expect(f[0].corpId).to.equal("controllerFeeder-W1N1");
+    expect(f[0].shape).to.equal("auxiliary");
+    expect(f[0].assignment).to.deep.equal({ roomName: HOME, spawnId: "spawn1" });
+  });
+
+  it("rung 3 - BIND: materialize keeps the LEGACY moving-corp id", () => {
+    const store: CorpStore = new Map();
+    materializeCommissions(planCommissions(world).commissions, store);
+    const corp = store.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+    // Type "moving" (a local mover), so its runtime id is `moving-${nodeId}`.
+    expect(corp.id).to.equal("moving-W1N1-controllerFeeder");
+    expect(corp.getSpawnId()).to.equal("spawn1");
+  });
+
+  it("rung 3 - TRIGGER: demands a feeder only with a storage bank + a miner", () => {
+    const store: CorpStore = new Map();
+    materializeCommissions(planCommissions(world).commissions, store);
+    const corp = store.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+    const ctx = { energyCapacity: 1300 } as never;
+
+    installRoom(false, true); // miner producing but NO storage yet
+    expect(corp.getSpawnDemand(ctx), "no bank -> haulers feed the controller directly").to.have.length(0);
+
+    installRoom(true, false); // storage but NO miner yet
+    expect(corp.getSpawnDemand(ctx), "infrastructure waits for income").to.have.length(0);
+
+    installRoom(true, true); // storage + miner
+    const demands = corp.getSpawnDemand(ctx);
+    expect(demands).to.have.length(1);
+    expect(demands[0].role).to.equal("feeder");
+    expect(demands[0].blocking).to.equal(false); // never holds the spawn ahead of producers
+    expect(demands[0].producesIncome).to.equal(false);
+  });
+
+  it("rung 3 - EXECUTE/PERSIST: run() is safe; store round-trips to a fixpoint", () => {
+    installRoom(true, true);
+    const store: CorpStore = new Map();
+    materializeCommissions(planCommissions(world).commissions, store);
+    expect(() => runCommissionedCorps(store, Game.time)).to.not.throw();
+
+    const corp = store.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+    corp.recordProduction(7);
+    const restored = deserializeStore(JSON.parse(JSON.stringify(serializeStore(store))));
+    const back = restored.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+    expect(back.id).to.equal(corp.id);
+    expect(back.getSpawnId()).to.equal("spawn1");
+  });
+
+  it("run() with a storage + feeder present sets the controllerFeederActive flag", () => {
+    installRoom(true, true);
+    const room = Game.rooms[HOME] as { memory: { controllerFeederActive?: boolean } };
+    const store: CorpStore = new Map();
+    materializeCommissions(planCommissions(world).commissions, store);
+    const corp = store.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+    // No feeder creep in the field yet -> the flag must stay false (a dead feeder
+    // must never leave haulers stranded at the bank; they feed the controller).
+    corp.work(Game.time);
+    expect(room.memory.controllerFeederActive).to.equal(false);
+
+    // A living feeder -> the flag flips on so CarryCorp defers to the last leg.
+    Game.creeps.feed1 = {
+      name: "feed1",
+      spawning: false,
+      room: { name: HOME },
+      pos: { getRangeTo: () => 1, isNearTo: () => true, isEqualTo: () => false },
+      store: { energy: 0, getFreeCapacity: () => 100, getUsedCapacity: () => 0 },
+      withdraw: () => 0,
+      transfer: () => 0,
+      drop: () => 0,
+      memory: { corpId: corp.id, workType: "feed", working: false }
+    } as never;
+    corp.work(Game.time);
+    expect(room.memory.controllerFeederActive).to.equal(true);
+  });
+
+  it("rung 4 - COMPOSE: coexists with the extension tender over the same world", async () => {
+    const { extensionTenderKind } = await import("../../../src/corps/kinds/extensionTenderKind");
+    registerCorpKind(extensionTenderKind as never);
+    const { commissions } = planCommissions(world);
+    const aux = commissions.filter(c => c.shape === "auxiliary").map(c => c.corpId);
+    expect(aux.sort()).to.deep.equal(["controllerFeeder-W1N1", "tender-W1N1"]);
+  });
+});
+
+describe("controller-feeder kind rung 1", () => {
+  beforeEach(resetWorld);
+  describeCorpKindConformance(controllerFeederKind as never, {
+    problem: world,
+    commission: {
+      corpId: "controllerFeeder-W1N1",
+      kind: "controllerFeeder",
+      shape: "auxiliary",
+      consumes: { spawnPartsPerTick: 0 },
+      produces: { valuePerTick: 0 },
+      assignment: { roomName: HOME, spawnId: "spawn1" }
+    },
+    expectedSpawnPartsPerTick: 0
+  });
+});


### PR DESCRIPTION
Once a room has a storage, route the surplus into the bank rather than
letting the controller mop up the whole remainder.

Root cause: the planner gave the controller sink capacity = totalSupply
(value ~50-80), so it absorbed every spare unit at the "RCL drop-off" and
the storage sink (value 1) never received planned flow. What little reached
storage came only via CarryCorp's spawn-circuit banking, which spills to the
controller past STORAGE_BANK (10k) - below the expansion CAPEX - so the bank
could never accumulate enough to fund expansion.

Planner (flowAdapter): once a room has a storage, cap the controller's
routing capacity at STORAGE_UPGRADE_TARGET (15 e/tick, tunable) so the
surplus flows to the storage sink. Below that rate the controller still mops
up all income, so lean single/2-source rooms and every pre-storage room are
unchanged.

Runtime (CarryCorp): add a first-class `storage` delivery circuit
(deliverToStorage) so storage-routed haulers drive to the bank and keep
filling it, with no 10k spill ceiling. The extension tender already
distributes locally from the depot (storage) to spawn/extensions, and the
spawn-critical override still tops a hungry spawn first.

Tests: planner banks the surplus (controller 15, storage 5) with a storage
present and is unchanged without one; CarryCorp routes storage-* flow to its
own bank circuit. Full unit suite green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0192FS9YkejbF8Q5Wz3Dju3r