### PR TITLE
Fix sourcePickupSpot to prioritize full containers over piles

### DIFF
--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -190,14 +190,25 @@ export function sourcePickupSpot(sourcePos: RoomPosition): EnergySpot {
   // a container's contents do not - when both hold energy at the source,
   // drain the depreciating stock first. Planning treats them as ONE summed
   // stock; this is the execution-side half of the same principle.
+  //
+  // EXCEPT while the container is FULL: harvest dropped onto a full container
+  // tile spills to the ground, so a fresh trickle-pile reappears EVERY tick and
+  // pile-first locks the hauler into ~10-energy pickups forever (observed live
+  // 2026-07-16: a hauler parked at the source inching toward full while 2000
+  // sat in the container). A full container means the pile is overflow in
+  // progress, not stale stock: withdraw from the container instead - one intent
+  // fills the hauler AND re-opens capacity so the next drops are absorbed. The
+  // leftover pile is drained by pile-first as soon as the container is no
+  // longer full.
   const pile = sourcePos
     .findInRange(FIND_DROPPED_RESOURCES, 1, { filter: r => r.resourceType === RESOURCE_ENERGY && r.amount > 0 })
     .sort((a, b) => b.amount - a.amount)[0];
-  if (pile) return { pos: pile.pos };
-
   const container = sourcePos.findInRange(FIND_STRUCTURES, 1, {
     filter: s => s.structureType === STRUCTURE_CONTAINER && (s as StructureContainer).store[RESOURCE_ENERGY] > 0
   })[0] as StructureContainer | undefined;
+  const containerFull = container !== undefined && (container.store.getFreeCapacity(RESOURCE_ENERGY) ?? 0) === 0;
+
+  if (pile && !containerFull) return { pos: pile.pos };
   if (container) return { pos: container.pos, structure: container };
 
   if (linkServed) return { pos: core!.pos, structure: core! };

--- a/test/unit/corps/sourcePickupSpot.test.ts
+++ b/test/unit/corps/sourcePickupSpot.test.ts
@@ -1,0 +1,99 @@
+import { expect } from "chai";
+import { sourcePickupSpot } from "../../../src/corps/nodeEnergy";
+
+// Minimal Screeps globals sourcePickupSpot touches.
+(global as any).RESOURCE_ENERGY = "energy";
+(global as any).FIND_DROPPED_RESOURCES = 106;
+(global as any).FIND_STRUCTURES = 107;
+(global as any).STRUCTURE_CONTAINER = "container";
+
+const cheby = (a: { x: number; y: number }, b: { x: number; y: number }): number =>
+  Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+
+interface Pile {
+  resourceType: string;
+  amount: number;
+  pos: { x: number; y: number };
+}
+
+interface Container {
+  structureType: string;
+  pos: { x: number; y: number };
+  store: { energy: number; getFreeCapacity: (r?: string) => number };
+}
+
+/** A mock source position with piles / a container within range 1. */
+function mockSourcePos(x: number, y: number, world: { piles?: Pile[]; containers?: Container[] }) {
+  const self = { x, y };
+  return {
+    x,
+    y,
+    roomName: "W0N0",
+    findInRange: (type: number, range: number, opts?: { filter?: (o: any) => boolean }) => {
+      const list: any[] =
+        type === (global as any).FIND_DROPPED_RESOURCES ? (world.piles ?? []) : (world.containers ?? []);
+      return list.filter(o => cheby(self, o.pos) <= range && (!opts?.filter || opts.filter(o)));
+    }
+  } as any;
+}
+
+const pile = (x: number, y: number, amount: number): Pile => ({ resourceType: "energy", amount, pos: { x, y } });
+const container = (x: number, y: number, energy: number, capacity = 2000): Container => ({
+  structureType: "container",
+  pos: { x, y },
+  store: { energy, getFreeCapacity: () => capacity - energy }
+});
+
+describe("sourcePickupSpot (pile vs container priority)", () => {
+  beforeEach(() => {
+    // No room vision needed: coreLink resolution is skipped when the room is
+    // absent, which keeps these tests on the pile/container branch.
+    (global as any).Game = { rooms: {} };
+  });
+
+  it("withdraws from a FULL container instead of chasing the per-tick overflow trickle", () => {
+    // The live bug: a full container makes the miner's harvest spill to the
+    // ground EVERY tick, so an unconditional pile-first rule locks the hauler
+    // into ~10-energy pickups forever while 2000 sits in the container.
+    const c = container(9, 10, 2000); // 2000/2000 - no free capacity
+    const trickle = pile(9, 10, 24); // this tick's overflow
+    const spot = sourcePickupSpot(mockSourcePos(10, 10, { piles: [trickle], containers: [c] }));
+
+    expect(spot.structure).to.equal(c);
+    expect(spot.pos).to.equal(c.pos);
+  });
+
+  it("drains a pile before a NON-full container (decay-first doctrine)", () => {
+    // A pile beside a container with headroom is stale stock (drops are being
+    // absorbed, the pile only decays) - drain the depreciating stock first.
+    const c = container(9, 10, 1200); // 800 free
+    const p = pile(9, 10, 300);
+    const spot = sourcePickupSpot(mockSourcePos(10, 10, { piles: [p], containers: [c] }));
+
+    expect(spot.structure).to.equal(undefined);
+    expect(spot.pos).to.equal(p.pos);
+  });
+
+  it("withdraws from a stocked container when there is no pile", () => {
+    const c = container(9, 10, 500);
+    const spot = sourcePickupSpot(mockSourcePos(10, 10, { containers: [c] }));
+
+    expect(spot.structure).to.equal(c);
+  });
+
+  it("resolves the drop pile when there is no container", () => {
+    const p = pile(11, 10, 300);
+    const spot = sourcePickupSpot(mockSourcePos(10, 10, { piles: [p] }));
+
+    expect(spot.structure).to.equal(undefined);
+    expect(spot.pos).to.equal(p.pos);
+  });
+
+  it("ignores an EMPTY container and waits clear of the bare source", () => {
+    const c = container(9, 10, 0);
+    const spot = sourcePickupSpot(mockSourcePos(10, 10, { containers: [c] }));
+
+    expect(spot.structure).to.equal(undefined);
+    expect(spot.waitClear).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fix a live bug in `sourcePickupSpot` where haulers get locked into ~10-energy pickups when a container at the source becomes full. When a container is at capacity, harvest overflow spills to the ground every tick, creating a fresh pile that the old pile-first logic would prioritize forever, leaving 2000 energy stuck in the container.

## Changes
- **Modified `sourcePickupSpot` logic**: Added a `containerFull` check that inverts the pile-vs-container priority when the container has zero free capacity
  - If pile exists AND container is NOT full: drain the pile first (decay-first doctrine for stale stock)
  - If pile exists AND container IS full: withdraw from the container instead (the pile is overflow in progress, not stale stock)
  - This allows one hauler intent to both fill the hauler AND re-open container capacity so subsequent drops are absorbed
  
- **Added comprehensive unit tests** (`test/unit/corps/sourcePickupSpot.test.ts`):
  - Verifies full container takes priority over trickle pile (the live bug case)
  - Confirms pile drains before non-full container (decay-first doctrine)
  - Tests fallback cases: container-only, pile-only, empty container
  - Uses Chebyshev distance mocking to simulate Screeps' `findInRange` behavior

## Implementation Details
The fix preserves the decay-first principle (piles depreciate, containers don't) while adding an exception: a full container indicates the pile is fresh overflow, not stale stock. The container's `getFreeCapacity()` check determines the priority inversion, keeping the logic localized to the decision point.

https://claude.ai/code/session_012Aj6kNdAv43po3FMRgEPxq