### PR TITLE
Phase 1: Invader-core reservation defund protocol

### DIFF
--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -25,7 +25,7 @@ consume (30) → auxiliary (40).
 | ConstructionCorp | `construction` | hybrid | proposes per owned room (container maintenance) + reads solver build commissions |
 | ExtensionTenderCorp | `extensionTender` | auxiliary | depot→spawn/extensions local mover; SLA fleet = max(clusters, coverage) |
 | ControllerFeederCorp | `controllerFeeder` | auxiliary | storage→controller-input relay once a bank exists |
-| ScoutCorp | `scout` | auxiliary | BFS intel, hostile stamps (`roomIntel.hostileUntil`) |
+| ScoutCorp | `scout` | auxiliary | BFS intel, hostile stamps (`roomIntel.hostileUntil` / `.invaderReservedUntil`) |
 | ReservationCorp | `reservation` | auxiliary | remote reservers (value 115, holdToFund) |
 | ClaimCorp | `claim` | auxiliary | capital-gated expansion claiming (spec 06) |
 | SpawningCorp | — | infrastructure | spawn queue execution; still registry-hosted |

--- a/docs/specs/12-invader-protocols.md
+++ b/docs/specs/12-invader-protocols.md
@@ -1,0 +1,113 @@
+# 12 — Invader protocols: flight, and eventually fight
+
+**Status:** Phase 1 (flight on invader-core reservation) **LANDED 2026-07-16**.
+Phase 2 (fight: kill the core, take the room back) is specced below and
+DEFERRED — same owner doctrine as spec 07 ("we spread like a disease; losing
+a room is fine"), and the same shape: specced now so it's a small task
+whenever the doctrine changes.
+**Priority:** phase 2 is P3 / backlog.
+
+## The problem
+
+Invader cores deploy into remote rooms and RESERVE the controller (live
+sighting: "Reserved: Invader (4998)"). The core is a **structure**, not a
+creep, so the v1 defense economics — `hostileRooms()` marking rooms from
+sighted hostile *creeps* — never triggers. The colony keeps funding the room:
+miners walk in (the source is contested and our reserver can't take the
+controller back, so income is throttled at best), reservers bounce off the
+reserved controller, and bodies are bought for a room we cannot hold. Up to
+~5000 ticks of waste per occupation.
+
+## Phase 1 — flight: defund invader-reserved rooms (LANDED)
+
+The reservation itself is the observable. One new mark on `RoomIntel`, same
+lifecycle as `hostileUntil`:
+
+- **Stamp** — `hostileRooms()`'s vision pass reads
+  `controller.reservation.username === "Invader"` (`INVADER_USERNAME`,
+  `utils/RoomDiscovery.ts`) and stamps
+  `invaderReservedUntil = Game.time + reservation.ticksToEnd`.
+- **Bound** — the mark persists WITHOUT vision until that tick, then lapses
+  (funding resumes on its own if we never look again). A live core renews its
+  reservation, so every fresh sighting refreshes the bound.
+- **All-clear** — a fresh sighting with the reservation gone lifts the mark
+  early, exactly like the hostile-creep mark.
+- **Effect** — `hostileRooms()` returns the union of both marks, so every
+  existing consumer defunds for free: HarvestCorp (no miners), CarryCorp (no
+  haulers for routes picking up there), ReservationCorp (no reservers),
+  constructionKind (no remote construction), expansion (not a claim
+  candidate). No consumer changed.
+
+### Acceptance tests (all landed green)
+
+- **Unit** `test/unit/utils/roomDiscovery.test.ts`: stamp + bound; no mark
+  for our own/another player's reservation; blind persistence until the
+  bound; early all-clear lift; controller-less rooms; both marks coexisting
+  in one room (creeps die → creep mark lifts, reservation mark holds).
+- **Grid** `def-t5-invader-reservation-defunds-remote` (tier 5, defense):
+  two-room world, east remote's controller reserved by user "2" for 5000
+  ticks, staged remote harvester for standing vision. The planner still
+  OPENS the remote mine (non-vacuity: the defund, not the planner, holds the
+  line — measured red at tick 224 on pre-change code), intel stamps the mark
+  at tick 1, and no miner/hauler/reserver is ever funded for the room across
+  the 300-tick window.
+- **Regression gate**: unit suite + `flow-handoff`, `runt-economy`,
+  `storage-depot` + `def-t3-invader-defunds-source` (the creep flavor still
+  passes on the shared lens).
+
+## Phase 2 — fight: kill the core, take the room back (SPECCED, DEFERRED)
+
+Economics first: a level-0 expansion core has 100k hits and no attack. A
+~10×ATTACK melee creep (~1300 energy incl. MOVE) kills it in ~330 ticks of
+contact. Payback: a reserved remote source is ~10 e/tick versus ~5
+unreserved, and an occupation left alone wastes up to 5000 ticks of that
+margin — the buster pays for itself if the room's remaining occupation
+exceeds ~500 ticks (read `invaderReservedUntil` for exactly this number).
+That is the commissioning gate, not a constant.
+
+Design (as a CorpKind through the spec-00 framework):
+
+1. **CoreBusterCorp** (`corps/kinds/coreBusterKind.ts`) — self-proposing
+   auxiliary, pattern of `reservationKind`. Propose ONE commission per room
+   that is (a) remote-mined by the current plan, (b) marked
+   `invaderReservedUntil` with ≥ ~1000 ticks remaining (payback gate), and
+   (c) within `MAX_SCOUT_DISTANCE` of the home spawn.
+2. **Behavior** — spawn one attacker (`buildAttackerBody`, new in
+   `BodyBuilder`), walk to the target room (`travelTo`), attack the invader
+   core (`FIND_HOSTILE_STRUCTURES`, `structureType === STRUCTURE_INVADER_CORE`);
+   handle the deploy-invulnerability effect by waiting adjacent. When the
+   core dies the reservation decays on its own; the existing ReservationCorp
+   re-takes the controller once `reservation` clears (its targetRooms filter
+   already handles this — no change).
+3. **Wiring traps** (each has burned a session — CLAUDE.md): add the kind to
+   CommissionHost `KINDS`, OrphanRescue `liveCorpIds`, SpawnDirector
+   `collectDemands`; `materialize` must refresh `spawnId`; run the
+   kind-conformance suite.
+4. **Defund interaction** — the buster is MILITARY, not economy: it must be
+   exempt from the `hostileRooms()` gate for its own target room (it exists
+   to enter exactly the rooms the economy flees). Spawn demand value below
+   reserver (115): the fight is an income optimisation, never blocking.
+
+### Acceptance tests (phase 2, write first when picked up)
+
+- **Unit**: the commissioning gate (payback math: remaining occupation vs
+  kill cost — table-driven off `invaderReservedUntil`); body builder caps;
+  no proposal for rooms we don't mine / marks below the gate / SK rooms.
+- **Grid** `def-t5-core-buster-reclaims-remote`: stage a destroyable
+  `invaderCore` object + reservation in the east room (backend supports
+  strongholds — `@screeps/backend/lib/strongholds.js`); assert the buster is
+  fielded, the core object disappears, the reservation clears, and a miner
+  works the source before window end. The phase-1 cell stays as the
+  no-military baseline (it stages a reservation WITHOUT a core, which phase 2
+  must not chase — that's the "core already dead, reservation decaying" case
+  where fighting buys nothing).
+- **Regression gate**: standard trio + both def-t* cells.
+
+## Non-goals
+
+- Fighting invader *creeps* (raids): TTL-bounded, self-resolving; the v1
+  defund already prices them correctly.
+- Strongholds (level 1-5, ramparted, in their own rooms): different weight
+  class entirely; out of scope.
+- Attacking other players' reservations: political, owner's call, not a
+  protocol.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -39,6 +39,7 @@ Conventions used by every spec:
 | 09 | [Robustness program](09-robustness-program.md) | phases 1, 4 done; 5 partial (CpuGovernor + bulkheads; schema versioning open); 6 partial (standdown); 2-3 open | P0 (phase 2) |
 | 10 | [RCL journey map](10-rcl-journey.md) | living ledger — most steps cell-pinned; see gap list | ongoing |
 | 11 | [Two plans: goal and now](11-two-plans.md) | phases 1-2 landed (agenda published + funding); phase 3 (transitions into agenda) open | P0 |
+| 12 | [Invader protocols: flight, and eventually fight](12-invader-protocols.md) | phase 1 (defund invader-reserved rooms) **LANDED 2026-07-16**, def-t5 cell green; phase 2 (core buster) specced, deferred | P3 (phase 2) |
 
 Recently completed (for context): economy consolidation onto
 `economy/primitives` + CorpPlanner (FlowSolver deleted); storage-as-core-depot

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -35,6 +35,16 @@ declare global {
      * early by any fresh sighting of the room with no hostiles.
      */
     hostileUntil?: number;
+    /**
+     * The room's controller is reserved by the Invader NPC (an invader core
+     * holds it) until ~this tick. Same defense economics as hostileUntil: the
+     * room's corps are defunded - mining is throttled/contested and our
+     * reserver cannot take the controller anyway. Set from the sighted
+     * reservation's ticksToEnd; cleared early by a fresh sighting with the
+     * reservation gone. A live core RENEWS its reservation, so the bound
+     * refreshes on every sighting rather than being exact.
+     */
+    invaderReservedUntil?: number;
     /** Number of energy sources in the room */
     sourceCount: number;
     /** Positions of energy sources */
@@ -159,7 +169,7 @@ declare global {
      * kept in Memory so a global reset - often the interesting moment - still
      * leaves evidence. The full ring lives in RawMemory segment 5.
      */
-    blackBoxTail?: Array<{ t: number; k: string; d: Record<string, unknown> }>;
+    blackBoxTail?: { t: number; k: string; d: Record<string, unknown> }[];
 
     /**
      * Arms the CPU governor's load-shedding (spec 09 ph5): set to "on" from
@@ -182,7 +192,7 @@ declare global {
       [spawnId: string]: {
         tick: number;
         fundingNeed: number;
-        queue: Array<{
+        queue: {
           role: string;
           corp: string;
           minCost: number;
@@ -192,9 +202,9 @@ declare global {
           why?: string;
           /** "bank>=N" (head, unaffordable) or "after:<corpId>". */
           precondition?: string;
-        }>;
+        }[];
         /** Execution receipts (actual-vs-NOW): the last ~8 spawns bought here. */
-        executed?: Array<{ tick: number; role: string; corp: string; cost: number }>;
+        executed?: { tick: number; role: string; corp: string; cost: number }[];
       };
     };
 

