### PR TITLE
Order controller parking tiles by proximity to fix upgrader placement

### DIFF
--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -291,10 +291,20 @@ export function controllerInputSpot(controller: StructureController): EnergySpot
  * Walkable upgrader PARKING tiles RINGING the input spot: tiles within range 1 of
  * the input (so an upgrader withdraws without moving) AND within upgrade range (3)
  * of the controller (so it upgrades from there), excluding the controller's own
- * tile AND the input tile itself. Sorted deterministically so each upgrader keeps a
- * stable slot across ticks. This is the "analyse the controller-adjacent layout"
- * strategy: the parked upgraders ring the one shared pile/container and never move
- * or block each other.
+ * tile AND the input tile itself. Ordered CLOSEST-TO-THE-CONTROLLER first (ties
+ * broken by (x,y) for a stable, deterministic slot each upgrader keeps across
+ * ticks). This is the "analyse the controller-adjacent layout" strategy: the
+ * parked upgraders ring the one shared pile/container and never move or block each
+ * other.
+ *
+ * Proximity ordering matters when the input spot sits ~2 tiles off the controller
+ * (a bare drop tile is placed to maximise parking capacity, so it lands on the
+ * open side, up to range 2 away). Its ring then spans range 1..3 of the
+ * controller. Filling from the FAR corner (a plain (x,y) sort did) left a lone
+ * RCL2 upgrader parked 3 tiles out on the open side while a range-1 tile sat free
+ * next to the controller - the "upgrader doesn't move close enough" symptom.
+ * Closest-first fills the tiles hugging the controller before the outer ring, so
+ * upgraders sit as near the controller as the shared input allows.
  *
  * The input tile is deliberately EXCLUDED: it is the dedicated drop/withdraw point
  * that the hauler must reach to deposit. An upgrader squatting it would wall the
@@ -319,7 +329,8 @@ export function controllerParkingTiles(controller: StructureController, input: R
       tiles.push(new RoomPosition(x, y, room.name));
     }
   }
-  tiles.sort((a, b) => a.x - b.x || a.y - b.y);
+  const distToController = (p: RoomPosition): number => Math.max(Math.abs(p.x - cx), Math.abs(p.y - cy));
+  tiles.sort((a, b) => distToController(a) - distToController(b) || a.x - b.x || a.y - b.y);
   return tiles;
 }
 

--- a/test/unit/corps/controllerInputSpot.test.ts
+++ b/test/unit/corps/controllerInputSpot.test.ts
@@ -99,4 +99,20 @@ describe("controllerInputSpot / controllerParkingTiles", () => {
     const tiles = controllerParkingTiles(c, controllerInputSpot(c).pos);
     for (const t of tiles) expect(["24,11", "24,12", "24,13"]).to.not.include(`${t.x},${t.y}`);
   });
+
+  it("orders the parking ring CLOSEST to the controller first (upgraders hug it)", () => {
+    // A bare drop tile is placed ~2 off the controller (open side, to maximise
+    // parking capacity), so its ring spans range 1..3 of the controller. The FIRST
+    // upgrader must take a range-1 tile next to the controller, not a far-corner
+    // range-3 tile - the "upgrader doesn't move close enough" regression.
+    const c = controllerWith({ cx: 25, cy: 10 });
+    const input = controllerInputSpot(c).pos;
+    const tiles = controllerParkingTiles(c, input);
+    expect(tiles.length).to.be.greaterThan(0);
+    const dist = (t: { x: number; y: number }) => cheb(t, { x: 25, y: 10 });
+    // Distances are non-decreasing: the ring fills from the controller outward.
+    for (let i = 1; i < tiles.length; i++) expect(dist(tiles[i])).to.be.at.least(dist(tiles[i - 1]));
+    // The slot the first (RCL2: only) upgrader takes is a minimal-distance tile.
+    expect(dist(tiles[0])).to.equal(Math.min(...tiles.map(dist)));
+  });
 });


### PR DESCRIPTION
## Summary
Fixed a regression where upgraders would park at distant tiles instead of hugging the controller when the input spot is positioned ~2 tiles away. The parking tile selection now prioritizes proximity to the controller.

## Key Changes
- **Sorting algorithm**: Changed `controllerParkingTiles()` to sort parking tiles by Chebyshev distance to the controller first, then by (x, y) coordinates as a tiebreaker, instead of sorting purely by (x, y)
- **Documentation**: Expanded the function's docstring to explain why proximity ordering matters and the specific regression it prevents
- **Test coverage**: Added a test case verifying that parking tiles are ordered closest-to-controller first and that the first upgrader takes a minimal-distance tile

## Implementation Details
The fix uses Chebyshev distance (`Math.max(Math.abs(p.x - cx), Math.abs(p.y - cy))`) to measure proximity, which matches the game's range-3 upgrade mechanic. When a bare drop tile is placed on the open side of a controller to maximize parking capacity, the resulting parking ring spans range 1–3. Without proximity ordering, the naive (x, y) sort would fill the far corner first, leaving closer tiles empty and causing upgraders to park too far away. The new closest-first approach ensures upgraders occupy the tiles nearest the controller before filling the outer ring.

https://claude.ai/code/session_011cikW1JLdQRRMf5xLFVyx3