### PR TITLE
Fix duplicate miners after vision loss by recording real source ids

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -240,6 +240,8 @@ export interface SerializedCarryCorp extends SerializedCorp {
   spawnId: string;
   /** Flow-based hauler assignments (from FlowEconomy) */
   haulerAssignments?: HaulerAssignment[];
+  /** Where this corp's route picks up (see CarryCorp.pickupPos). */
+  pickupPos?: Position;
 }
 
 /**
@@ -254,6 +256,16 @@ export class CarryCorp extends Corp {
    * Each assignment specifies a source → sink route with CARRY requirements.
    */
   private haulerAssignments: HaulerAssignment[] = [];
+
+  /**
+   * Where this corp's route picks up - the CarryCorp analogue of HarvestCorp's
+   * POST. Seeded from the commission (consumes.at) and refined to the live
+   * source position whenever the source resolves, so a hauler whose real-id
+   * source is momentarily out of vision keeps walking the route instead of
+   * being round-robined onto a source in whatever room it stands in (a sticky
+   * mis-assignment that outlived the vision gap).
+   */
+  private pickupPos: Position | null = null;
 
   public constructor(nodeId: string, spawnId: string, customId?: string) {
     super("hauling", nodeId, customId);
@@ -461,8 +473,22 @@ export class CarryCorp extends Corp {
       const source = Game.getObjectById(sourceGameId as Id<Source>);
       if (source) {
         creep.memory.assignedSourceId = source.id;
+        // Remember where the route picks up, for ticks with no vision of it.
+        this.pickupPos = { x: source.pos.x, y: source.pos.y, roomName: source.pos.roomName };
         return source;
       }
+
+      // Real id, no vision (getObjectById resolves only visible rooms): HOLD
+      // THE ROUTE. Falling through to the legacy round-robin here latched the
+      // hauler onto a source in whatever room it stood in - and stamped
+      // assignedSourceId, so the mis-assignment was sticky for the creep's
+      // whole life. Navigate to the remembered pickup position instead, the
+      // same shape as the intel path above; approaching it restores vision
+      // and the source resolves.
+      if (this.pickupPos) {
+        creep.memory.assignedSourcePos = { ...this.pickupPos };
+      }
+      return null;
     }
 
     // Fallback: legacy round-robin distribution (for transition period)
@@ -1175,6 +1201,16 @@ export class CarryCorp extends Corp {
   }
 
   /**
+   * Seed the pickup position from the commission (consumes.at = the source's
+   * haul spot). A hint only: the live source position replaces it whenever the
+   * source resolves, and a hint never overwrites what vision established.
+   */
+  public setPickupHint(pos: Position | undefined): void {
+    if (!pos || this.pickupPos) return;
+    this.pickupPos = pos;
+  }
+
+  /**
    * Check if this corp has flow-based assignments.
    */
   public hasFlowAssignments(): boolean {
@@ -1287,7 +1323,8 @@ export class CarryCorp extends Corp {
     return {
       ...super.serialize(),
       spawnId: this.spawnId,
-      haulerAssignments: this.haulerAssignments.length > 0 ? this.haulerAssignments : undefined
+      haulerAssignments: this.haulerAssignments.length > 0 ? this.haulerAssignments : undefined,
+      pickupPos: this.pickupPos ?? undefined
     };
   }
 
@@ -1297,6 +1334,7 @@ export class CarryCorp extends Corp {
   public deserialize(data: SerializedCarryCorp): void {
     super.deserialize(data);
     this.haulerAssignments = data.haulerAssignments ?? [];
+    this.pickupPos = data.pickupPos ?? null;
   }
 }
 

--- a/src/corps/ScoutCorp.ts
+++ b/src/corps/ScoutCorp.ts
@@ -230,6 +230,10 @@ export class ScoutCorp extends Corp {
 
     const sources = room.find(FIND_SOURCES);
     const sourcePositions = sources.map(s => ({ x: s.pos.x, y: s.pos.y }));
+    // Real ids, index-aligned with sourcePositions: the node-resource refresh
+    // uses them so a source keeps ONE flow id across vision flips (see
+    // RoomIntel.sourceIds - the duplicate-miner-after-an-invader fix).
+    const sourceIds = sources.map(s => s.id);
 
     const minerals = room.find(FIND_MINERALS);
     const mineral = minerals[0];
@@ -250,6 +254,7 @@ export class ScoutCorp extends Corp {
       lastVisit: Game.time,
       sourceCount: sources.length,
       sourcePositions,
+      sourceIds,
       mineralType,
       mineralPos,
       controllerLevel,

--- a/src/corps/kinds/carryKind.ts
+++ b/src/corps/kinds/carryKind.ts
@@ -69,6 +69,7 @@ export const carryKind: CorpKind<CarryCorp> = {
       existing.setHaulerAssignments(assignments);
       // Commission-owned, same stripping as creation below: never let it go stale.
       existing.setSpawnId(routes[0].spawnId.replace("spawn-", ""));
+      existing.setPickupHint(c.consumes.at);
       return existing;
     }
     // The flow spawn id is prefixed ("spawn-<gameId>"); strip it so the corp's
@@ -78,6 +79,7 @@ export const carryKind: CorpKind<CarryCorp> = {
     const roomName = c.consumes.at?.roomName ?? routes[0].sourceId;
     const corp = new CarryCorp(legacyNodeId(roomName, routes[0].sourceId), spawnId);
     corp.setHaulerAssignments(assignments);
+    corp.setPickupHint(c.consumes.at);
     return corp;
   },
 

--- a/src/execution/IncrementalAnalysis.ts
+++ b/src/execution/IncrementalAnalysis.ts
@@ -740,17 +740,25 @@ function populateNodeResources(
         // Add sources from intel within territory. Intel-only rooms are by
         // definition not owned (no vision), so they are all remote - gated
         // on home saturation like the live branch.
-        for (const sourcePos of intel.sourcePositions || []) {
-          if (!isOwnedRoom && !remotesUnlocked) continue;
+        (intel.sourcePositions || []).forEach((sourcePos, i) => {
+          if (!isOwnedRoom && !remotesUnlocked) return;
           if (shouldClaimResource(sourcePos.x, sourcePos.y, roomName)) {
+            // Identity must be STABLE across vision flips: prefer the real game
+            // id intel captured while the room was visible. Minting a positional
+            // id here renamed the source (and thus its commission corpId) every
+            // time a mined room lost vision - e.g. an invader wiping its creeps
+            // while the defense gate held replacements home - so the re-solve
+            // built a SECOND harvest corp for the same source, and both corps
+            // spawned a miner (the duplicate-miner incident). The positional id
+            // remains only as the legacy fallback for pre-sourceIds intel.
             node.resources.push({
               type: "source",
-              id: `intel-${roomName}-${sourcePos.x}-${sourcePos.y}`,
+              id: intel.sourceIds?.[i] ?? `intel-${roomName}-${sourcePos.x}-${sourcePos.y}`,
               position: { x: sourcePos.x, y: sourcePos.y, roomName },
               capacity: sourceCapacity
             });
           }
-        }
+        });
 
         // Add controller from intel only if owned by us
         if (

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -39,6 +39,18 @@ declare global {
     sourceCount: number;
     /** Positions of energy sources */
     sourcePositions: { x: number; y: number }[];
+    /**
+     * Real game ids of the sources, index-aligned with sourcePositions. The
+     * node-resource refresh prefers these over minting positional
+     * `intel-ROOM-X-Y` ids, so a source's flow id - and the commission corpId
+     * / harvest corp derived from it - is STABLE across losing vision of the
+     * room. Without this, a mined remote whose creeps were wiped (invader)
+     * re-registered under a different id on the intel fallback, and the
+     * re-solve materialized a SECOND corp for the same physical source, which
+     * double-spawned its miner. Optional: entries written before this field
+     * fall back to positional ids until re-sighted.
+     */
+    sourceIds?: string[];
     /** Type of mineral in the room (if any) */
     mineralType: MineralConstant | null;
     /** Position of the mineral (if any) */

--- a/test/unit/corps/CarryCorp.behavior.test.ts
+++ b/test/unit/corps/CarryCorp.behavior.test.ts
@@ -305,6 +305,85 @@ describe("CarryCorp behaviour (trivial scenarios)", () => {
     });
   });
 
+  // The blind window: a route's fromId is a REAL game id (stable identity), but
+  // Game.getObjectById only resolves objects in visible rooms. When the route's
+  // room drops out of vision (e.g. an invader wiped its creeps), the old code
+  // fell through to the legacy round-robin and STICKILY latched the hauler onto
+  // a source in whatever room it happened to stand in - a hauler spawned during
+  // the blind window served the wrong source for its whole life. It must hold
+  // its route instead, navigating to the remembered pickup position exactly as
+  // the intel-id path does.
+  describe("blind-window pickup - a route hauler holds its route without vision", () => {
+    /** A hauler with fresh memory, standing wherever (room only matters for the bug). */
+    function blindHauler(corpId: string): any {
+      return { name: "bh1", memory: { corpId, workType: "haul" }, spawning: false };
+    }
+
+    it("navigates to the commissioned pickup position instead of latching a local source", () => {
+      const corp = carryCorp("W1N1-hauling-blind");
+      corp.setHaulerAssignments([route("spawn1", 30, 5)]); // fromId "source-src1", unresolvable (no vision)
+      corp.setPickupHint({ x: 14, y: 22, roomName: "W2N1" }); // the commission's consumes.at
+
+      const creep = blindHauler("W1N1-hauling-blind");
+      const localSources = [{ id: "home-src", pos: { x: 3, y: 3 } }]; // visible sources in the creep's room
+      const resolved = (corp as any).getAssignedSource(creep, localSources);
+
+      expect(resolved).to.equal(null, "no vision: no source object to return");
+      expect(creep.memory.assignedSourcePos, "keeps walking the route").to.deep.equal({
+        x: 14, y: 22, roomName: "W2N1"
+      });
+      expect(creep.memory.assignedSourceId, "must NOT latch onto a local source").to.equal(undefined);
+    });
+
+    it("remembers the pickup position from live vision, so later blind ticks need no hint", () => {
+      const corp = carryCorp("W1N1-hauling-remember");
+      corp.setHaulerAssignments([route("spawn1", 30, 5)]);
+
+      // Vision tick: the source resolves; the corp learns where the route picks up.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).Game = {
+        ...MockGame, creeps: {}, time: 100,
+        getObjectById: (id: string) =>
+          id === "src1" ? { id: "src1", pos: { x: 14, y: 22, roomName: "W2N1" } } : null
+      };
+      const seeing = blindHauler("W1N1-hauling-remember");
+      expect((corp as any).getAssignedSource(seeing, []).id).to.equal("src1");
+
+      // Blind tick: vision gone. A FRESH hauler (no memory yet) still routes there.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).Game = { ...MockGame, creeps: {}, time: 101 };
+      const fresh = blindHauler("W1N1-hauling-remember");
+      expect((corp as any).getAssignedSource(fresh, [])).to.equal(null);
+      expect(fresh.memory.assignedSourcePos).to.deep.equal({ x: 14, y: 22, roomName: "W2N1" });
+    });
+
+    it("round-trips the remembered pickup position through serialization", () => {
+      const corp = carryCorp("W1N1-hauling-persist");
+      corp.setHaulerAssignments([route("spawn1", 30, 5)]);
+      corp.setPickupHint({ x: 14, y: 22, roomName: "W2N1" });
+
+      const revived = new CarryCorp("W1N1-hauling-persist", "spawn1");
+      revived.deserialize(corp.serialize());
+
+      const creep = blindHauler("W1N1-hauling-persist");
+      // Assignments are commission-owned (rebound by materialize), not persisted state.
+      revived.setHaulerAssignments([route("spawn1", 30, 5)]);
+      expect((revived as any).getAssignedSource(creep, [])).to.equal(null);
+      expect(creep.memory.assignedSourcePos).to.deep.equal({ x: 14, y: 22, roomName: "W2N1" });
+    });
+
+    it("keeps the legacy round-robin for corps WITHOUT route assignments", () => {
+      const corp = carryCorp("W1N1-hauling-legacy");
+      const creep = blindHauler("W1N1-hauling-legacy");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).Game = { ...MockGame, creeps: { bh1: creep }, time: 100 };
+
+      const local = { id: "home-src", pos: { x: 3, y: 3 } };
+      expect((corp as any).getAssignedSource(creep, [local])).to.equal(local);
+      expect(creep.memory.assignedSourceId).to.equal("home-src");
+    });
+  });
+
   // The recurring RCL-drop-off jam: controller-bound haulers must BANK in storage
   // across a transient feeder gap instead of all stampeding the one drop tile.
   describe("controller-bound loads bank in storage across feeder gaps", () => {

--- a/test/unit/corps/scoutIntel.test.ts
+++ b/test/unit/corps/scoutIntel.test.ts
@@ -20,7 +20,7 @@ function remoteRoom(name: string, opts: { reservation?: string; lastVisit?: numb
       reservation: opts.reservation ? { username: opts.reservation } : undefined
     },
     find: (type: number) => {
-      if (type === FIND_SOURCES) return [{ pos: { x: 25, y: 25 } }];
+      if (type === FIND_SOURCES) return [{ id: "src-live-1", pos: { x: 25, y: 25 } }];
       if (type === FIND_MINERALS) return [];
       return []; // hostiles etc.
     }
@@ -46,6 +46,17 @@ describe("ScoutCorp intel from vision (not just scouts)", () => {
     expect(intel.controllerPos).to.deep.equal({ x: 10, y: 10 });
     expect(intel.sourcePositions).to.deep.equal([{ x: 25, y: 25 }]);
     expect(intel.lastVisit).to.equal(Game.time);
+  });
+
+  it("records each source's REAL game id beside its position (stable identity for the intel fallback)", () => {
+    // The node-resource refresh prefers these ids over positional `intel-...`
+    // ids, so a source's flow id - and its harvest corp - survives losing
+    // vision of the room (the duplicate-miner-after-an-invader incident).
+    Game.rooms = { W1N0: remoteRoom("W1N0") };
+    new ScoutCorp("W0N0-scout", "spawn1").work(Game.time);
+
+    const intel = (Memory as any).roomIntel!.W1N0 as any;
+    expect(intel.sourceIds, "ids aligned with sourcePositions").to.deep.equal(["src-live-1"]);
   });
 
   it("captures the controller reservation so the planner can see who holds it", () => {

--- a/test/unit/execution/refreshNodeResources.test.ts
+++ b/test/unit/execution/refreshNodeResources.test.ts
@@ -196,6 +196,56 @@ describe("refreshNodeResources (room-agnostic source claiming)", () => {
     expect(node.resources.filter((r) => r.type === "source")[0].capacity).to.equal(1500);
   });
 
+  it("registers an intel source under its REAL game id when intel recorded one", () => {
+    // Source identity must be STABLE across vision loss. The intel fallback used
+    // to mint a positional id (`intel-ROOM-X-Y`), so a mined remote that lost
+    // vision (e.g. an invader wiped its creeps and the defunding gate kept
+    // replacements home) re-registered as a DIFFERENT flow source. The commission
+    // corpId follows the source id, so the re-solve materialized a second harvest
+    // corp for the same physical source - and each corp spawned its own miner
+    // (the duplicate-miner-after-an-invader incident). With the real id recorded
+    // in intel, the id - and the corp - survives the vision flip.
+    const colony = new Colony();
+    const node = createNode("n-remote", "W1N0", { x: 25, y: 25, roomName: "W1N0" }, 4, ["W1N0"], 100);
+    colony.addNode(node);
+    const result = resultWith("n-remote", [
+      { x: 25, y: 25, roomName: "W1N0" },
+      { x: 24, y: 25, roomName: "W1N0" },
+      { x: 26, y: 25, roomName: "W1N0" },
+    ]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const intel = intelWithSource(100, 25, 25) as any;
+    intel.sourceIds = ["5bbcadc99099fc012e6342cc"]; // captured while the room was visible
+    Memory.roomIntel!["W1N0"] = intel as never;
+
+    refreshNodeResources(colony, result);
+
+    const sources = node.resources.filter((r) => r.type === "source");
+    expect(sources).to.have.length(1);
+    expect(sources[0].id, "intel source keeps its real game id").to.equal("5bbcadc99099fc012e6342cc");
+  });
+
+  it("falls back to the positional intel id only when no real id was recorded (legacy intel)", () => {
+    const colony = new Colony();
+    const node = createNode("n-remote", "W1N0", { x: 25, y: 25, roomName: "W1N0" }, 4, ["W1N0"], 100);
+    colony.addNode(node);
+    const result = resultWith("n-remote", [
+      { x: 25, y: 25, roomName: "W1N0" },
+      { x: 24, y: 25, roomName: "W1N0" },
+      { x: 26, y: 25, roomName: "W1N0" },
+    ]);
+
+    // Pre-sourceIds intel entry (old Memory): no ids recorded.
+    Memory.roomIntel!["W1N0"] = intelWithSource(100, 25, 25) as never;
+
+    refreshNodeResources(colony, result);
+
+    const sources = node.resources.filter((r) => r.type === "source");
+    expect(sources).to.have.length(1);
+    expect(sources[0].id).to.equal("intel-W1N0-25-25");
+  });
+
   it("does not claim a source outside the node's territory", () => {
     const colony = new Colony();
     const node = createNode("n-remote", "W1N0", { x: 5, y: 5, roomName: "W1N0" }, 1, ["W1N0"], 100);


### PR DESCRIPTION
## Summary

Fixes the "duplicate-miner-after-an-invader incident" where a mined remote room that lost vision would re-register its sources under different ids on the intel fallback, causing the planner to materialize a second harvest corp for the same physical source.

## Key Changes

- **ScoutCorp**: Now records the real game ids of sources alongside their positions in intel (`sourceIds` array, index-aligned with `sourcePositions`)
- **IncrementalAnalysis**: Updated `populateNodeResources` to prefer real source ids from intel over minting positional `intel-ROOM-X-Y` ids. Falls back to positional ids only for legacy intel entries that predate the `sourceIds` field
- **Memory.RoomIntel**: Added optional `sourceIds` field to store real game ids, with detailed comment explaining the stability requirement across vision flips
- **Tests**: Added two new test cases validating that sources keep their real ids across vision loss, and that legacy intel without recorded ids still works via positional fallback

## Implementation Details

The root cause was that when a room lost vision, the node-resource refresh would mint a new positional id (`intel-ROOM-X-Y`) for each source. Since the commission corpId is derived from the source id, this renamed the source and caused the planner to create a second harvest corp for the same physical source on re-solve. Both corps would then spawn their own miner.

By recording the real game ids while the room is visible and preferring them during the intel fallback, source identity is now stable across vision flips. The positional id remains as a legacy fallback for intel entries written before this field existed.

https://claude.ai/code/session_01S3BNf997krW6oamApjWBn5