--- a/src/utils/RoomDiscovery.ts
+++ b/src/utils/RoomDiscovery.ts
@@ -286,14 +286,19 @@ export function isSourceKeeperRoom(name: string): boolean {
   return inBand(h) && inBand(v) && !(h === 5 && v === 5);
 }
 
+/** The Invader NPC's username: invader creeps and invader-core reservations. */
+export const INVADER_USERNAME = "Invader";
+
 /**
- * Rooms currently containing hostile creeps (invaders, or any player's),
- * memoized per tick. The v1 DEFENSE ECONOMICS (owner directive 2026-07-10):
- * while hostiles hold a room, the corps operating there are DEFUNDED - no
- * new bodies are bought for a grinder (miners mining there, haulers hauling
- * there, reservers headed there). Existing creeps run out; funding resumes
- * the tick the room clears. Vision-limited by design: an unseen room is not
- * assumed hostile.
+ * Rooms currently held by hostiles, memoized per tick. Two flavors, one set:
+ * hostile CREEPS (invaders, or any player's) sighted in the room, and an
+ * invader CORE's controller reservation - the core is a structure the creep
+ * pass never sees, so the reservation itself is the observable. The v1
+ * DEFENSE ECONOMICS (owner directive 2026-07-10): while hostiles hold a
+ * room, the corps operating there are DEFUNDED - no new bodies are bought
+ * for a grinder (miners mining there, haulers hauling there, reservers
+ * headed there). Existing creeps run out; funding resumes the tick the room
+ * clears. Vision-limited by design: an unseen room is not assumed hostile.
  */
 let hostileRoomsTick = -1;
 let hostileRoomsCache = new Set<string>();
