### PR TITLE
Fix RCL drop-off jam by banking loads across feeder gaps

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -56,6 +56,47 @@ const SPAWN_PRIORITY_FREE_CAPACITY = 50;
 const SPAWN_DIVERT_FILL = 0.5;
 
 /**
+ * Energy staged at the controller input below which a controller-bound hauler
+ * feeds the controller DIRECTLY instead of banking in storage. While the input
+ * holds at least this much buffer, the feeder (or the residual buffer itself)
+ * keeps the upgraders fed, so haulers bank; only when the buffer runs low is the
+ * controller genuinely at risk and a hauler steps in with a direct delivery.
+ * Sized as a working buffer, not a full container - well under the feeder's
+ * CONTROLLER_FEED_TARGET so normal feeder operation never trips it.
+ */
+export const CONTROLLER_STARVE_FLOOR = 200;
+
+/**
+ * Should a controller-bound hauler BANK its load in storage rather than haul it
+ * to the controller drop-off tile? Yes whenever a storage bank has room AND
+ * either a feeder is actively relaying the bank to the controller OR the
+ * controller input still holds a working buffer.
+ *
+ * This is the fix for the recurring RCL-drop-off jam: the redirect used to be
+ * gated SOLELY on `controllerFeederActive`, so the instant the single, non-blocking
+ * feeder died (or before it first spawned) every controller-bound hauler in the
+ * fleet reverted to the ONE drop tile at once - the measured pile-up. Keying the
+ * redirect off the input buffer instead means a transient feeder gap no longer
+ * stampedes the fleet onto the tile: haulers keep banking while the buffer lasts
+ * (giving the feeder time to respawn), and only step in directly if the buffer
+ * actually runs down with no feeder servicing it (genuine starvation - the
+ * anti-downgrade fallback). Pure so the routing rule is unit-testable.
+ */
+export function shouldBankControllerLoad(params: {
+  /** A storage exists, is ours, and has free capacity for the load. */
+  hasBankCapacity: boolean;
+  /** A live feeder is relaying storage -> controller this tick. */
+  feederActive: boolean;
+  /** Energy staged at the controller input right now (container/link + piles). */
+  controllerInputStock: number;
+  /** Override the starvation floor (defaults to {@link CONTROLLER_STARVE_FLOOR}). */
+  starveFloor?: number;
+}): boolean {
+  if (!params.hasBankCapacity) return false; // no bank -> the controller must be fed directly
+  return params.feederActive || params.controllerInputStock >= (params.starveFloor ?? CONTROLLER_STARVE_FLOOR);
+}
+
+/**
  * Small energy buffer kept in the core depot so the extension tender always has a
  * load on hand. Deliberately modest: it only needs to bridge between hauler drop-offs,
  * not bankroll the whole network - a large buffer would pull haulers off the
@@ -872,6 +913,21 @@ export class CarryCorp extends Corp {
   }
 
   /**
+   * Energy staged at the controller input right now: its container/link buffer,
+   * else the bare drop pile on the input tile. The gauge {@link shouldBankControllerLoad}
+   * reads to tell a healthy (feeder-maintained) buffer from genuine starvation.
+   */
+  private controllerInputStock(controller: StructureController): number {
+    const spot = controllerDeliverySpot(controller);
+    if (spot.structure) return spot.structure.store[RESOURCE_ENERGY] ?? 0;
+    let stock = 0;
+    for (const r of spot.pos.findInRange(FIND_DROPPED_RESOURCES, 1)) {
+      if (r.resourceType === RESOURCE_ENERGY) stock += r.amount;
+    }
+    return stock;
+  }
+
+  /**
    * Deliver to the controller's consumers: an upgrader container, then the
    * upgrader/builder creeps directly, then dropping adjacent to the controller.
    * Returns false when the room has no controller.
@@ -880,18 +936,26 @@ export class CarryCorp extends Corp {
     const controller = room.controller;
     if (!controller) return false;
 
-    // STORAGE-FIRST HUB: once a dedicated controller feeder is relaying the bank
-    // to the controller, the long-range haulers stop at the storage and the feeder
+    // STORAGE-FIRST HUB: the long-range haulers stop at the storage and the feeder
     // runs the short last leg (owner 2026-07-11: "storage is primary, dedicated
-    // feeder for controller"). Deposit into the bank instead of hauling all the way
-    // to the controller. Fall THROUGH to direct delivery only when the bank is
-    // missing or physically full, so energy is never stranded and a dead feeder
-    // (flag cleared) reverts to direct hauling.
-    if (room.memory.controllerFeederActive) {
-      const bank = room.storage;
-      if (bank && bank.my && bank.store.getFreeCapacity(RESOURCE_ENERGY) > 0) {
-        return this.deliverToStorage(creep, room);
-      }
+    // feeder for controller"). Bank the load instead of hauling all the way to the
+    // controller - but key the redirect off the controller INPUT BUFFER, not just a
+    // live feeder: gating solely on the feeder meant that the instant the single,
+    // non-blocking feeder died the whole controller-bound fleet reverted to the one
+    // drop tile at once (the measured RCL-drop-off jam). See shouldBankControllerLoad:
+    // haulers keep banking across a transient feeder gap while the buffer lasts, and
+    // only feed the controller directly when it actually runs low (starvation) or the
+    // bank is missing/full - so energy is never stranded.
+    const bank = room.storage;
+    const hasBankCapacity = !!(bank && bank.my && bank.store.getFreeCapacity(RESOURCE_ENERGY) > 0);
+    if (
+      shouldBankControllerLoad({
+        hasBankCapacity,
+        feederActive: !!room.memory.controllerFeederActive,
+        controllerInputStock: this.controllerInputStock(controller)
+      })
+    ) {
+      return this.deliverToStorage(creep, room);
     }
 
     // The controller node resolves its own input spot (upgrader container, else the

--- a/test/unit/corps/CarryCorp.behavior.test.ts
+++ b/test/unit/corps/CarryCorp.behavior.test.ts
@@ -1,6 +1,13 @@
 import { expect } from "chai";
 import "../../../src/types/Memory"; // load the CreepMemory/Memory type augmentation
-import { CarryCorp, pickSinkByAllocation, pickRuntToRecycle, pickDeliverySink } from "../../../src/corps/CarryCorp";
+import {
+  CarryCorp,
+  pickSinkByAllocation,
+  pickRuntToRecycle,
+  pickDeliverySink,
+  shouldBankControllerLoad,
+  CONTROLLER_STARVE_FLOOR
+} from "../../../src/corps/CarryCorp";
 import { HaulerAssignment } from "../../../src/flow/FlowTypes";
 import { Game as MockGame } from "../mock";
 
@@ -295,6 +302,41 @@ describe("CarryCorp behaviour (trivial scenarios)", () => {
 
     it("does nothing when there is no carry demand", () => {
       expect(pickRuntToRecycle([3], 0, 5)).to.equal(null);
+    });
+  });
+
+  // The recurring RCL-drop-off jam: controller-bound haulers must BANK in storage
+  // across a transient feeder gap instead of all stampeding the one drop tile.
+  describe("controller-bound loads bank in storage across feeder gaps", () => {
+    it("banks while the feeder is actively relaying, whatever the input stock", () => {
+      expect(
+        shouldBankControllerLoad({ hasBankCapacity: true, feederActive: true, controllerInputStock: 0 })
+      ).to.equal(true);
+    });
+
+    it("STILL banks when the feeder is momentarily gone but the input holds a buffer", () => {
+      // The core regression: the old code (gated solely on controllerFeederActive)
+      // sent this load to the drop tile the instant the feeder died. With a healthy
+      // buffer the upgraders are fine, so the hauler banks and never joins the pile.
+      expect(
+        shouldBankControllerLoad({
+          hasBankCapacity: true,
+          feederActive: false,
+          controllerInputStock: CONTROLLER_STARVE_FLOOR + 1
+        })
+      ).to.equal(true);
+    });
+
+    it("feeds the controller DIRECTLY only when the input is starving AND no feeder", () => {
+      expect(
+        shouldBankControllerLoad({ hasBankCapacity: true, feederActive: false, controllerInputStock: 0 })
+      ).to.equal(false);
+    });
+
+    it("feeds the controller directly when there is no bank capacity, feeder or not", () => {
+      expect(
+        shouldBankControllerLoad({ hasBankCapacity: false, feederActive: true, controllerInputStock: 5000 })
+      ).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the recurring RCL-drop-off jam where controller-bound haulers would all stampede onto a single drop tile the instant the controller feeder died. The root cause was gating the storage-bank redirect solely on `controllerFeederActive`; now it also checks the controller input buffer level, allowing haulers to keep banking across transient feeder gaps while a working buffer exists.

## Key Changes

- **New constant `CONTROLLER_STARVE_FLOOR`**: 200 energy — the minimum working buffer at the controller input below which haulers feed directly instead of banking. Sized as a working buffer, not a full container, so normal feeder operation never trips it.

- **New pure function `shouldBankControllerLoad()`**: Unit-testable routing rule that returns true (bank in storage) when:
  - Storage has free capacity AND
  - Either a feeder is actively relaying OR the controller input stock ≥ `CONTROLLER_STARVE_FLOOR`
  
  Returns false (feed controller directly) only when the bank is full/missing OR the input is starving with no feeder.

- **New private method `controllerInputStock()`**: Gauges energy staged at the controller input (container/link + dropped piles), used by the routing decision.

- **Updated `deliverToController()` logic**: Replaced the simple `controllerFeederActive` gate with a call to `shouldBankControllerLoad()`, passing the bank capacity, feeder status, and measured input stock. This decouples the redirect from feeder liveness alone.

- **Comprehensive unit tests**: Four test cases covering the core regression (banking across feeder gaps), starvation fallback, and edge cases (no bank capacity).

## Implementation Details

The fix preserves the "storage-first hub" design (long-range haulers stop at storage, feeder runs the short last leg) while making it resilient to transient feeder deaths. Haulers now read the actual controller input buffer instead of trusting a single feeder flag, so a momentary feeder gap doesn't trigger a fleet-wide redirect to the one drop tile. The `CONTROLLER_STARVE_FLOOR` threshold ensures upgraders stay fed during normal operation while still triggering direct delivery if the buffer actually runs down (genuine starvation or feeder failure).

https://claude.ai/code/session_01HfC6biqN9gjXJARE4NCYun