### PR TITLE
Spend the bank: surplus draw-down turns a full warchest into controller progress (spec 03)

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -51,10 +51,15 @@ terrain ─▶ Nodes ─▶ FlowGraph ─▶ ColonyProblem ─▶ ColonyPlan ─
    spawn/controller/storage; SK rooms skipped), and builds source×sink edges
    with **real cached `pathDistance`** (`:216`). Shapes in `flow/FlowTypes.ts`.
 
-3. **FlowGraph → ColonyProblem.** `economy/flowAdapter.ts:108` `buildColonyProblem`
+3. **FlowGraph → ColonyProblem.** `economy/flowAdapter.ts` `buildColonyProblem`
    flattens the graph into a pure, `Game`-free `ColonyProblem` (`CorpPlanner.ts:90`):
    `{spawns, sources, sinks, dist}`. It also injects **scavenge** sources
-   (dropped energy/tombstones ≥ 750, `scavenge.ts`) and **link `haulPos`**
+   (dropped energy/tombstones ≥ 750, `scavenge.ts`; stocks inside a
+   feeder-managed controller bucket are excluded — the feeder would just
+   refill them), **bank**
+   sources (spec 03 surplus draw-down: a storage above `WARCHEST_TARGET`
+   becomes a transient source and its room's storage sink is dropped —
+   `economy/bank.ts`), and **link `haulPos`**
    (a link-served source is *hauled* from the core link by storage but *mined*
    at the real walk distance). Sink `value` = `DEFAULT_SINK_VALUE`; controllers
    carry `reserve = ANTI_DOWNGRADE_RESERVE` (2).

--- a/docs/specs/03-storage-drawdown.md
+++ b/docs/specs/03-storage-drawdown.md
@@ -1,17 +1,47 @@
-# 03 — Storage draw-down (spend the bank when income dips)
+# 03 — Storage draw-down (spend the bank)
 
-**Status:** withdrawal not started; the deposit half now works. As of the
-storage-hauler-routing change the planner caps the controller at
-`STORAGE_UPGRADE_TARGET` once a room has a storage (`flowAdapter.ts`) and routes
-the surplus to the storage sink, which CarryCorp delivers as a first-class `storage`
-circuit (`deliverToStorage`) with no spill ceiling — so the bank actually
-accumulates the expansion CAPEX instead of stalling at `STORAGE_BANK = 10000`.
-Withdrawal is partially implicit: the tender refills extensions from the depot,
-and `ControllerFeederCorp` relays storage → controller input as a steady last
-leg once a bank exists. But neither is an *income-dip response* — nothing feeds
-builders from the bank, and the planner never treats the bank as supply when
-income collapses.
-**Priority:** P1.
+**Status:** the SURPLUS half is LIVE (2026-07-16); the income-dip (shortfall)
+half is not started. The deposit half works: the planner caps the controller at
+`STORAGE_UPGRADE_TARGET` once a room has a storage (`economy/bank.ts`, re-exported
+by `flowAdapter.ts`) and routes the surplus to the storage sink, which CarryCorp
+delivers as a first-class `storage` circuit (`deliverToStorage`) with no spill
+ceiling — so the bank actually accumulates the expansion CAPEX instead of
+stalling at `STORAGE_BANK = 10000`.
+
+The **surplus withdrawal** now closes the loop (measured live failure it fixes:
+100k+ banked while the controller upgraded at ~3.3 e/t): once a room's bank
+passes `WARCHEST_TARGET = EXPANSION_CAPEX + 2·EXPANSION_SAFETY_RESERVE`
+(`economy/bank.ts`), the surplus joins the solve as a transient **bank source**
+at the storage position (`detectBankSources`, `flowAdapter.ts`), that room's
+storage sink is dropped from the problem (structural anti-pump), and the
+controller cap lifts back to mop-up. The runtime chain scales from the same
+primitives: `ControllerFeederCorp` fields shuttles to `feederRelayRate(banked)`
+and upgrader sizing (`upgraderAllocation`, `UpgradingCorp.ts`) uses the relay
+as its inflow term while a feeder actively relays a surplus. Bank flows never
+materialize as CarryCorp commissions (`commissionPlan.ts` skips `bank-*`) —
+the tender (bank → spawn/extensions) and feeder (bank → controller input) own
+those legs. The draw tapers linearly (`surplus/150`, capped 20 e/t), so the
+bank settles AT the warchest with everything above it flowing to the
+controller — an equilibrium, not a mode switch.
+
+Companion fixes in the same change: the controller drop-off container jumps
+the construction ladder in the surplus regime (`ConstructionCorp.ts` rung 1.7 —
+a bare drop tile decays ~2 e/t under a 30 e/t relay), and stocks inside the
+FEEDER-MANAGED controller bucket (Chebyshev ≤ 3 of an owned controller, only
+while `controllerFeederActive`) are excluded from scavenge detection
+(`excludeControllerBucket`, `scavenge.ts`) so the upgraders' buffer can never
+be re-planned as supply while the feeder would just refill it. Pre-feeder the
+drop-off stays scavengeable — it is the colony's overflow buffer there, and
+recapturing over-spill into construction is load-bearing (measured:
+unconditional exclusion dropped fid-t4-preramped gross fidelity 72% → 53%,
+5.5 e/t rotting on the ground).
+
+What remains is the *income-dip response* — nothing feeds builders from the
+bank, and the planner still never treats the bank as supply when income
+collapses while the bank is BELOW the warchest (the `bankDrawRate` design
+below).
+**Priority:** P1 (remaining shortfall half: P2 — the surplus half removed the
+main live bleed).
 
 ## Goal
 

--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -19,6 +19,7 @@ import { MAX_BUILDERS } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
 import { carryPartsFor, SOURCE_RATE, sustainableConsumptionRate } from "../economy/primitives";
+import { spendableBankSurplus } from "../economy/bank";
 import { evaluateRoadRoute, RoadRouteSpec, UNMAINTAINED_ROAD_LIFE } from "../economy/roadEconomics";
 import { bestAdjacentTile, controllerInputSpot, coreDepot, sourceHarvestSpot } from "./nodeEnergy";
 
@@ -604,6 +605,22 @@ export class ConstructionCorp extends Corp {
       const depot = this.findMissingCoreDepot(room);
       if (depot) {
         this.placeSite(room, depot.x, depot.y, STRUCTURE_CONTAINER);
+        return;
+      }
+    }
+
+    // 1.7 Controller container JUMPS the queue in the surplus-spend regime
+    //     (spec 03 withdrawal): with the warchest full, the feeder relays the
+    //     bank draw plus the upgrade target through the drop-off - 30+ e/t
+    //     across a bare tile whose pile decays ~2 e/t forever. The 5k
+    //     container pays for itself in ~2500 ticks and every rung below waits
+    //     one 5k build. While the warchest is still FILLING the ladder is
+    //     unchanged (rung 3 below) - cons-ext-before-ctrl-container and
+    //     cons-link-core-first pin that ordering.
+    if (containersOpen && room.storage?.my && spendableBankSurplus(room.storage.store.energy ?? 0) > 0) {
+      const ctrlContainer = this.findMissingControllerContainer(room);
+      if (ctrlContainer) {
+        this.placeSite(room, ctrlContainer.x, ctrlContainer.y, STRUCTURE_CONTAINER);
         return;
       }
     }

--- a/src/corps/ControllerFeederCorp.ts
+++ b/src/corps/ControllerFeederCorp.ts
@@ -24,7 +24,7 @@ import { Position } from "../types/Position";
 import { CoreDepot, coreDepot, controllerInputSpot } from "./nodeEnergy";
 import { travelTo, travelToBypass } from "./movement";
 import { carryPartsFor } from "../economy/primitives";