@@ -320,15 +325,42 @@ export function hostileRooms(): Set<string> {
       } else if (intel?.hostileUntil) {
         delete intel.hostileUntil; // fresh all-clear sighting
       }
+
+      // Invader-core reservation: the room is held even with zero hostile
+      // creeps in sight. The reservation's ticksToEnd bounds the occupation
+      // the way a creep's ticksToLive bounds a raid - though a live core
+      // RENEWS it, so each sighting refreshes the bound; blind, the mark
+      // lapses at the last-seen bound and the next sighting re-arms it.
+      const reservation = Game.rooms[roomName].controller?.reservation;
+      const stamped = Memory.roomIntel[roomName]; // may exist since the creep pass
+      if (reservation && reservation.username === INVADER_USERNAME) {
+        const until = Game.time + reservation.ticksToEnd;
+        if (stamped) stamped.invaderReservedUntil = until;
+        else {
+          Memory.roomIntel[roomName] = { lastVisit: Game.time, invaderReservedUntil: until } as RoomIntel;
+        }
+      } else if (stamped?.invaderReservedUntil) {
+        delete stamped.invaderReservedUntil; // fresh sighting: reservation gone
+      }
     }
     // Marks persist without vision until their TTL bound expires.
     for (const roomName in Memory.roomIntel) {
-      const until = Memory.roomIntel[roomName]?.hostileUntil;
-      if (until !== undefined && until > Game.time) hostileRoomsCache.add(roomName);
+      const intel = Memory.roomIntel[roomName];
+      const hostileUntil = intel?.hostileUntil;
+      const reservedUntil = intel?.invaderReservedUntil;
+      if (
+        (hostileUntil !== undefined && hostileUntil > Game.time) ||
+        (reservedUntil !== undefined && reservedUntil > Game.time)
+      ) {
+        hostileRoomsCache.add(roomName);
+      }
     }
   } else {
     for (const roomName in Game.rooms) {
-      if (Game.rooms[roomName].find(FIND_HOSTILE_CREEPS).length > 0) hostileRoomsCache.add(roomName);
+      const room = Game.rooms[roomName];
+      if (room.find(FIND_HOSTILE_CREEPS).length > 0 || room.controller?.reservation?.username === INVADER_USERNAME) {
+        hostileRoomsCache.add(roomName);
+      }
     }
   }
   return hostileRoomsCache;

