### PR TITLE
Latch maintenance builders to one target until ceiling

### DIFF
--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -14,13 +14,7 @@ import { plan as governorPlan } from "../execution/CpuGovernor";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { Squad, SquadPlan, splitIntoMembers } from "./Squad";
 import { buildTankerBody, buildUpgraderBody } from "../spawn/BodyBuilder";
-import {
-  pickRepairTarget,
-  pickCriticalRepairTarget,
-  wantsCriticalRecovery,
-  wantsMaintenanceBuilder,
-  REPAIR_TO
-} from "./repair";
+import { pickCriticalRepairTarget, wantsCriticalRecovery, wantsMaintenanceBuilder, nextRepairTarget } from "./repair";
 import { MAX_BUILDERS } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
@@ -1177,11 +1171,6 @@ export class ConstructionCorp extends Corp {
     }) as (StructureContainer | StructureRoad)[];
   }
 
-  /** The structure most in need of repair (below the ceiling, by fraction), or null. */
-  private findRepairTarget(room: Room): StructureContainer | StructureRoad | null {
-    return pickRepairTarget(this.roomRepairables(room), REPAIR_TO);
-  }
-
   /** Whether to field/keep a maintenance builder for decaying structures (hysteresis). */
   private wantsMaintenance(room: Room): boolean {
     return wantsMaintenanceBuilder(this.roomRepairables(room), this.builders.count() > 0);
@@ -1205,13 +1194,20 @@ export class ConstructionCorp extends Corp {
    * Maintain decaying structures when there is nothing to build. Containers fuel
    * the builder themselves (they hold energy), so maintenance needs no tanker;
    * roads hold nothing, so a road target sends the builder to the nearest energy
-   * instead. It tops up the most-decayed structure, then the next, until all reach
-   * the ceiling - at which point findRepairTarget returns null and the builder
-   * idles to be recycled.
+   * instead. It fully repairs one structure (latched, most-decayed first) to the
+   * ceiling before starting the next, until all reach the ceiling - at which point
+   * nextRepairTarget returns null and the builder idles to be recycled.
    */
   private doMaintenance(creep: Creep, room: Room): void {
-    const target = this.findRepairTarget(room);
-    if (!target) return; // all healthy: idle until plan() retires this builder
+    // Latch onto one structure and repair it to the ceiling before switching, so
+    // the builder finishes a structure instead of ping-ponging to whichever is
+    // momentarily most decayed (see nextRepairTarget).
+    const target = nextRepairTarget(this.roomRepairables(room), creep.memory.repairTargetId);
+    if (!target) {
+      delete creep.memory.repairTargetId; // all healthy: idle until plan() retires this builder
+      return;
+    }
+    creep.memory.repairTargetId = target.id;
 
     if (creep.store[RESOURCE_ENERGY] === 0) {
       this.refuelForMaintenance(creep, target);

--- a/src/corps/repair.ts
+++ b/src/corps/repair.ts
@@ -72,6 +72,34 @@ interface Repairable {
 }
 
 /**
+ * The structure a maintenance builder should repair THIS tick. It latches to its
+ * current target and finishes it (repairs to the REPAIR_TO ceiling) before moving
+ * on, instead of re-picking the lowest-fraction structure every tick.
+ *
+ * Without the latch the builder retargets each tick to whichever structure has the
+ * lowest hits fraction. As it repairs the most-decayed one past a rival's fraction,
+ * the rival becomes "most decayed" and the builder walks off to it - then back -
+ * ping-ponging between the two and topping up neither (the "repairs something once
+ * then moves on" annoyance). Holding the target until it is back at the ceiling
+ * makes the builder fully repair one structure before starting the next; the
+ * most-decayed structure is still the one it starts on, so nothing endangered
+ * waits longer.
+ *
+ * Returns the latched target while it is still below the ceiling, otherwise the
+ * next most-decayed structure (or null when everything is at the ceiling).
+ */
+export function nextRepairTarget<T extends Repairable & { id: string }>(
+  structures: T[],
+  latchedId: string | undefined
+): T | null {
+  if (latchedId) {
+    const latched = structures.find(s => s.id === latchedId);
+    if (latched && latched.hits < latched.hitsMax * REPAIR_TO) return latched;
+  }
+  return pickRepairTarget(structures, REPAIR_TO);
+}
+
+/**
  * The most-decayed structure below `belowFraction` of its max hits, or null if all
  * are healthier than that. "Most decayed" is the lowest hits/hitsMax fraction, so
  * structures of different scales (roads vs containers) rank fairly.

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -387,6 +387,14 @@ declare global {
     repairingCritical?: boolean;
 
     /**
+     * The structure a maintenance builder is currently repairing. It latches to
+     * one target and finishes it (repairs to the ceiling) before switching, so
+     * the builder doesn't ping-pong between two similarly-decayed structures,
+     * topping up neither. Cleared when the target reaches the ceiling or is gone.
+     */
+    repairTargetId?: string;
+
+    /**
      * ID of the SpawningCorp that spawned this creep.
      */
     spawnedBy?: string;

--- a/test/unit/corps/repair.test.ts
+++ b/test/unit/corps/repair.test.ts
@@ -4,12 +4,14 @@ import {
   pickCriticalRepairTarget,
   wantsCriticalRecovery,
   wantsMaintenanceBuilder,
+  nextRepairTarget,
   REPAIR_TO,
   REPAIR_SPAWN_BELOW,
   REPAIR_CRITICAL,
 } from "../../../src/corps/repair";
 
 const c = (hits: number, hitsMax = 250000) => ({ hits, hitsMax });
+const cid = (id: string, hits: number, hitsMax = 250000) => ({ id, hits, hitsMax });
 
 describe("corps/repair", () => {
   describe("pickRepairTarget", () => {
@@ -74,6 +76,101 @@ describe("corps/repair", () => {
       const road = { hits: 1000, hitsMax: 5000 }; // 20% - critical
       const container = c(100000); // 40% - not critical
       expect(pickCriticalRepairTarget([container, road])).to.equal(road);
+    });
+  });
+
+  describe("nextRepairTarget (finish-one-before-the-next latch)", () => {
+    it("with no latch, picks the most-decayed structure", () => {
+      const worst = cid("a", 100000);
+      expect(nextRepairTarget([cid("b", 200000), worst], undefined)).to.equal(worst);
+    });
+    it("stays on the latched target even after it stops being the most decayed", () => {
+      // 'a' started worst (50%), and we've repaired it up to 60% - now 'b' (55%)
+      // is the lowest fraction, but the latch keeps the builder finishing 'a'.
+      const latched = cid("a", Math.floor(250000 * 0.6));
+      const rival = cid("b", Math.floor(250000 * 0.55));
+      expect(nextRepairTarget([rival, latched], "a")).to.equal(latched);
+    });
+    it("releases the latch and moves on once the target reaches the ceiling", () => {
+      const done = cid("a", 250000); // fully repaired
+      const next = cid("b", Math.floor(250000 * 0.55));
+      expect(nextRepairTarget([next, done], "a")).to.equal(next);
+    });
+    it("re-picks the most decayed when the latched structure is gone (decayed away)", () => {
+      const next = cid("b", 100000);
+      expect(nextRepairTarget([next, cid("c", 240000)], "missing")).to.equal(next);
+    });
+    it("returns null once everything is at the ceiling", () => {
+      expect(nextRepairTarget([cid("a", 250000), cid("b", 250000)], "a")).to.equal(null);
+    });
+  });
+
+  describe("repair efficiency (WORK spent repairing, not commuting)", () => {
+    // A builder that re-picks the lowest-fraction target EVERY tick ping-pongs
+    // between two similarly-decayed structures: it repairs the worst a little,
+    // that lifts it past its rival, so the rival becomes worst and the builder
+    // walks off to it - abandoning a structure still below the ceiling and
+    // burning ticks (and its WORK parts) on the commute. This drives a tiny
+    // deterministic sim through nextRepairTarget and measures the waste, so a
+    // regression back to per-tick re-picking trips these assertions.
+    interface SimStruct {
+      id: string;
+      hits: number;
+      hitsMax: number;
+      pos: number; // 1-D position; the builder walks one tile/tick between them
+    }
+    const REPAIR_POWER = 5000; // large so the sim is short; the latch is scale-free
+
+    function simulate(structs: SimStruct[], start: number, maxTicks = 1000) {
+      let pos = start;
+      let latched: string | undefined;
+      let prevId: string | undefined;
+      let repairTicks = 0;
+      let moveTicks = 0;
+      let abandonments = 0;
+      for (let t = 0; t < maxTicks; t++) {
+        const target = nextRepairTarget(structs, latched);
+        if (!target) break; // everything at the ceiling
+        // Abandonment: we switched targets while the previous one was still below
+        // the ceiling - the exact waste the latch exists to prevent.
+        const prev = prevId ? structs.find(s => s.id === prevId) : undefined;
+        if (prev && prev.id !== target.id && prev.hits < prev.hitsMax * REPAIR_TO) {
+          abandonments++;
+        }
+        prevId = target.id;
+        latched = target.id;
+        if (pos === target.pos) {
+          target.hits = Math.min(target.hitsMax, target.hits + REPAIR_POWER);
+          repairTicks++;
+        } else {
+          pos += Math.sign(target.pos - pos);
+          moveTicks++;
+        }
+      }
+      return { repairTicks, moveTicks, abandonments, utilization: repairTicks / (repairTicks + moveTicks) };
+    }
+
+    it("never abandons a below-ceiling structure to go work on another", () => {
+      const structs: SimStruct[] = [
+        { id: "a", hits: 125000, hitsMax: 250000, pos: 0 }, // 50%
+        { id: "b", hits: 137500, hitsMax: 250000, pos: 12 } // 55%, far away
+      ];
+      expect(simulate(structs, 0).abandonments).to.equal(0);
+    });
+
+    it("spends its WORK parts repairing, not commuting (one traversal, not a ping-pong)", () => {
+      const structs: SimStruct[] = [
+        { id: "a", hits: 125000, hitsMax: 250000, pos: 0 },
+        { id: "b", hits: 137500, hitsMax: 250000, pos: 12 }
+      ];
+      const { moveTicks, utilization } = simulate(structs, 0);
+      // Finishing 'a' before starting 'b' costs exactly ONE 12-tile walk. A
+      // per-tick re-pick would cross that gap dozens of times.
+      expect(moveTicks).to.be.at.most(12);
+      // Effective WORK: the fraction of ticks the builder's WORK parts actually
+      // repair rather than commute. Ping-ponging drags this toward zero; finishing
+      // one structure at a time keeps the parts effective.
+      expect(utilization).to.be.greaterThan(0.75);
     });
   });
 


### PR DESCRIPTION
## Summary
Maintenance builders now latch onto a single repair target and finish it (repair to the ceiling) before moving to the next structure, instead of re-picking the most-decayed structure every tick. This eliminates wasteful ping-ponging between similarly-decayed structures and improves WORK part utilization.

## Key Changes
- **New `nextRepairTarget()` function** in `src/corps/repair.ts`: implements the latch logic. Returns the latched target while below ceiling, otherwise picks the next most-decayed structure. Includes comprehensive documentation of the ping-pong problem and the latch solution.
- **Updated `doMaintenance()` in `src/corps/ConstructionCorp.ts`**: now uses `nextRepairTarget()` with a latch ID stored in creep memory, replacing the previous per-tick re-pick via `findRepairTarget()`. Removed the now-unused `findRepairTarget()` method.
- **New creep memory field** `repairTargetId` in `src/types/Memory.ts`: tracks the latched repair target ID across ticks; cleared when the target reaches ceiling or is gone.
- **Comprehensive test suite** in `test/unit/corps/repair.test.ts`: 
  - 5 unit tests for `nextRepairTarget()` covering latch behavior, ceiling release, missing targets, and full-health cases
  - 2 integration tests with a deterministic 1-D simulator measuring repair efficiency: verify zero abandonments and >75% utilization (vs. ping-ponging that would drag utilization toward zero)

## Implementation Details
The latch is scale-free: a builder finishes one structure before starting the next regardless of distance or decay rate. The simulator tests confirm the fix prevents the exact waste the latch exists to prevent—switching targets while the previous one is still below ceiling—and validates that a single traversal between structures (not dozens of ping-pongs) occurs.

https://claude.ai/code/session_01KsLeRotSVQRruTnc6Y2T8j