-import { STORAGE_UPGRADE_TARGET } from "../economy/flowAdapter";
+import { feederRelayRate } from "../economy/bank";
 
 export interface SerializedControllerFeederCorp extends SerializedCorp {
   spawnId: string;
@@ -40,7 +40,8 @@ export interface SerializedControllerFeederCorp extends SerializedCorp {
 const CONTROLLER_FEED_TARGET = 2000;
 
 /**
- * ControllerFeederCorp fields one feeder that shuttles storage -> controller input.
+ * ControllerFeederCorp fields the shuttle fleet (usually one feeder; more only
+ * while a bank surplus is being drawn down) that relays storage -> controller input.
  */
 export class ControllerFeederCorp extends Corp {
   private spawnId: string;
@@ -183,10 +184,16 @@ export class ControllerFeederCorp extends Corp {
   }
 
   /**
-   * Demand one feeder once a storage bank exists and the room produces energy.
-   * NON-blocking infrastructure: until it spawns, room.memory.controllerFeederActive
+   * Demand feeders once a storage bank exists and the room produces energy.
+   * NON-blocking infrastructure: until one spawns, room.memory.controllerFeederActive
    * stays false and the haulers feed the controller directly, so nothing is starved.
-   * Sized to sustain the upgrade target over the bank->controller round trip.
+   * Sized to sustain the RELAY RATE (economy/bank.feederRelayRate) over the
+   * bank->controller round trip: the save-regime upgrade target while the
+   * warchest fills - one shuttle, exactly as before - plus the surplus draw
+   * once the bank is full, fielding additional shuttles when one body cannot
+   * physically move the flow (a 35 e/t relay is ~27 CARRY across a 15-tile
+   * leg; pretending one 13-CARRY feeder covers it would starve the upgraders
+   * the plan just scaled up).
    */
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
@@ -196,15 +203,18 @@ export class ControllerFeederCorp extends Corp {
     if (!controller) return [];
     if (!(room.storage && room.storage.my)) return []; // no bank yet -> haulers feed the controller directly
     if (!this.roomHasMiner(room)) return []; // infrastructure follows income
-    if (this.getFeeders().length >= 1) return []; // one feeder per room is enough
 
-    // Balanced 1:1 body sized to sustain the upgrade target over the round trip
-    // (the feeder travels, unlike the parked extension tender). The storage sits by
+    // Balanced 1:1 body sized to sustain the relay over the round trip (the
+    // feeder travels, unlike the parked extension tender). The storage sits by
     // the spawn, so the spawn->controller distance approximates the bank->controller leg.
+    const banked = room.storage.store.energy ?? 0;
     const distance = spawn.pos.getRangeTo(controller.pos);
     const PART_PAIR = 100; // CARRY + MOVE
     const maxCarry = Math.max(1, Math.min(Math.floor(ctx.energyCapacity / PART_PAIR), 25));
-    const carry = Math.max(1, Math.min(Math.ceil(carryPartsFor(STORAGE_UPGRADE_TARGET, distance) * 1.2), maxCarry));
+    const neededCarry = Math.max(1, Math.ceil(carryPartsFor(feederRelayRate(banked), distance) * 1.2));
+    const wantedFeeders = Math.ceil(neededCarry / maxCarry);
+    if (this.getFeeders().length >= wantedFeeders) return [];
+    const carry = Math.min(neededCarry, maxCarry);
 
     return [
       {

--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -16,6 +16,7 @@ import { CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
 import { effectiveLife, staffsPost, sustainableConsumptionRate } from "../economy/primitives";
+import { bankSurplusRate, feederRelayRate } from "../economy/bank";
 import { travelTicksPerTile } from "./economics";
 
 /** Safety bound on upgraders per controller (prevents a swarm if an allocation goes stale). */
@@ -50,6 +51,34 @@ export function upgraderTargetCount(
   const rclCap = (controllerLevel ?? 99) <= 2 ? RCL2_UPGRADER_CAP : UPGRADER_COUNT_CAP;
   const byAllocation = Math.ceil(allocated / Math.max(1, affordableWork));
   return Math.max(1, Math.min(UPGRADER_COUNT_CAP, rclCap, parkingTiles || UPGRADER_COUNT_CAP, byAllocation));
+}
+
+/**
+ * The energy/tick the upgrader fleet is sized to consume (pure, unit-tested):
+ * STOCK-GROUNDED sizing (owner doctrine 2026-07-10) - the stock at the work
+ * site drained over a creep generation, plus what measurably flows in - capped
+ * by the plan's allocation so upgraders never out-eat what the solver routes.
+ *
+ * The inflow term is the anti-downgrade trickle (2)... UNLESS the room's bank
+ * is in SURPLUS and a feeder is actively relaying it (bankedBehindFeeder is
+ * the storage's energy when `controllerFeederActive`, null otherwise). Then
+ * the relay rate (economy/bank.feederRelayRate - the same primitive that
+ * sizes the feeder fleet) is the real inflow, and the fleet scales up to the
+ * plan. This is the consumption half of the spec-03 surplus draw: while the
+ * warchest FILLS the sip keeps the bank accumulating (the pinned save
+ * regime); once it is FULL the windfall doctrine applies - "a windfall ->
+ * consumers scale up to eat it" - which a feeder-capped 2000 input stock
+ * otherwise hides (measured live: 100k banked, upgraders sized to ~3.3 e/t).
+ */
+export function upgraderAllocation(
+  planAllocated: number,
+  stock: number | null,
+  bankedBehindFeeder: number | null
+): number {
+  if (stock === null) return planAllocated;
+  const surplusRelay = bankedBehindFeeder !== null && bankSurplusRate(bankedBehindFeeder) > 0;
+  const inflow = surplusRelay ? feederRelayRate(bankedBehindFeeder!) : 2;
+  return Math.max(2, Math.min(planAllocated, sustainableConsumptionRate(stock, inflow)));
 }
 
 /**
@@ -355,18 +384,19 @@ export class UpgradingCorp extends Corp {
     const base = this.sinkAllocation && this.sinkAllocation.allocated > 0 ? this.sinkAllocation.allocated : 2;
     const planAllocated = spawn ? this.effectiveAllocated(spawn.room, base) : base;
     // STOCK-GROUNDED sizing (owner doctrine 2026-07-10): the upgrader fleet is
-    // sized to the energy ACTUALLY at the controller side - banked stock
-    // drained over a creep lifetime - not to the goal plan's allocation. The
-    // plan says what SHOULD flow here; the stock is what DID. Under-delivery
-    // keeps upgraders minimal (spawn capacity stays on the supply side, macro:
-    // income first); accumulated savings scale them up to be spent. Floored
-    // at the anti-downgrade reserve so the controller is never abandoned, and
-    // capped by the plan so upgraders never out-eat what the solver routes.
-    // No visible controller (harness stubs, degenerate rooms): the stock is
-    // unmeasurable, so trust the plan rather than clamping to the floor.
+    // sized to the energy ACTUALLY at the controller side - stock drained over
+    // a creep lifetime plus the measured-shape inflow - not to the goal plan's
+    // allocation (see upgraderAllocation). Under-delivery keeps upgraders
+    // minimal (spawn capacity stays on the supply side, macro: income first);
+    // a full warchest behind an active feeder relay scales them up to be
+    // spent. No visible controller (harness stubs, degenerate rooms): the
+    // stock is unmeasurable, so trust the plan rather than clamping to the floor.
     const stock = spawn && controller ? this.controllerSideStock(controller) : null;
-    const allocated =
-      stock === null ? planAllocated : Math.max(2, Math.min(planAllocated, sustainableConsumptionRate(stock, 2)));
+    const bankedBehindFeeder =
+      spawn && spawn.room.memory.controllerFeederActive && spawn.room.storage?.my
+        ? spawn.room.storage.store.energy ?? 0
+        : null;
+    const allocated = upgraderAllocation(planAllocated, stock, bankedBehindFeeder);
 
     // One upgrader can only afford so many WORK parts at the current capacity;
     // a single small upgrader cannot consume a whole source. Size the COUNT to

--- a/src/economy/bank.ts
+++ b/src/economy/bank.ts
@@ -1,0 +1,129 @@
+/**
+ * @fileoverview Storage bank draw-down - the SURPLUS half of spec 03.
+ *
+ * The storage is the colony's warchest: it accumulates the expansion CAPEX
+ * (economy/expansion.ts capital trigger) while income exceeds consumption.
+ * Without a withdrawal half the bank only ever grows - measured live: 100k+
+ * banked while the controller upgraded at the anti-downgrade trickle, because
+ * the planner never treats banked energy as supply.
+ *
+ * The mechanism rides the existing TRANSIENT SOURCE machinery (scavenging):
+ * a bank above the warchest target is a ground-stock-shaped supply at the
+ * storage position - no miner, a bounded drain rate, re-detected every solve
+ * so the draw tapers to zero as the bank approaches the target. The taper IS
+ * the hysteresis: no mode flag, no flapping at the boundary.
+ *
+ * Anti-pump is STRUCTURAL (spec 03): whenever a room emits a bank source, that
+ * room's storage sink is dropped from the problem for that solve
+ * (flowAdapter.buildColonyProblem), so bank->storage circulation is impossible
+ * by construction, not by tuning. Bank flows also never materialize as
+ * CarryCorp haulers (commissionPlan skips them): the depot movers already run
+ * the last legs - the extension tender (bank -> spawn/extensions) and the
+ * ControllerFeederCorp (bank -> controller input) - and both size themselves
+ * from these same primitives, so plan and runtime cannot drift apart.
+ *
+ * @module economy/bank
+ */
+
+import "../types/Memory"; // Memory augmentation for the expansion import below
+import { Position } from "../types/Position";
+import { PlannerSource } from "./CorpPlanner";
+import { EXPANSION_CAPEX, EXPANSION_SAFETY_RESERVE } from "./expansion";
+
+/**
+ * Banked energy the colony KEEPS: the expansion campaign's full cost plus a
+ * doubled safety reserve. Derived - never a second hardcoded number - because
+ * a drain floor below EXPANSION_CAPEX + EXPANSION_SAFETY_RESERVE would pin the
+ * bank under the capital trigger and permanently disable expansion (the exact
+ * failure mode the pre-#98 STORAGE_BANK=10k spill caused). The extra reserve
+ * is headroom so consumer-fleet attrition lag (upgraders sized at the peak
+ * draw outliving the taper) can overshoot the target without dipping the bank
+ * below the trigger.
+ */
+export const WARCHEST_TARGET = EXPANSION_CAPEX + 2 * EXPANSION_SAFETY_RESERVE;
+
+/** Target ticks to drain the spendable surplus - mirrors SCAVENGE_DRAIN_TICKS. */
+export const SURPLUS_DRAIN_TICKS = 150;
+
+/**
+ * Cap on the surplus draw (energy/tick) so a 100k bank doesn't commission an
+ * absurd consumer fleet - mirrors MAX_SCAVENGE_RATE. A capped draw just takes
+ * more solves to drain; the bank persists and is re-detected each cycle.
+ */
+export const MAX_SURPLUS_DRAW = 20;
+
+/**
+ * Energy/tick the planner keeps routing to the controller ONCE THE ROOM HAS A
+ * STORAGE bank that is still FILLING; everything above this banks in the
+ * storage instead of piling at the controller drop-off (owner 2026-07-11:
+ * "once we have a storage, that should be a good destination for a lot of
+ * drop-offs, and we deliver it locally from there"). This is the deposit half
+ * of the storage bank: the durable storage - not the controller - soaks the
+ * surplus, so it can accumulate the expansion CAPEX the capital trigger saves
+ * toward. Once the bank passes WARCHEST_TARGET the cap lifts entirely (the
+ * controller reverts to mopping up) and the surplus draws back out - see
+ * bankSurplusRate.
+ *
+ * It is the tuning knob for the upgrade-vs-bank balance: raise it to favour
+ * faster RCL, lower it to save harder. Below this rate the controller still
+ * mops up ALL income (its capacity exceeds the supply, so nothing is left to
+ * bank), so a lean single/2-source room upgrades exactly as before and only
+ * genuine surplus banks. Comfortably above the anti-downgrade reserve so
+ * upgrading always makes progress. Without a storage there is nowhere durable
+ * to bank surplus, so the controller keeps absorbing the whole remainder
+ * (pre-storage behaviour is unchanged). Lives here (not flowAdapter) so the
+ * feeder and upgrader sizing derive from the same module without cycles.
+ */
+export const STORAGE_UPGRADE_TARGET = 15;
+
+/** Banked energy above the warchest target - what the colony may spend. */
+export function spendableBankSurplus(banked: number): number {
+  return Math.max(0, banked - WARCHEST_TARGET);
+}
+
+/**
+ * Energy/tick of bank surplus the colony spends this plan cycle: drain the
+ * spendable surplus over SURPLUS_DRAIN_TICKS, capped at MAX_SURPLUS_DRAW.
+ * Zero while the warchest is still filling. Linear in the surplus, so the
+ * draw tapers smoothly to zero at the target instead of flapping a regime
+ * switch around it.
+ */
+export function bankSurplusRate(banked: number): number {
+  return Math.min(MAX_SURPLUS_DRAW, spendableBankSurplus(banked) / SURPLUS_DRAIN_TICKS);
+}
+
+/**
+ * Energy/tick the ControllerFeederCorp must relay storage -> controller input:
+ * the save-regime upgrade target plus whatever surplus the plan is drawing.
+ * The feeder sizes its shuttle fleet to this, and upgrader sizing uses it as
+ * the inflow term while a feeder actively relays a surplus - all three
+ * consumers of "how fast does bank energy reach the controller" read this one
+ * function, so they cannot disagree.
+ */
+export function feederRelayRate(banked: number): number {
+  return STORAGE_UPGRADE_TARGET + bankSurplusRate(banked);
+}
+
+/** Stable bank source id for a room (one storage per room): "bank-W1N1". */
+export function bankSourceId(roomName: string): string {
+  return `bank-${roomName}`;
+}
+
+/**
+ * Turn a room's banked storage energy into a transient PlannerSource (no
+ * miner; bounded drain), or null while the warchest is still filling. The
+ * planner then routes it like any scavenge stock - value routing, not a
+ * script, decides where the surplus goes.
+ */
+export function bankToTransientSource(roomName: string, storagePos: Position, banked: number): PlannerSource | null {
+  const rate = bankSurplusRate(banked);
+  if (rate <= 0) return null;
+  return {
+    id: bankSourceId(roomName),
+    nodeId: `${roomName}-bank`,
+    pos: storagePos,
+    rate,
+    maxMiners: 0,
+    transient: true
+  };
+}

--- a/src/economy/commissionPlan.ts
+++ b/src/economy/commissionPlan.ts
@@ -75,6 +75,13 @@ export function commissionsFromPlan(problem: ColonyProblem, plan: ColonyPlan): C
     routesBySource.set(h.sourceId, list);
   }
   for (const [sourceId, routes] of routesBySource) {
+    // Bank sources (spec 03 withdrawal) get NO transport commission: the depot
+    // movers already run those legs - the extension tender (bank -> spawn) and
+    // the ControllerFeederCorp (bank -> controller input, sized to the same
+    // economy/bank primitives). A CarryCorp here would fight the feeder for
+    // the input tile and, via the feeder-active redirect, pump the load
+    // straight back into the storage it withdrew from.
+    if (sourceId.startsWith("bank-")) continue;
     const src = sourceById.get(sourceId);
     const flow = routes.reduce((s, r) => s + r.flowRate, 0);
     out.push({

--- a/src/economy/flowAdapter.ts
+++ b/src/economy/flowAdapter.ts
@@ -41,37 +41,30 @@ import { commissionsFromPlan } from "./commissionPlan";
 export const ANTI_DOWNGRADE_RESERVE = 2;
 
 /**
- * Energy/tick the planner keeps routing to the controller ONCE THE ROOM HAS A
- * STORAGE bank; everything above this banks in the storage instead of piling at
- * the controller drop-off (owner 2026-07-11: "once we have a storage, that should
- * be a good destination for a lot of drop-offs, and we deliver it locally from
- * there"). This is the deposit half of the storage bank: the durable storage - not
- * the controller - soaks the surplus, so it can accumulate the expansion CAPEX the
- * capital trigger saves toward (bankedEnergy reads storage; STORAGE_BANK spill to
- * the controller otherwise capped it at 10k, below EXPANSION_CAPEX).
- *
- * It is the tuning knob for the upgrade-vs-bank balance: raise it to favour faster
- * RCL, lower it to save harder. Below this rate the controller still mops up ALL
- * income (its capacity exceeds the supply, so nothing is left to bank), so a lean
- * single/2-source room upgrades exactly as before and only genuine surplus banks.
- * Comfortably above the anti-downgrade reserve so upgrading always makes progress.
- * Without a storage there is nowhere durable to bank surplus, so the controller
- * keeps absorbing the whole remainder (pre-storage behaviour is unchanged).
+ * The save-regime controller cap lives in economy/bank.ts with the rest of the
+ * warchest primitives (the feeder and upgrader sizing derive from the same
+ * module); re-exported here for the existing import sites.
  */
-export const STORAGE_UPGRADE_TARGET = 15;
+export { STORAGE_UPGRADE_TARGET } from "./bank";
+import { STORAGE_UPGRADE_TARGET, bankToTransientSource } from "./bank";
 
 /**
  * Routing capacity for a controller sink. Uncapped (mops up the remainder) until
- * the controller's room has a storage bank, then bounded to {@link
- * STORAGE_UPGRADE_TARGET} so the surplus banks in storage. Pure over the set of
- * storage-bearing rooms so it is unit-testable without Game.
+ * the controller's room has a storage bank that is still FILLING, then bounded to
+ * {@link STORAGE_UPGRADE_TARGET} so the surplus banks in storage. Once the bank
+ * passes the warchest target (the room appears in `surplusRooms` because a bank
+ * source was emitted for it - see detectBankSources), the cap lifts and the
+ * controller reverts to mopping up: the warchest is full, so there is nothing
+ * left to save for and the surplus draw needs somewhere to land. Pure over the
+ * two room sets so it is unit-testable without Game.
  */
 export function controllerRoutingCapacity(
   sink: { position: Position },
   totalSupply: number,
-  roomsWithStorage: ReadonlySet<string>
+  roomsWithStorage: ReadonlySet<string>,
+  surplusRooms: ReadonlySet<string> = new Set()
 ): number {
-  if (roomsWithStorage.has(sink.position.roomName)) {
+  if (roomsWithStorage.has(sink.position.roomName) && !surplusRooms.has(sink.position.roomName)) {
     return Math.max(STORAGE_UPGRADE_TARGET, ANTI_DOWNGRADE_RESERVE);
   }
   return Math.max(totalSupply, 1);
@@ -220,6 +213,26 @@ export function detectLinkHaulPositions(graph: FlowGraph): Map<string, Position>
 }
 
 /**
+ * Detect SURPLUS storage banks across visible owned rooms and turn each into a
+ * transient bank source at its storage position (spec 03 withdrawal, surplus
+ * half - see economy/bank.ts). A bank still filling its warchest emits nothing:
+ * the deposit half (STORAGE_UPGRADE_TARGET cap) keeps accumulating it. Live
+ * default for buildColonyProblem; injectable for tests.
+ */
+export function detectBankSources(): PlannerSource[] {
+  if (typeof Game === "undefined" || !Game.rooms) return [];
+  const out: PlannerSource[] = [];
+  for (const roomName in Game.rooms) {
+    const storage = Game.rooms[roomName].storage;
+    if (!storage || !storage.my) continue;
+    const banked = storage.store.energy ?? 0;
+    const source = bankToTransientSource(roomName, { x: storage.pos.x, y: storage.pos.y, roomName }, banked);
+    if (source) out.push(source);
+  }
+  return out;
+}
+
+/**
  * Sources whose haul route ConstructionCorp has fully paved, by GAME id (the
  * `paved` receipt in room memory - see RoomMemory.roadRoutes). Graph source ids
  * carry a "source-" prefix, so callers match with stripFlowId. Live default for
@@ -242,7 +255,8 @@ export function buildColonyProblem(
   dist: ColonyProblem["dist"] = pathDistance,
   transientSources: PlannerSource[] = detectTransientSources(),
   linkHaulPos: Map<string, Position> = detectLinkHaulPositions(graph),
-  pavedSources: Set<string> = detectPavedSources()
+  pavedSources: Set<string> = detectPavedSources(),
+  bankSources: PlannerSource[] = detectBankSources()
 ): ColonyProblem {
   const spawns: PlannerSpawn[] = graph.getSinks("spawn").map(s => ({ id: s.id, pos: s.position }));
 
@@ -261,8 +275,10 @@ export function buildColonyProblem(
   // the shard1 stress fixture: unhauled piles grew, inflating supply until
   // the plan wanted build 140 e/t / 316 CARRY against 20 e/t of mining).
   const minedSupply = sources.reduce((sum, s) => sum + s.rate, 0);
-  // Ground stocks join as miner-less transient sources (scavenging).
-  sources.push(...transientSources);
+  // Ground stocks join as miner-less transient sources (scavenging), and so
+  // do SURPLUS storage banks (spec 03 withdrawal: a bank above its warchest
+  // is a ground-stock-shaped supply at the storage position).
+  sources.push(...transientSources, ...bankSources);
   const totalSupply = sources.reduce((sum, s) => sum + s.rate, 0);
 
   // Rooms whose bank is built: their controller stops mopping up the surplus so
@@ -271,11 +287,17 @@ export function buildColonyProblem(
   for (const sink of graph.getSinks()) {
     if (sink.type === "storage") roomsWithStorage.add(sink.position.roomName);
   }
+  // Rooms whose bank is in SURPLUS (a bank source was emitted): the warchest is
+  // full, so the controller cap lifts AND - the structural anti-pump (spec 03) -
+  // the room's storage sink is dropped from this solve entirely. Withdrawing
+  // and depositing in the same plan is impossible by construction.
+  const surplusRooms = new Set(bankSources.map(b => b.pos.roomName));
 
   const sinks: PlannerSink[] = [];
   for (const sink of graph.getSinks()) {
     const kind = toSinkKind(sink.type);
     if (!kind) continue;
+    if (kind === "storage" && surplusRooms.has(sink.position.roomName)) continue;
     sinks.push({
       id: sink.id,
       kind,
@@ -310,7 +332,7 @@ export function buildColonyProblem(
             Math.max(minedSupply, 1)
           : kind === "storage"
           ? Math.max(totalSupply, 1) // soak excess
-          : controllerRoutingCapacity(sink, totalSupply, roomsWithStorage), // controller: mops up the remainder, unless a storage banks the surplus
+          : controllerRoutingCapacity(sink, totalSupply, roomsWithStorage, surplusRooms), // controller: mops up the remainder, unless a still-filling storage banks the surplus
       reserve: kind === "controller" ? ANTI_DOWNGRADE_RESERVE : undefined
     });
   }
@@ -338,6 +360,10 @@ function publishRoster(plan: ReturnType<typeof planColony>): void {
     corps.push({ kind: "mine", work: Math.max(1, Math.ceil(m.rate / 2)), sourceId: m.sourceId, spawnId: m.spawnId });
   }
   for (const h of plan.haulers) {
+    // Bank flows are executed by the depot movers (tender/feeder), never by a
+    // spawnable CarryCorp - publishing them would be permanent phantom variance
+    // for the plan-vs-fielded gauges.
+    if (h.sourceId.startsWith("bank-")) continue;
     corps.push({
       kind: "haul",
       carry: Math.max(1, Math.ceil(h.carryParts)),
@@ -373,9 +399,10 @@ export function solveWithCorpPlanner(
   graph: FlowGraph,
   tick = 0,
   dist: ColonyProblem["dist"] = pathDistance,
-  transientSources: PlannerSource[] = detectTransientSources()
+  transientSources: PlannerSource[] = detectTransientSources(),
+  bankSources: PlannerSource[] = detectBankSources()
 ): FlowSolution {
-  return solveColony(graph, tick, dist, transientSources).solution;
+  return solveColony(graph, tick, dist, transientSources, bankSources).solution;
 }
 
 /**
@@ -392,9 +419,17 @@ export function solveColony(
   graph: FlowGraph,
   tick = 0,
   dist: ColonyProblem["dist"] = pathDistance,
-  transientSources: PlannerSource[] = detectTransientSources()
+  transientSources: PlannerSource[] = detectTransientSources(),
+  bankSources: PlannerSource[] = detectBankSources()
 ): { solution: FlowSolution; commissions: Commission[] } {
-  const problem = buildColonyProblem(graph, dist, transientSources, detectLinkHaulPositions(graph));
+  const problem = buildColonyProblem(
+    graph,
+    dist,
+    transientSources,
+    detectLinkHaulPositions(graph),
+    detectPavedSources(),
+    bankSources
+  );
   const plan = planColony(problem);
   publishRoster(plan);
   const commissions = commissionsFromPlan(problem, plan);

--- a/src/economy/scavenge.ts
+++ b/src/economy/scavenge.ts
@@ -25,6 +25,25 @@ import { PlannerSource } from "./CorpPlanner";
 /** Below this many energy a stock is left to opportunistic source-hauler pickup. */
 export const SCAVENGE_THRESHOLD = 750;
 
+/**
+ * Chebyshev range around an OWNED controller inside which energy is the
+ * upgraders' working buffer, never scavenge supply - WHILE A FEEDER RELAY
+ * MANAGES IT (room.memory.controllerFeederActive). Matches upgrade range and
+ * the input-spot buffer scan (controllerInputSpot resolves containers within
+ * range 3): under a feeder the input stock is held at CONTROLLER_FEED_TARGET,
+ * so planning it as supply commissions haulers to carry the upgraders' own
+ * buffer home again - an energy circle the feeder immediately refills, paying
+ * transport overhead in both directions forever.
+ *
+ * The gate matters: BEFORE a room has a feeder (no storage - RCL2/3), the
+ * controller drop-off is the colony's OVERFLOW buffer (haulers spill the
+ * post-spawn surplus there), and scavenging the overgrown pile back into
+ * construction is load-bearing recapture - excluding it unconditionally left
+ * the spill to rot (measured: fid-t4-preramped gross fidelity 72% -> 53%,
+ * decay 5.5 e/t of 20 mined).
+ */
+export const CONTROLLER_BUCKET_RANGE = 3;
+
 /** Target ticks to clear a stock - sets how much hauling we throw at it. */
 export const SCAVENGE_DRAIN_TICKS = 150;
 
@@ -76,6 +95,18 @@ export function collectStocks(finds: EnergyFind[], threshold = SCAVENGE_THRESHOL
     .map(f => ({ id: stockId(f.pos), pos: f.pos, amount: f.energy }));
 }
 
+/**
+ * Drop finds inside the controller bucket (see CONTROLLER_BUCKET_RANGE). Pure:
+ * pass null when the room has no owned controller and everything is kept.
+ */
+export function excludeControllerBucket(finds: EnergyFind[], controllerPos: Position | null): EnergyFind[] {
+  if (!controllerPos) return finds;
+  return finds.filter(
+    f =>
+      Math.max(Math.abs(f.pos.x - controllerPos.x), Math.abs(f.pos.y - controllerPos.y)) > CONTROLLER_BUCKET_RANGE
+  );
+}
+
 /** Turn a detected stock into a transient PlannerSource (no miner; bounded drain rate). */
 export function stockToTransientSource(stock: GroundStock, nodeId: string): PlannerSource {
   return {
@@ -94,7 +125,7 @@ export function stockToTransientSource(stock: GroundStock, nodeId: string): Plan
  * functions above.
  */
 export function detectRoomStocks(room: Room, threshold = SCAVENGE_THRESHOLD): GroundStock[] {
-  const finds: EnergyFind[] = [];
+  let finds: EnergyFind[] = [];
 
   for (const r of room.find(FIND_DROPPED_RESOURCES)) {
     if (r.resourceType === RESOURCE_ENERGY && r.amount > 0) {
@@ -109,6 +140,17 @@ export function detectRoomStocks(room: Room, threshold = SCAVENGE_THRESHOLD): Gr
     const energy = ruin.store[RESOURCE_ENERGY];
     if (energy > 0) finds.push({ pos: ruin.pos, energy });
   }
+
+  // The FEEDER-MANAGED controller bucket is not scavengeable: that energy
+  // already reached its destination and the feeder would just refill it (the
+  // circle). Without a feeder the drop-off is the overflow buffer and stays
+  // scavengeable - recapture of over-spill into construction is load-bearing.
+  const ctrl = room.controller;
+  const feederManaged = !!ctrl && ctrl.my && !!room.memory.controllerFeederActive;
+  finds = excludeControllerBucket(
+    finds,
+    feederManaged ? { x: ctrl!.pos.x, y: ctrl!.pos.y, roomName: room.name } : null
+  );
 
   // ONE SUMMED STOCK (owner 2026-07-10): a pile sitting on/next to a stocked
   // container is a single quantity of energy for planning - the container's

--- a/test/grid/baseline.json
+++ b/test/grid/baseline.json
@@ -106,6 +106,7 @@
     "cons-one-site-at-a-time": "pass",
     "cons-ext-before-ctrl-container": "pass",
     "cons-ctrl-container-last": "pass",
+    "cons-ctrl-container-surplus-first": "pass",
     "cons-pocket-container-exact-tile": "pass",
     "haul-t4-tender-death-failsafe": "pass",
     "cons-capguard-storage-rcl4": "pass",

--- a/test/grid/baseline.json
+++ b/test/grid/baseline.json
@@ -35,6 +35,7 @@
     "spawn-timer-survives-busy-spawn": "pass",
     "spawn-hold-full-miner-regrow": "pass",
     "haul-t4-feeder-fields-for-bank": "pass",
+    "haul-t4-bank-surplus-upgrades": "pass",
     "spawn-first-miner-outranks-all": "pass",
     "haul-t4-tender-bus-regime": "pass",
     "spawn-blocking-hauler-spawns-at-min-scaled": "pass",

--- a/test/grid/cells/construction.ts
+++ b/test/grid/cells/construction.ts
@@ -657,6 +657,43 @@ export function buildConstructionT4Cells(): GridCell[] {
     },
 
     {
+      // Spec 03 surplus regime: with the warchest FULL (40k > 27,650), the
+      // feeder relays 30+ e/t through the drop-off, and a bare tile decays
+      // ~2 e/t forever - so the 5k controller container JUMPS the extension
+      // grind. The normal ladder (extensions first, controller container last)
+      // stays pinned by cons-ext-before-ctrl-container and
+      // cons-ctrl-container-last: a FILLING bank (e.g. cons-link-core-first's
+      // 10k) never hoists.
+      id: "cons-ctrl-container-surplus-first",
+      tier: 4,
+      avenue: "construction",
+      window: 60,
+      rooms: { home: twoSourceRoom },
+      bot: { x: 25, y: 25 },
+      controller: { level: 4 },
+      structures: [
+        { type: "storage", x: 24, y: 25, energy: 40_000 },
+        { type: "container", x: 15, y: 29, energy: 0 },
+        { type: "container", x: 35, y: 29, energy: 0 },
+        // extensions BELOW the RCL4 cap: the extension rung still wants more,
+        // which is exactly what the hoist must outrank in surplus
+        ...EXT_20.slice(0, 10).map((p) => ({ type: "extension", x: p.x, y: p.y, energy: 50 })),
+      ],
+      creeps: quiet(),
+      assertions: [
+        eventually("the drop-off container jumps the extension grind", (s) =>
+          sites(s).some(
+            (o: any) =>
+              o.structureType === "container" && Math.max(Math.abs(o.x - 25), Math.abs(o.y - 10)) <= 2
+          )
+        ),
+        always("no extension site while the surplus pours over a bare drop-off", (s) =>
+          !sites(s).some((o: any) => o.structureType === "extension")
+        ),
+      ],
+    },
+
+    {
       // Link anchoring: at RCL5 with zero links, the CORE link beside the
       // storage wins - even though both sources are >8 range and eligible.
       id: "cons-link-core-first",

--- a/test/grid/cells/hauling.ts
+++ b/test/grid/cells/hauling.ts
@@ -472,6 +472,83 @@ export function buildHaulingT4Cells(): GridCell[] {
         }),
       ],
     },
+
+    {
+      // Spec 03 withdrawal, the SURPLUS half: a bank ABOVE the warchest target
+      // (WARCHEST_TARGET = 27,650; 60k staged) is spendable, and the spend is
+      // EMERGENT - the bank joins the solve as a transient source, the
+      // controller reverts to mop-up, and the feeder relay + stock-grounded
+      // upgraders drain it into controller progress. The staged fleet mirrors
+      // haul-t4-storage-bank-and-spill (whose 9,800 bank pins the SAVE regime:
+      // that cell's >=6000 floor must stay green - a filling warchest never
+      // drains).
+      id: "haul-t4-bank-surplus-upgrades",
+      tier: 4,
+      avenue: "logistics",
+      window: 250,
+      rooms: { home: tenderRoom },
+      bot: { x: 25, y: 25 },
+      controller: { level: 4 },
+      structures: [
+        { type: "storage", x: 24, y: 24, energy: 60_000 },
+        { type: "container", x: 24, y: 41, energy: 1800 },
+        { type: "container", x: 25, y: 12, energy: 2000 },
+        ...EXT_ROW.map((p) => ({ type: "extension", x: p.x, y: p.y, energy: 50 })),
+      ],
+      // Staged consumers so the drain is observable inside the window: three
+      // parked upgraders (18 WORK) ring the input container; the stale feeder
+      // and tender are adopted like the sibling cells' staging.
+      creeps: tenderCreeps([
+        {
+          name: "fd",
+          x: 23,
+          y: 25,
+          body: ["carry", "carry", "carry", "carry", "move", "move", "move", "move"],
+          memory: { workType: "feed", corpId: "stale-feeder" },
+        },
+        {
+          name: "u1",
+          x: 24,
+          y: 11,
+          body: ["work", "work", "work", "work", "work", "work", "carry", "carry", "carry", "move", "move"],
+          memory: { workType: "upgrade", corpId: "stale-upgrading", working: false, upgradeSpot: { x: 24, y: 11 } },
+        },
+        {
+          name: "u2",
+          x: 26,
+          y: 11,
+          body: ["work", "work", "work", "work", "work", "work", "carry", "carry", "carry", "move", "move"],
+          memory: { workType: "upgrade", corpId: "stale-upgrading", working: false, upgradeSpot: { x: 26, y: 11 } },
+        },
+        {
+          name: "u3",
+          x: 24,
+          y: 13,
+          body: ["work", "work", "work", "work", "work", "work", "carry", "carry", "carry", "move", "move"],
+          memory: { workType: "upgrade", corpId: "stale-upgrading", working: false, upgradeSpot: { x: 24, y: 13 } },
+        },
+      ]),
+      assertions: [
+        eventually("the bank draws down toward the warchest", (s) => {
+          const st = s.objects().find((o: any) => o.type === "storage");
+          return !!st && (st.store?.energy ?? 0) <= 58_500;
+        }),
+        always("the bank never materializes a CarryCorp (depot movers own the legs)", (s) =>
+          !JSON.stringify(s.memory?.commissionedCorps ?? {}).includes("carry-bank-")
+        ),
+        eventually("the feeder relays the surplus to the controller input", (s) => {
+          const creeps = s.memory?.creeps ?? {};
+          for (const name in creeps) {
+            if (creeps[name]?.lastDeliver?.to === "controller-input") return true;
+          }
+          return false;
+        }),
+        eventually("the surplus becomes controller progress", (s) => {
+          const ctrl = s.objects().find((o: any) => o.type === "controller");
+          return !!ctrl && (ctrl.progress ?? 0) >= 500;
+        }),
+      ],
+    },
   ];
 }
 

--- a/test/unit/corps/upgraderTargetCount.test.ts
+++ b/test/unit/corps/upgraderTargetCount.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
 import "../../../src/types/Memory";
-import { upgraderTargetCount } from "../../../src/corps/UpgradingCorp";
+import { upgraderAllocation, upgraderTargetCount } from "../../../src/corps/UpgradingCorp";
+import { WARCHEST_TARGET, feederRelayRate } from "../../../src/economy/bank";
+import { sustainableConsumptionRate } from "../../../src/economy/primitives";
 
 /**
  * The upgrader COUNT ceiling. Sized to consume the controller allocation, but
@@ -37,5 +39,45 @@ describe("upgraderTargetCount", () => {
 
   it("always fields at least one upgrader so the controller is never abandoned", () => {
     expect(upgraderTargetCount(0, 2, PARKING, 2)).to.equal(1);
+  });
+});
+
+/**
+ * The upgrader ENERGY allocation (stock-grounded sizing, spec 03 surplus half).
+ * The plan says what SHOULD flow to the controller; the work-site stock says
+ * what DID. While the warchest fills, upgraders sip (floor trickle inflow) so
+ * the bank actually accumulates; once the bank is in SURPLUS and a feeder
+ * relays it, the relay rate is real measured-shape inflow and the fleet scales
+ * up to planAllocated - that is what spends a 100k bank on the controller.
+ */
+describe("upgraderAllocation", () => {
+  it("trusts the plan when the stock is unmeasurable (no controller in view)", () => {
+    expect(upgraderAllocation(12, null, null)).to.equal(12);
+  });
+
+  it("save regime: sips from the local stock while the warchest fills", () => {
+    // 2000 staged at the input, bank below target behind the feeder: the
+    // pinned pre-surplus behavior - 2 + 2000/1500 ~ 3.33, NOT the plan's 15.
+    expect(upgraderAllocation(15, 2000, 10_000)).to.be.closeTo(sustainableConsumptionRate(2000, 2), 1e-9);
+  });
+
+  it("save regime: no feeder relay behind the stock behaves identically", () => {
+    expect(upgraderAllocation(15, 2000, null)).to.be.closeTo(sustainableConsumptionRate(2000, 2), 1e-9);
+  });
+
+  it("surplus regime: the feeder relay is real inflow and the fleet scales to the plan", () => {
+    const banked = WARCHEST_TARGET + 100_000;
+    // plan opened to 30 by the bank draw; relay 35 + stock term clears it, so
+    // the PLAN caps the fleet (planner authority), not the drip-fed stock.
+    expect(upgraderAllocation(30, 2000, banked)).to.be.closeTo(30, 1e-9);
+    // and the uncapped sizing is exactly the shared-primitives formula
+    expect(upgraderAllocation(999, 2000, banked)).to.be.closeTo(
+      sustainableConsumptionRate(2000, feederRelayRate(banked)),
+      1e-9
+    );
+  });
+
+  it("never sizes below the anti-downgrade floor", () => {
+    expect(upgraderAllocation(15, 0, null)).to.equal(2);
   });
 });

--- a/test/unit/economy/bank.test.ts
+++ b/test/unit/economy/bank.test.ts
@@ -1,0 +1,88 @@
+import { expect } from "chai";
+import {
+  WARCHEST_TARGET,
+  SURPLUS_DRAIN_TICKS,
+  MAX_SURPLUS_DRAW,
+  STORAGE_UPGRADE_TARGET,
+  spendableBankSurplus,
+  bankSurplusRate,
+  feederRelayRate,
+  bankSourceId,
+  bankToTransientSource
+} from "../../../src/economy/bank";
+import { EXPANSION_CAPEX, EXPANSION_SAFETY_RESERVE } from "../../../src/economy/expansion";
+
+// Spec 03 (storage draw-down), the SURPLUS half: once the bank holds the
+// expansion warchest, everything above it is spendable on the controller.
+// These are exact-value pins on the pure primitives every consumer (planner
+// adapter, feeder, upgrader sizing) must derive from - one home, no drift.
+describe("economy/bank - the surplus spend primitives", () => {
+  describe("WARCHEST_TARGET", () => {
+    it("sits ABOVE the expansion capital trigger, derived from its constants", () => {
+      // A drain floor below EXPANSION_CAPEX + EXPANSION_SAFETY_RESERVE would
+      // permanently disable expansion (the pre-#98 STORAGE_BANK=10k failure
+      // mode). The target must be derived, never a second hardcoded number.
+      expect(WARCHEST_TARGET).to.be.greaterThan(EXPANSION_CAPEX + EXPANSION_SAFETY_RESERVE);
+    });
+  });
+
+  describe("spendableBankSurplus", () => {
+    it("is zero at or below the warchest target", () => {
+      expect(spendableBankSurplus(0)).to.equal(0);
+      expect(spendableBankSurplus(WARCHEST_TARGET)).to.equal(0);
+      expect(spendableBankSurplus(WARCHEST_TARGET - 1)).to.equal(0);
+    });
+    it("is exactly the stock above the target", () => {
+      expect(spendableBankSurplus(WARCHEST_TARGET + 4000)).to.equal(4000);
+    });
+  });
+
+  describe("bankSurplusRate", () => {
+    it("draws nothing while the warchest is still filling", () => {
+      expect(bankSurplusRate(WARCHEST_TARGET)).to.equal(0);
+      expect(bankSurplusRate(10_000)).to.equal(0);
+    });
+    it("drains the surplus over the target horizon", () => {
+      expect(bankSurplusRate(WARCHEST_TARGET + 1500)).to.be.closeTo(1500 / SURPLUS_DRAIN_TICKS, 1e-9);
+    });
+    it("caps the draw so a 100k bank doesn't ask for an absurd consumer fleet", () => {
+      expect(bankSurplusRate(WARCHEST_TARGET + 100_000)).to.equal(MAX_SURPLUS_DRAW);
+    });
+    it("tapers to zero approaching the target (no flapping at the boundary)", () => {
+      expect(bankSurplusRate(WARCHEST_TARGET + 150)).to.be.closeTo(1, 1e-9);
+    });
+  });
+
+  describe("feederRelayRate", () => {
+    it("relays exactly the save-regime upgrade target while the warchest fills", () => {
+      expect(feederRelayRate(10_000)).to.equal(STORAGE_UPGRADE_TARGET);
+    });
+    it("adds the surplus draw on top once the warchest is full", () => {
+      expect(feederRelayRate(WARCHEST_TARGET + 3000)).to.be.closeTo(
+        STORAGE_UPGRADE_TARGET + bankSurplusRate(WARCHEST_TARGET + 3000),
+        1e-9
+      );
+    });
+  });
+
+  describe("bankToTransientSource", () => {
+    const pos = { x: 24, y: 24, roomName: "W1N1" };
+
+    it("emits nothing while the warchest is still filling", () => {
+      expect(bankToTransientSource("W1N1", pos, WARCHEST_TARGET)).to.equal(null);
+      expect(bankToTransientSource("W1N1", pos, 5000)).to.equal(null);
+    });
+
+    it("emits a miner-less transient source at the storage, sized to the surplus draw", () => {
+      const banked = WARCHEST_TARGET + 3000;
+      const src = bankToTransientSource("W1N1", pos, banked)!;
+      expect(src).to.not.equal(null);
+      expect(src.id).to.equal(bankSourceId("W1N1"));
+      expect(src.id).to.equal("bank-W1N1");
+      expect(src.pos).to.deep.equal(pos);
+      expect(src.rate).to.be.closeTo(bankSurplusRate(banked), 1e-9);
+      expect(src.maxMiners).to.equal(0);
+      expect(src.transient).to.equal(true);
+    });
+  });
+});

--- a/test/unit/economy/flowAdapter.test.ts
+++ b/test/unit/economy/flowAdapter.test.ts
@@ -153,6 +153,121 @@ describe("economy/flowAdapter - CorpPlanner as the FlowSolution authority", () =
   });
 });
 
+// Spec 03 storage draw-down, the SURPLUS half: once a room's bank holds the
+// expansion warchest, the surplus becomes SUPPLY (a miner-less bank source at
+// the storage) and the controller reverts to mopping up - the save-regime
+// STORAGE_UPGRADE_TARGET cap only applies while the warchest is filling.
+// Anti-pump is STRUCTURAL: a room with a bank source has no storage sink in
+// the same solve, so bank->storage circulation is impossible by construction
+// (these tests fail against a naive "just lower the storage value" tuning).
+describe("economy/flowAdapter - storage draw-down: the surplus spend (spec 03)", () => {
+  const g = globalThis as unknown as { Game?: any; Memory?: any };
+  let savedGame: unknown;
+  let savedMemory: unknown;
+
+  beforeEach(() => {
+    savedGame = g.Game;
+    savedMemory = g.Memory;
+    g.Game = { time: 0, getObjectById: () => null, rooms: {}, creeps: {} };
+    g.Memory = {};
+  });
+  afterEach(() => {
+    g.Game = savedGame;
+    g.Memory = savedMemory;
+  });
+
+  const bankSource = (rate: number): PlannerSource => ({
+    id: "bank-W0N0",
+    nodeId: "W0N0-bank",
+    pos: at(6),
+    rate,
+    maxMiners: 0,
+    transient: true
+  });
+
+  it("a surplus bank becomes supply and the controller mops up past the save cap", () => {
+    // 2 sources = 20 e/t mined, plus a 10 e/t bank draw. The spawn takes its
+    // ~10 overhead; the controller absorbs the remaining 20 - ABOVE the
+    // save-regime STORAGE_UPGRADE_TARGET (15) that a filling warchest imposes.
+    const graph = graphOf([homeNodeWithStorage(5), sourceNode("s1", 15), sourceNode("s2", 25)]);
+    const sol = solveWithCorpPlanner(graph, 0, manhattan, [], [bankSource(10)]);
+
+    const ctrl = sol.sinkAllocations.find(a => a.sinkType === "controller")!;
+    expect(ctrl.allocated).to.be.closeTo(20, 1e-9);
+    // the bank flow is planned (it appears as a hauling flow toward a sink)...
+    expect(sol.haulers.some(h => h.fromId === "bank-W0N0")).to.equal(true);
+    // ...but the bank is never mined
+    expect(sol.miners.map(m => m.sourceId)).to.not.include("bank-W0N0");
+  });
+
+  it("anti-pump is structural: the surplus room's storage sink is dropped from the solve", () => {
+    const graph = graphOf([homeNodeWithStorage(5), sourceNode("s1", 15), sourceNode("s2", 25)]);
+    const sol = solveWithCorpPlanner(graph, 0, manhattan, [], [bankSource(10)]);
+
+    // the sink is ABSENT - not merely allocated zero
+    expect(sol.sinkAllocations.some(a => a.sinkType === "storage")).to.equal(false);
+    expect(sol.haulers.some(h => h.toId.startsWith("storage-"))).to.equal(false);
+  });
+
+  it("bank flows never materialize as CarryCorp commissions (the depot movers own those legs)", async () => {
+    const { solveColony } = await import("../../../src/economy/flowAdapter");
+    const graph = graphOf([homeNodeWithStorage(5), sourceNode("s1", 15), sourceNode("s2", 25)]);
+    const { commissions } = solveColony(graph, 0, manhattan, [], [bankSource(10)]);
+
+    // No transport commission for the bank: the extension tender (bank->spawn)
+    // and the controller feeder (bank->controller input) already run those legs.
+    expect(commissions.some(c => c.corpId === "carry-bank-W0N0")).to.equal(false);
+    // The consumers still see the full flow: the upgrade commission is sized to
+    // the opened controller allocation, bank draw included.
+    const upgrade = commissions.find(c => c.kind === "upgrade")!;
+    expect(upgrade.consumes.energyRate).to.be.closeTo(20, 1e-9);
+    // and the published roster carries no phantom bank haulers either
+    const roster = (g.Memory as { economyPlan?: { corps: Array<{ kind: string; fromId?: string }> } }).economyPlan!;
+    expect(roster.corps.some(c => c.kind === "haul" && c.fromId === "bank-W0N0")).to.equal(false);
+  });
+
+  it("a filling warchest keeps today's save regime: cap 15, surplus banks", () => {
+    // No bank source injected (bank below the warchest target): behavior is
+    // EXACTLY the pinned deposit half - controller capped, storage soaks.
+    const graph = graphOf([
+      homeNodeWithStorage(5),
+      sourceNode("s1", 15),
+      sourceNode("s2", 25),
+      sourceNode("s3", 35)
+    ]);
+    const sol = solveWithCorpPlanner(graph, 0, manhattan, [], []);
+
+    const ctrl = sol.sinkAllocations.find(a => a.sinkType === "controller")!;
+    const store = sol.sinkAllocations.find(a => a.sinkType === "storage")!;
+    expect(ctrl.allocated).to.be.closeTo(15, 1e-9);
+    expect(store.allocated).to.be.closeTo(5, 1e-9);
+  });
+
+  it("detectBankSources reads live storages: surplus rooms emit, filling rooms don't", async () => {
+    const { detectBankSources } = await import("../../../src/economy/flowAdapter");
+    const { WARCHEST_TARGET, bankSurplusRate } = await import("../../../src/economy/bank");
+    const storageAt = (roomName: string, energy: number) => ({
+      controller: { my: true },
+      storage: {
+        my: true,
+        pos: { x: 24, y: 24, roomName },
+        store: { energy, getUsedCapacity: () => energy }
+      }
+    });
+    g.Game.rooms = {
+      W0N0: storageAt("W0N0", WARCHEST_TARGET + 3000), // surplus: draws
+      W1N0: storageAt("W1N0", 9800) // still filling: saves
+    };
+
+    const banks = detectBankSources();
+    expect(banks).to.have.length(1);
+    expect(banks[0].id).to.equal("bank-W0N0");
+    expect(banks[0].rate).to.be.closeTo(bankSurplusRate(WARCHEST_TARGET + 3000), 1e-9);
+    expect(banks[0].transient).to.equal(true);
+    expect(banks[0].maxMiners).to.equal(0);
+  });
+});
+
 describe("economy/flowAdapter - paved-source detection", () => {
   const g = globalThis as unknown as { Game?: unknown };
   let savedGame: unknown;

--- a/test/unit/economy/scavenge.test.ts
+++ b/test/unit/economy/scavenge.test.ts
@@ -3,6 +3,8 @@ import {
   scavengeRate,
   collectStocks,
   stockToTransientSource,
+  excludeControllerBucket,
+  CONTROLLER_BUCKET_RANGE,
   EnergyFind,
   SCAVENGE_THRESHOLD,
   SCAVENGE_DRAIN_TICKS,
@@ -36,6 +38,35 @@ describe("economy/scavenge", () => {
     it("respects a custom threshold", () => {
       expect(collectStocks([find("x", 200)], 100)).to.have.length(1);
       expect(collectStocks([find("x", 50)], 100)).to.have.length(0);
+    });
+  });
+
+  describe("excludeControllerBucket", () => {
+    const ctrl = { x: 25, y: 8, roomName: ROOM };
+
+    it("drops finds inside the controller bucket (the upgraders' working buffer)", () => {
+      // The FEEDER-MANAGED drop-off is DELIVERED energy waiting to be
+      // upgraded - planning it as scavenge supply commissions haulers to carry
+      // the upgraders' own buffer home while the feeder refills it (a circle).
+      // The caller (detectRoomStocks) passes the controller pos only while
+      // room.memory.controllerFeederActive - pre-feeder, the drop-off is the
+      // colony's overflow buffer and its recapture is load-bearing.
+      const inBucket = { energy: 2000, pos: { x: 25 + CONTROLLER_BUCKET_RANGE, y: 8, roomName: ROOM } };
+      const outside = { energy: 2000, pos: { x: 25 + CONTROLLER_BUCKET_RANGE + 1, y: 8, roomName: ROOM } };
+      const kept = excludeControllerBucket([inBucket, outside], ctrl);
+      expect(kept).to.deep.equal([outside]);
+    });
+
+    it("keeps everything when no feeder-managed controller pos is given", () => {
+      const finds = [find("pile", 2000, 26)];
+      expect(excludeControllerBucket(finds, null)).to.deep.equal(finds);
+    });
+
+    it("covers upgrade range: matches the input-spot buffer scan", () => {
+      // controllerInputSpot resolves buffers within range 3; the exclusion must
+      // cover at least that zone or a pile can be both counted as upgrader
+      // stock AND hauled away as scavenge.
+      expect(CONTROLLER_BUCKET_RANGE).to.be.at.least(3);
     });
   });
 

--- a/test/unit/framework/controllerFeederKind.test.ts
+++ b/test/unit/framework/controllerFeederKind.test.ts
@@ -154,6 +154,67 @@ describe("controller-feeder kind on the corp framework (rungs 2-4)", () => {
     expect(demands[0].producesIncome).to.equal(false);
   });
 
+  it("sizes the relay to the save-regime target while the warchest fills", async () => {
+    const { STORAGE_UPGRADE_TARGET } = await import("../../../src/economy/bank");
+    const { carryPartsFor } = await import("../../../src/economy/primitives");
+    const store: CorpStore = new Map();
+    materializeCommissions(planCommissions(world).commissions, store);
+    const corp = store.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+
+    installRoom(true, true); // bank at 5000: well below the warchest target
+    const demands = corp.getSpawnDemand({ energyCapacity: 1300 } as never);
+    expect(demands).to.have.length(1);
+    // spawn (25,25) -> controller (40,25): range 15. Sized to sustain the
+    // save-regime 15 e/t over the round trip, exactly as before the surplus
+    // mechanism existed - a filling warchest must see NO behavior change.
+    const expected = Math.ceil(carryPartsFor(STORAGE_UPGRADE_TARGET, 15) * 1.2);
+    expect(demands[0].bodyParam).to.equal(expected);
+  });
+
+  it("scales the relay (more feeders) once the bank is in surplus", async () => {
+    const { WARCHEST_TARGET, feederRelayRate } = await import("../../../src/economy/bank");
+    const { carryPartsFor } = await import("../../../src/economy/primitives");
+    const store: CorpStore = new Map();
+    materializeCommissions(planCommissions(world).commissions, store);
+    const corp = store.get("controllerFeeder-W1N1")!.corp as ControllerFeederCorp;
+
+    installRoom(true, true);
+    const banked = WARCHEST_TARGET + 100_000; // deep surplus: draw at its cap
+    (Game.rooms[HOME] as { storage: { store: { energy: number } } }).storage.store.energy = banked;
+
+    // needed carry across the relay exceeds one max body (13 CARRY at 1300
+    // capacity), so the corp fields a second (and third) feeder rather than
+    // pretending one shuttle can move 35 e/t.
+    const needed = Math.ceil(carryPartsFor(feederRelayRate(banked), 15) * 1.2);
+    const maxCarry = 13;
+    const wantedFeeders = Math.ceil(needed / maxCarry);
+    expect(wantedFeeders).to.be.greaterThan(1); // the scenario actually exercises scaling
+
+    const demands = corp.getSpawnDemand({ energyCapacity: 1300 } as never);
+    expect(demands).to.have.length(1);
+    expect(demands[0].bodyParam).to.equal(maxCarry);
+
+    // stub live feeders one below the target: still demanding
+    for (let i = 0; i < wantedFeeders - 1; i++) {
+      Game.creeps[`feed${i}`] = {
+        name: `feed${i}`,
+        spawning: false,
+        room: { name: HOME },
+        memory: { corpId: corp.id, workType: "feed" }
+      } as never;
+    }
+    expect(corp.getSpawnDemand({ energyCapacity: 1300 } as never)).to.have.length(1);
+
+    // at the target: satisfied
+    Game.creeps[`feed${wantedFeeders - 1}`] = {
+      name: `feed${wantedFeeders - 1}`,
+      spawning: false,
+      room: { name: HOME },
+      memory: { corpId: corp.id, workType: "feed" }
+    } as never;
+    expect(corp.getSpawnDemand({ energyCapacity: 1300 } as never)).to.have.length(0);
+  });
+
   it("rung 3 - EXECUTE/PERSIST: run() is safe; store round-trips to a fixpoint", () => {
     installRoom(true, true);
     const store: CorpStore = new Map();


### PR DESCRIPTION
Measured live failure: 100k+ banked while the controller upgraded at
~3.3 e/t. Three broken assumptions, one mechanism:

- The planner never treated the bank as supply (supply = mined income +
  scavenge stocks only), so banked energy permanently exited the economy.
- controllerRoutingCapacity capped the controller at STORAGE_UPGRADE_TARGET
  whenever a storage EXISTED, unconditional on its level - the save regime
  had no terminal state.
- Upgrader stock-grounded sizing hardcoded inflow=2 while the feeder held
  the input at 2000, so the windfall doctrine ("consumers scale up to eat
  it") could never see the windfall hiding behind the relay.

The fix rides the existing transient-source machinery: above
WARCHEST_TARGET (= EXPANSION_CAPEX + 2x EXPANSION_SAFETY_RESERVE, derived
so expansion is never starved - economy/bank.ts) the surplus joins the
solve as a miner-less bank source at the storage, that room's storage sink
is DROPPED from the problem (anti-pump structural, not tuned), and the
controller reverts to mop-up. Value routing does the rest; no sink value
changes. The draw tapers linearly (surplus/150, cap 20 e/t), so the bank
settles AT the warchest as an equilibrium, not a mode flag.

Runtime scales from the same primitives: the feeder fields shuttles to
feederRelayRate(banked), upgrader sizing (upgraderAllocation) uses the
relay as inflow while a feeder relays a surplus, and bank flows never
materialize as CarryCorp commissions - the tender and feeder own those
legs (a CarryCorp would fight the feeder for the input tile and pump loads
back into the storage via the feeder-active redirect).

Companion: stocks in a FEEDER-MANAGED controller bucket are excluded from
scavenge detection (the feeder would just refill them - a transport-paying
circle). Gated on controllerFeederActive: pre-feeder the drop-off is the
colony's overflow buffer and its recapture into construction is
load-bearing (unconditional exclusion measured fid-t4-preramped gross
fidelity 72% -> 53%, 5.5 e/t rotting on the ground).

New grid cell haul-t4-bank-surplus-upgrades (bank drains toward the
warchest, no carry-bank corp ever, feeder relays, controller progresses);
save-regime cells (haul-t4-storage-bank-and-spill 9800 bank) unchanged and
green. Full grid: T0-T4 fully green, BOT LEVEL 4, ratchet clean. Unit 731
passing; flow-handoff + runt-economy + storage-depot green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015m5ZsUHcf4T9J5Xzo7dx1J