--- a/test/grid/baseline.json
+++ b/test/grid/baseline.json
@@ -46,6 +46,7 @@
     "plan-t4-two-spawn-nearest": "pass",
     "haul-t0-first-delivery": "pass",
     "def-t3-invader-defunds-source": "pass",
+    "def-t5-invader-reservation-defunds-remote": "pass",
     "plan-t5-sk-never-mined": "pass",
     "agenda-t3-replacement-labeled": "pass",
     "churn-t3-gapless-replacement": "pass",

--- a/test/grid/cells/defense.ts
+++ b/test/grid/cells/defense.ts
@@ -5,6 +5,12 @@
  * headed in) emit no spawn demands, so the colony never buys bodies for a
  * grinder. One sighting captures the hostile's ticksToLive, so the mark
  * outlives vision; funding resumes on the TTL bound or an all-clear look.
+ *
+ * Two hostile flavors share the one danger lens (hostileRooms): sighted
+ * hostile CREEPS (TTL-bounded), and an invader CORE's controller
+ * reservation (bounded by the reservation's ticksToEnd) - the core is a
+ * structure the creep pass never sees, so the reservation is the
+ * observable. See docs/specs/12-invader-protocols.md.
  */
 
 import { GridCell, always, eventually } from "../GridCell";
@@ -12,6 +18,29 @@ import { RoomBuilder } from "../../integration/scenario/RoomBuilder";
 
 /** Ticks the staged invader lives (its ageTime is set at stage). */
 const INVADER_DIES_AT = 150;
+
+/** Home room with an east exit slot at (49, 24..26) - multiroom pattern. */
+const homeEast = (build: (b: RoomBuilder) => RoomBuilder) => (roomName: string) => {
+  const b = new RoomBuilder(roomName).border();
+  for (let y = 24; y <= 26; y++) b.tile(49, y, "plain");
+  return build(b).toRoom();
+};
+
+/** East room with the matching west slot at (0, 24..26). */
+const eastRoom = (build: (b: RoomBuilder) => RoomBuilder) => (roomName: string) => {
+  const b = new RoomBuilder(roomName).border();
+  for (let y = 24; y <= 26; y++) b.tile(0, y, "plain");
+  return build(b).toRoom();
+};
+
+/** Ensure the Invader NPC user ("2") exists in a fresh mockup db. */
+async function ensureInvaderUser(db: any): Promise<void> {
+  const users = db["users"];
+  const invaderUser = await users.findOne({ _id: "2" });
+  if (!invaderUser) {
+    await users.insert({ _id: "2", username: "Invader", cpu: 0, gcl: 0, active: 0 });
+  }
+}
 
 export function buildDefenseCells(): GridCell[] {
   return [
@@ -31,12 +60,7 @@ export function buildDefenseCells(): GridCell[] {
       bot: { x: 25, y: 25 },
       controller: { level: 2 },
       async stage(ctx) {
-        // The Invader NPC user ("2") may not exist in a fresh mockup db.
-        const users = ctx.db["users"];
-        const invaderUser = await users.findOne({ _id: "2" });
-        if (!invaderUser) {
-          await users.insert({ _id: "2", username: "Invader", cpu: 0, gcl: 0, active: 0 });
-        }
+        await ensureInvaderUser(ctx.db);
         await ctx.db["rooms.objects"].insert({
           type: "creep",
           name: "invader-1",
@@ -91,6 +115,120 @@ export function buildDefenseCells(): GridCell[] {
                 Math.max(Math.abs(o.x - 40), Math.abs(o.y - 25)) <= 1
             );
         }),
+      ],
+    },
+
+    {
+      // An invader CORE reserves the remote room's controller (the screenshot
+      // scenario: "Reserved: Invader (4998)"). No hostile creep is ever in
+      // sight, so the v1 creep pass alone would keep funding a room whose
+      // controller we cannot take back. The reservation is the observable:
+      // the planner still OPENS the remote mine (non-vacuity - the defund,
+      // not the planner, is what holds the line), intel stamps the
+      // reservation-bounded mark, and no body is ever bought for the room -
+      // no miner/hauler for its source, no reserver at all.
+      id: "def-t5-invader-reservation-defunds-remote",
+      tier: 5,
+      avenue: "defense",
+      window: 300,
+      rooms: {
+        home: homeEast((b) => b.controller(25, 10).source(25, 40)),
+        east: eastRoom((b) => b.controller(10, 10).source(25, 25)),
+      },
+      adjacency: { east: "E" },
+      bot: { x: 25, y: 25 },
+      controller: { level: 3 },
+      // Full extensions: bodies are affordable, so the defund - not energy -
+      // is what's being measured (pattern: spawn-reserver-started-income).
+      structures: [
+        { type: "extension", x: 23, y: 23, energy: 50 },
+        { type: "extension", x: 23, y: 27, energy: 50 },
+        { type: "extension", x: 27, y: 23, energy: 50 },
+        { type: "extension", x: 27, y: 27, energy: 50 },
+        { type: "extension", x: 22, y: 25, energy: 50 },
+        { type: "extension", x: 28, y: 25, energy: 50 },
+        { type: "extension", x: 24, y: 22, energy: 50 },
+        { type: "extension", x: 26, y: 22, energy: 50 },
+      ],
+      creeps: [
+        // Home income pair keeps the economy sane (multiroom pattern).
+        {
+          name: "mH",
+          x: 24,
+          y: 39,
+          body: ["work", "work", "work", "work", "work", "move", "move", "move"],
+          memory: { workType: "harvest", corpId: "staged-def-m", assignedSourceId: "$id(home,source,25,40)" },
+        },
+        {
+          name: "hH",
+          x: 22,
+          y: 30,
+          body: ["carry", "carry", "carry", "carry", "move", "move", "move", "move"],
+          memory: { workType: "haul", corpId: "staged-def-h", working: false, assignedSourceId: "$id(home,source,25,40)" },
+        },
+        // Remote harvester: gives standing vision of the east room (the mark
+        // needs a sighting) and arms ReservationCorp's trigger. NO corpId -
+        // canary-proven untouchable, so it stands all window.
+        {
+          name: "rh",
+          x: 26,
+          y: 25,
+          room: "east",
+          body: ["work", "work", "move"],
+          memory: { workType: "harvest" },
+        },
+      ],
+      async stage(ctx) {
+        await ensureInvaderUser(ctx.db);
+        // The core itself is not staged - the RESERVATION is the observable
+        // the protocol keys on, and it outlives the window (as live cores
+        // renew theirs). Whole-object $set: dotted paths silently no-op in
+        // the mockup db.
+        await ctx.db["rooms.objects"].update(
+          { room: ctx.room("east"), type: "controller" },
+          { $set: { reservation: { user: "2", endTime: ctx.gameTime + 5000 } } }
+        );
+      },
+      assertions: [
+        // Non-vacuity: the planner still opens the remote mine (the defund is
+        // downstream, at spawn-demand time - pattern: plan-t5-remote-pipeline).
+        eventually("the planner opens the invader-reserved remote source", (s) => {
+          const src = s.objects("east").find((o: any) => o.type === "source");
+          if (!src) return false;
+          return (s.memory?.economyPlan?.corps ?? []).some(
+            (c: any) => c.kind === "mine" && c.sourceId === `source-${src._id}`
+          );
+        }),
+        // The sighting stamps the reservation-bounded mark.
+        eventually("intel stamps the invader-reservation mark", (s) => {
+          const intel = s.memory?.roomIntel?.[s.room("east")];
+          return typeof intel?.invaderReservedUntil === "number";
+        }),
+        // The defund: no body is ever bought for the reserved room - nothing
+        // is ever ASSIGNED its source, and no reserver is fielded anywhere.
+        always(
+          "no miner, hauler, or reserver is funded for the reserved room",
+          (s) => {
+            const src = s.objects("east").find((o: any) => o.type === "source");
+            if (!src) return true;
+            const assigned = Object.values(s.memory?.creeps ?? {}).some(
+              (mem: any) => mem?.assignedSourceId === src._id
+            );
+            const reserver = [undefined, "east"].some((h) =>
+              s
+                .objects(h)
+                .some((o: any) => o.type === "creep" && typeof o.name === "string" && o.name.startsWith("reserver-"))
+            );
+            return !assigned && !reserver;
+          },
+          10 // staging settles
+        ),
+        // Belt and suspenders: no miner ever physically enters the room.
+        always("no miner ever walks into the reserved room", (s) =>
+          !s
+            .objects("east")
+            .some((o: any) => o.type === "creep" && typeof o.name === "string" && o.name.startsWith("miner-"))
+        ),
       ],
     },
   ];

--- a/test/unit/utils/roomDiscovery.test.ts
+++ b/test/unit/utils/roomDiscovery.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * hostileRooms() - the defense-economics danger lens (v1 defund protocol).
+ *
+ * Two mark flavors, one set:
+ * - hostileUntil: a sighted hostile CREEP's ticksToLive bounds the threat.
+ * - invaderReservedUntil: an invader CORE's controller reservation bounds the
+ *   occupation. The core is a structure, not a creep, so the creep pass never
+ *   sees it - the reservation on the controller is the observable.
+ *
+ * Both marks persist without vision until their bound and are lifted early by
+ * a fresh all-clear sighting. hostileRooms() memoizes per tick, so every
+ * distinct observation below bumps Game.time first.
+ */
+import "../../../src/types/Memory";
+import { expect } from "chai";
+import { hostileRooms } from "../../../src/utils/RoomDiscovery";
+
+const FIND_HOSTILE_CREEPS = 103;
+
+/** A visible room with optional hostiles and an optional controller reservation. */
+function mockRoom(
+  name: string,
+  opts: { hostiles?: Array<{ ticksToLive: number }>; reservation?: { username: string; ticksToEnd: number } } = {}
+): any {
+  return {
+    name,
+    controller: { reservation: opts.reservation },
+    find: (type: number) => (type === FIND_HOSTILE_CREEPS ? opts.hostiles ?? [] : [])
+  };
+}
+
+describe("utils/RoomDiscovery - hostileRooms invader-reservation marking", () => {
+  const g = globalThis as unknown as { Game?: any; Memory?: any; FIND_HOSTILE_CREEPS?: number };
+  let savedGame: unknown;
+  let savedMemory: unknown;
+  let savedFind: unknown;
+  // Monotonic across tests: hostileRooms() memoizes per Game.time at module
+  // level, so re-using a tick would replay the previous test's cached set.
+  let time = 10_000;
+
+  /** Advance the tick clock (defeats the per-tick memo) and read the set. */
+  function observe(rooms: Record<string, any>): Set<string> {
+    time += 1;
+    g.Game = { time, rooms };
+    return hostileRooms();
+  }
+
+  beforeEach(() => {
+    savedGame = g.Game;
+    savedMemory = g.Memory;
+    savedFind = g.FIND_HOSTILE_CREEPS;
+    g.FIND_HOSTILE_CREEPS = FIND_HOSTILE_CREEPS;
+    g.Memory = { roomIntel: {} };
+  });
+  afterEach(() => {
+    g.Game = savedGame;
+    g.Memory = savedMemory;
+    g.FIND_HOSTILE_CREEPS = savedFind as number;
+  });
+
+  it("marks an invader-reserved room and stamps the reservation-bounded intel", () => {
+    const set = observe({ E1N1: mockRoom("E1N1", { reservation: { username: "Invader", ticksToEnd: 4998 } }) });
+    expect(set.has("E1N1"), "room is defunded while the Invader holds its controller").to.equal(true);
+    expect(g.Memory.roomIntel.E1N1.invaderReservedUntil).to.equal(time + 4998);
+  });
+
+  it("does not mark a room we or another player reserve", () => {
+    const set = observe({
+      E1N1: mockRoom("E1N1", { reservation: { username: "shadymccoy", ticksToEnd: 3000 } }),
+      E2N1: mockRoom("E2N1")
+    });
+    expect(set.has("E1N1")).to.equal(false);
+    expect(set.has("E2N1")).to.equal(false);
+    expect(g.Memory.roomIntel.E1N1?.invaderReservedUntil).to.equal(undefined);
+  });
+
+  it("persists the mark without vision until the reservation bound expires", () => {
+    observe({ E1N1: mockRoom("E1N1", { reservation: { username: "Invader", ticksToEnd: 5 } }) });
+    const until = g.Memory.roomIntel.E1N1.invaderReservedUntil as number;
+
+    // Vision lost: the mark outlives the sighting...
+    expect(observe({}).has("E1N1"), "mark persists blind inside the bound").to.equal(true);
+
+    // ...until the reservation would have run out.
+    time = until - 1; // next observe() bumps to `until`: bound reached
+    expect(observe({}).has("E1N1"), "bound reached: funding resumes").to.equal(false);
+  });
+
+  it("lifts the mark early on a fresh sighting with the reservation gone", () => {
+    observe({ E1N1: mockRoom("E1N1", { reservation: { username: "Invader", ticksToEnd: 4998 } }) });
+    const set = observe({ E1N1: mockRoom("E1N1") }); // core died / reservation cleared
+    expect(set.has("E1N1")).to.equal(false);
+    expect(g.Memory.roomIntel.E1N1.invaderReservedUntil).to.equal(undefined);
+  });
+
+  it("a controller-less (highway) sighting neither crashes nor marks", () => {
+    const room = mockRoom("E5N0");
+    room.controller = undefined;
+    expect(observe({ E5N0: room }).has("E5N0")).to.equal(false);
+  });
+
+  it("keeps the v1 hostile-creep marking, and both marks coexist in one room", () => {
+    const set = observe({
+      E1N1: mockRoom("E1N1", {
+        hostiles: [{ ticksToLive: 200 }],
+        reservation: { username: "Invader", ticksToEnd: 4998 }
+      })
+    });
+    expect(set.has("E1N1")).to.equal(true);
+    expect(g.Memory.roomIntel.E1N1.hostileUntil).to.equal(time + 200);
+    expect(g.Memory.roomIntel.E1N1.invaderReservedUntil).to.equal(time + 4998);
+
+    // The invaders die but the core still holds the controller: the creep
+    // mark lifts on the all-clear sighting, the reservation mark holds.
+    const after = observe({ E1N1: mockRoom("E1N1", { reservation: { username: "Invader", ticksToEnd: 4996 } }) });
+    expect(after.has("E1N1"), "reservation alone keeps the room defunded").to.equal(true);
+    expect(g.Memory.roomIntel.E1N1.hostileUntil).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 1 of the invader protocols (spec 12): detect and defund rooms held by invader cores via controller reservation, extending the v1 defense economics to cover both hostile creeps and invader-core occupations.

## Key Changes

- **RoomDiscovery.ts**: Extended `hostileRooms()` to detect invader-core reservations alongside hostile creeps
  - Added `INVADER_USERNAME` constant ("Invader")
  - New mark type `invaderReservedUntil` on RoomIntel, same lifecycle as `hostileUntil`
  - Reservation bound = `Game.time + reservation.ticksToEnd`; persists blind until expiry
  - Early all-clear lift when fresh sighting shows reservation gone
  - Union of both marks returned to defund consumers (no consumer changes needed)

- **Memory.ts**: Added `invaderReservedUntil?: number` field to RoomIntel type definition with full documentation

- **Test coverage**:
  - New unit suite `test/unit/utils/roomDiscovery.test.ts` (120 lines): stamp + bound, blind persistence, early lift, controller-less rooms, coexisting marks
  - New grid cell `def-t5-invader-reservation-defunds-remote` (tier 5, defense): two-room scenario with east remote reserved by Invader for 5000 ticks, staged remote harvester for standing vision
    - Asserts planner still opens the remote mine (non-vacuity)
    - Asserts intel stamps the reservation-bounded mark
    - Asserts no miner/hauler/reserver funded for the reserved room across 300-tick window
  - Updated baseline: `def-t5-invader-reservation-defunds-remote` passes

- **Documentation**:
  - New spec `docs/specs/12-invader-protocols.md`: Phase 1 (landed) and Phase 2 (deferred, specced for future work)
  - Updated `docs/specs/README.md` to reference spec 12
  - Updated `docs/ROUTINES.md` with invader protocol context

- **Refactoring**: Extracted `ensureInvaderUser()` helper in defense cell staging (DRY: used by both existing and new cells)

## Implementation Details

The core insight: invader cores are structures (invisible to the creep pass), but their controller reservation is observable and bounds the occupation exactly like a creep's TTL. The reservation renews on each sighting, so the bound refreshes rather than being exact—a live core keeps the room marked indefinitely until it dies or we clear the reservation.

Both marks coexist in one room: if invaders raid while a core holds the controller, both `hostileUntil` and `invaderReservedUntil` are set. When the creeps die (all-clear sighting), the creep mark lifts but the reservation mark holds. When the core dies (reservation clears), the reservation mark lifts.

All existing defund consumers (HarvestCorp, CarryCorp, ReservationCorp, constructionKind, expansion) work unchanged—they read the union from `hostileRooms()`.

Phase 2 (fight: kill the core, take the room back) is specced in detail but deferred pending doctrine change (currently "we spread like a disease; losing a room is fine").

https://claude.ai/code/session_017x2pmt8ynM4G3ScKqSkCUQ