### PR TITLE
Fix scavenger stock detection to include container contents

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -369,30 +369,7 @@ export class CarryCorp extends Corp {
       creep.say("pickup");
     }
     if (!creep.memory.working && creep.store.getFreeCapacity() === 0) {
-      creep.memory.working = true;
-      // Each hauler has ONE permanent home circuit (assigned in proportion to the
-      // flow solver's per-sink allocations - see assignCircuit), so it is a dumb
-      // automaton on a defined route, not re-rolling its destination every trip.
-      // Re-assign only when it has no circuit or its route's flow has vanished
-      // (e.g. construction finished).
-      const home = creep.memory.homeSink as LocalSink | undefined;
-      if (!home || !this.committedSinkHasFlow(home) || this.foundingUnderstaffed(home)) {
-        this.assignCircuit(creep);
-      }
-      // This trip's destination is decided ONCE, here: top up a hungry spawn
-      // (the critical bottleneck, under-weighted by its tiny flow share), else run
-      // the home circuit. Fixed for the whole trip, so no mid-route thrash.
-      const homeSink = creep.memory.homeSink as LocalSink;
-      creep.memory.deliverSinkId = homeSink !== "spawn" && this.spawnNetworkCritical(room) ? "spawn" : homeSink;
-      creep.say(
-        creep.memory.deliverSinkId === "controller"
-          ? "→ctrl"
-          : creep.memory.deliverSinkId === "founding"
-          ? "→found"
-          : creep.memory.deliverSinkId === "storage"
-          ? "→bank"
-          : "→spawn"
-      );
+      this.depart(creep, room);
     }
 
     // A clean bus: it fills completely at its source stop, then runs the route and
@@ -405,6 +382,39 @@ export class CarryCorp extends Corp {
     } else {
       this.pickupEnergy(creep, room);
     }
+  }
+
+  /**
+   * Send a loaded hauler out on its delivery leg: commit to a home circuit and fix
+   * this trip's destination. Called on the normal full-load state flip, and by the
+   * scavenger path when its transient stock runs dry mid-load (a drained stock can
+   * never top the hauler up to full, so waiting for the flip would freeze it).
+   */
+  private depart(creep: Creep, room: Room): void {
+    creep.memory.working = true;
+    // Each hauler has ONE permanent home circuit (assigned in proportion to the
+    // flow solver's per-sink allocations - see assignCircuit), so it is a dumb
+    // automaton on a defined route, not re-rolling its destination every trip.
+    // Re-assign only when it has no circuit or its route's flow has vanished
+    // (e.g. construction finished).
+    const home = creep.memory.homeSink as LocalSink | undefined;
+    if (!home || !this.committedSinkHasFlow(home) || this.foundingUnderstaffed(home)) {
+      this.assignCircuit(creep);
+    }
+    // This trip's destination is decided ONCE, here: top up a hungry spawn
+    // (the critical bottleneck, under-weighted by its tiny flow share), else run
+    // the home circuit. Fixed for the whole trip, so no mid-route thrash.
+    const homeSink = creep.memory.homeSink as LocalSink;
+    creep.memory.deliverSinkId = homeSink !== "spawn" && this.spawnNetworkCritical(room) ? "spawn" : homeSink;
+    creep.say(
+      creep.memory.deliverSinkId === "controller"
+        ? "→ctrl"
+        : creep.memory.deliverSinkId === "founding"
+        ? "→found"
+        : creep.memory.deliverSinkId === "storage"
+        ? "→bank"
+        : "→spawn"
+    );
   }
 
   // ===========================================================================
@@ -559,13 +569,23 @@ export class CarryCorp extends Corp {
       return;
     }
 
-    // A scavenger draws from a ground stock (tombstone / ruin / pile); an ordinary
-    // hauler from its source's output spot (container / drop pile / wait tile). The
-    // stock spot is null once drained - the scavenger then just carries home what
-    // it has and stands down (re-detection drops the stock next economy rebuild).
+    // A scavenger draws from a ground stock (tombstone / ruin / pile / summed
+    // container); an ordinary hauler from its source's output spot (container /
+    // drop pile / wait tile). The stock spot is null once drained - the scavenger
+    // then carries home what it has and stands down (re-detection drops the stock
+    // next economy rebuild).
     if (this.isScavenger()) {
       const spot = scavengeSpot(targetPos);
-      if (spot) workSpot(creep, spot, "collect");
+      if (spot) {
+        workSpot(creep, spot, "collect");
+      } else if (creep.store[RESOURCE_ENERGY] > 0) {
+        // Drained stock, partial load aboard: DEPART NOW. The clean-bus state
+        // machine only flips to delivering on a FULL load, and a stock that no
+        // longer exists can never provide the top-up - waiting for the flip
+        // froze the scavenger beside its dead stock for the rest of its life
+        // (observed live 2026-07-17, 744/800 aboard).
+        this.depart(creep, room);
+      }
       return;
     }
     workSpot(creep, sourcePickupSpot(targetPos), "collect");

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -219,9 +219,10 @@ export function sourcePickupSpot(sourcePos: RoomPosition): EnergySpot {
 
 /**
  * Where a scavenger collects a ground stock: a tombstone or ruin holding energy
- * (withdraw), else a dropped pile (pick up), at or beside `pos`. Returns null when
- * the stock is gone - the scavenger has drained it and can stand down. Position-
- * based so it serves the stock by where it was detected.
+ * (withdraw), else a dropped pile (pick up) or the container the stock was summed
+ * with (withdraw), at or beside `pos`. Returns null when the stock is gone - the
+ * scavenger has drained it and can stand down. Position-based so it serves the
+ * stock by where it was detected.
  */
 export function scavengeSpot(pos: RoomPosition): EnergySpot | null {
   const tomb = pos
@@ -237,7 +238,29 @@ export function scavengeSpot(pos: RoomPosition): EnergySpot | null {
   const pile = pos
     .findInRange(FIND_DROPPED_RESOURCES, 1, { filter: r => r.resourceType === RESOURCE_ENERGY && r.amount > 0 })
     .sort((a, b) => b.amount - a.amount)[0];
-  if (pile) return { pos: pile.pos };
+
+  // A stock detected ON a container tile INCLUDES that container's contents
+  // (detectRoomStocks' one-summed-stock rule), so the container is part of this
+  // scavenger's stock and must be reachable - otherwise a stock whose bulk sits
+  // in the container is mostly invisible to its own scavenger (observed live
+  // 2026-07-17: a full source container's overflow pile was promoted to a 2000+
+  // stock, and the scavenger stood beside the container forever, seeing only
+  // the per-tick trickle). Range 0 mirrors detection exactly: a container on a
+  // NEIGHBOURING tile was never summed into this stock and belongs to some
+  // other route - drawing from it would steal off-route energy.
+  //
+  // Pile-vs-container priority is sourcePickupSpot's rule: the decaying pile
+  // first, EXCEPT while the container is full - then the pile is overflow in
+  // progress, re-created every tick, and pile-first locks the scavenger into
+  // ~10-energy pickups while the stock's bulk sits in the container. One
+  // withdraw fills the scavenger AND re-opens capacity for the next drops.
+  const container = pos.findInRange(FIND_STRUCTURES, 0, {
+    filter: s => s.structureType === STRUCTURE_CONTAINER && (s as StructureContainer).store[RESOURCE_ENERGY] > 0
+  })[0] as StructureContainer | undefined;
+  const containerFull = container !== undefined && (container.store.getFreeCapacity(RESOURCE_ENERGY) ?? 0) === 0;
+
+  if (pile && !containerFull) return { pos: pile.pos };
+  if (container) return { pos: container.pos, structure: container };
 
   return null;
 }

--- a/test/unit/corps/scavengePickup.test.ts
+++ b/test/unit/corps/scavengePickup.test.ts
@@ -6,19 +6,26 @@ import { scavengeSpot, workSpot, EnergySpot } from "../../../src/corps/nodeEnerg
 (global as any).FIND_DROPPED_RESOURCES = 106;
 (global as any).FIND_TOMBSTONES = 118;
 (global as any).FIND_RUINS = 123;
+(global as any).FIND_STRUCTURES = 107;
+(global as any).STRUCTURE_CONTAINER = "container";
 
 const cheby = (a: { x: number; y: number }, b: { x: number; y: number }): number =>
   Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
 
 interface Stocked {
   pos: { x: number; y: number };
-  store?: Record<string, number>;
+  store?: { energy: number; getFreeCapacity?: (r?: string) => number };
   resourceType?: string;
   amount?: number;
+  structureType?: string;
 }
 
-/** A mock RoomPosition standing among tombstones / ruins / piles. */
-function mockPos(x: number, y: number, world: { tombs?: Stocked[]; ruins?: Stocked[]; piles?: Stocked[] }) {
+/** A mock RoomPosition standing among tombstones / ruins / piles / containers. */
+function mockPos(
+  x: number,
+  y: number,
+  world: { tombs?: Stocked[]; ruins?: Stocked[]; piles?: Stocked[]; containers?: Stocked[] }
+) {
   const self = { x, y };
   return {
     x,
@@ -30,7 +37,9 @@ function mockPos(x: number, y: number, world: { tombs?: Stocked[]; ruins?: Stock
           ? world.tombs
           : type === (global as any).FIND_RUINS
             ? world.ruins
-            : world.piles;
+            : type === (global as any).FIND_STRUCTURES
+              ? world.containers
+              : world.piles;
       return (list ?? []).filter(o => cheby(self, o.pos) <= range && (!opts?.filter || opts.filter(o)));
     }
   } as any;
@@ -39,6 +48,11 @@ function mockPos(x: number, y: number, world: { tombs?: Stocked[]; ruins?: Stock
 const tomb = (x: number, y: number, energy: number): Stocked => ({ pos: { x, y }, store: { energy } });
 const ruin = (x: number, y: number, energy: number): Stocked => ({ pos: { x, y }, store: { energy } });
 const pile = (x: number, y: number, amount: number): Stocked => ({ pos: { x, y }, resourceType: "energy", amount });
+const container = (x: number, y: number, energy: number, capacity = 2000): Stocked => ({
+  structureType: "container",
+  pos: { x, y },
+  store: { energy, getFreeCapacity: () => capacity - energy }
+});
 
 describe("scavengeSpot (stock pickup resolution)", () => {
   it("withdraws from a tombstone when one holds energy", () => {
@@ -66,6 +80,62 @@ describe("scavengeSpot (stock pickup resolution)", () => {
 
   it("returns null when the stock is gone (scavenger can stand down)", () => {
     expect(scavengeSpot(mockPos(25, 25, {}))).to.equal(null);
+  });
+
+  // A stock detected ON a container tile includes the container's contents
+  // (detectRoomStocks' one-summed-stock rule), so the scavenger must be able to
+  // withdraw from that container - not just chase the ground portion. This is
+  // the live 2026-07-17 incident: a full source container's overflow pile was
+  // promoted to a 2000+ stock, and the scavenger stood beside the container
+  // inching along on the ~10-energy per-tick trickle it could see.
+  describe("container-backed stocks (the summed container is reachable)", () => {
+    it("withdraws from a FULL container instead of chasing the overflow trickle", () => {
+      const c = container(25, 25, 2000); // 2000/2000 - no free capacity
+      const trickle = pile(25, 25, 12); // this tick's spill
+      const spot = scavengeSpot(mockPos(25, 25, { piles: [trickle], containers: [c] }));
+
+      expect(spot).to.not.equal(null);
+      expect(spot!.structure).to.equal(c);
+      expect(spot!.pos).to.equal(c.pos);
+    });
+
+    it("drains the pile before a NON-full container (decay-first doctrine)", () => {
+      const c = container(25, 25, 1200); // 800 free - drops are being absorbed
+      const p = pile(25, 25, 300);
+      const spot = scavengeSpot(mockPos(25, 25, { piles: [p], containers: [c] }));
+
+      expect(spot!.structure).to.equal(undefined);
+      expect(spot!.pos).to.equal(p.pos);
+    });
+
+    it("withdraws the stock's container remainder once the pile is gone", () => {
+      const c = container(25, 25, 1500);
+      const spot = scavengeSpot(mockPos(25, 25, { containers: [c] }));
+
+      expect(spot).to.not.equal(null);
+      expect(spot!.structure).to.equal(c);
+    });
+
+    it("still prefers a tombstone over the container (decays fastest)", () => {
+      const t = tomb(25, 25, 100);
+      const c = container(25, 25, 2000);
+      const spot = scavengeSpot(mockPos(25, 25, { tombs: [t], containers: [c] }));
+
+      expect(spot!.withdrawFrom).to.equal(t);
+    });
+
+    it("ignores a container on an ADJACENT tile (not part of the summed stock)", () => {
+      // Detection only sums a container at range 0 of the find; a neighbouring
+      // container belongs to some other route (e.g. a commissioned source's) and
+      // drawing from it would steal off-route energy.
+      const c = container(26, 25, 2000);
+      expect(scavengeSpot(mockPos(25, 25, { containers: [c] }))).to.equal(null);
+    });
+
+    it("ignores an EMPTY container (stock gone, scavenger stands down)", () => {
+      const c = container(25, 25, 0);
+      expect(scavengeSpot(mockPos(25, 25, { containers: [c] }))).to.equal(null);
+    });
   });
 });
 

--- a/test/unit/corps/scavengerContainerStock.test.ts
+++ b/test/unit/corps/scavengerContainerStock.test.ts
@@ -1,0 +1,167 @@
+import { expect } from "chai";
+import "../../../src/types/Memory"; // load the CreepMemory/Memory type augmentation
+import { CarryCorp } from "../../../src/corps/CarryCorp";
+import { HaulerAssignment } from "../../../src/flow/FlowTypes";
+import { Game as MockGame, MockRoomPosition } from "../mock";
+
+/**
+ * The live 2026-07-17 incident, driven end to end through CarryCorp.pickupEnergy:
+ * a full source container's overflow pile was promoted to a scavenge stock
+ * (detectRoomStocks sums a container's contents into a find ON its tile), and the
+ * commissioned scavenger - hauler-g-7-38-..., 744/800 aboard - stood beside the
+ * 2000-energy container for good. Two distinct failures compound:
+ *
+ *   1. scavengeSpot never resolved containers, so the scavenger could only see
+ *      the ~10-energy per-tick overflow trickle of a stock whose bulk sat in the
+ *      container (the same trickle-lock #104 fixed for source haulers).
+ *   2. When the visible ground stock ran dry, the scavenger froze: the clean-bus
+ *      state machine only departs on a FULL load, and a drained stock can never
+ *      top it up - the promised "carries home what it has" had no code behind it.
+ */
+
+// Minimal Screeps globals the pickup path touches.
+(global as any).RESOURCE_ENERGY = "energy";
+(global as any).FIND_SOURCES = 105;
+(global as any).FIND_DROPPED_RESOURCES = 106;
+(global as any).FIND_STRUCTURES = 107;
+(global as any).FIND_TOMBSTONES = 118;
+(global as any).FIND_RUINS = 123;
+(global as any).STRUCTURE_CONTAINER = "container";
+
+const cheby = (a: { x: number; y: number }, b: { x: number; y: number }): number =>
+  Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+
+/** The stuff standing in the room around the stock, consulted by findInRange. */
+const world: { tombs: any[]; ruins: any[]; piles: any[]; structures: any[] } = {
+  tombs: [],
+  ruins: [],
+  piles: [],
+  structures: []
+};
+
+/** A RoomPosition whose findInRange sees the mock world above. pickupEnergy
+ * constructs the stock position itself (new RoomPosition(...)), so the WORLD
+ * has to live behind the global class rather than in a hand-built object. */
+class StockRoomPosition extends MockRoomPosition {
+  public findInRange(type: number, range: number, opts?: { filter?: (o: any) => boolean }): any[] {
+    const list =
+      type === (global as any).FIND_TOMBSTONES
+        ? world.tombs
+        : type === (global as any).FIND_RUINS
+          ? world.ruins
+          : type === (global as any).FIND_DROPPED_RESOURCES
+            ? world.piles
+            : type === (global as any).FIND_STRUCTURES
+              ? world.structures
+              : [];
+    return list.filter(o => cheby(this, o.pos) <= range && (!opts?.filter || opts.filter(o)));
+  }
+}
+
+function fullContainer(x: number, y: number, energy: number, capacity = 2000): any {
+  return {
+    structureType: "container",
+    pos: { x, y },
+    store: { energy, getFreeCapacity: () => capacity - energy }
+  };
+}
+
+/** The commissioned scavenge route for the stock at W1N1 (37,38). */
+function scavCorp(): CarryCorp {
+  const corp = new CarryCorp("W1N1-hauling-7-38", "spawn1");
+  corp.setHaulerAssignments([
+    {
+      edgeId: "scavenge-W1N1-37-38|spawn-spawn1",
+      fromId: "scavenge-W1N1-37-38", // CommissionedHauler.sourceId: the raw stock id
+      toId: "spawn-spawn1",
+      distance: 20,
+      carryParts: 16,
+      flowRate: 5,
+      spawnCostPerTick: 0,
+      spawnId: "spawn-spawn1"
+    } as HaulerAssignment
+  ]);
+  return corp;
+}
+
+/** A scavenger standing beside the stock tile, partway through filling up. */
+function scavenger(energy: number, capacity = 800): any {
+  const calls = { withdrawTarget: undefined as any, pickups: 0, said: [] as string[] };
+  return {
+    name: "scav1",
+    room: { name: "W1N1" },
+    pos: new StockRoomPosition(37, 39, "W1N1"),
+    store: { energy, getFreeCapacity: () => capacity - energy },
+    memory: { corpId: "W1N1-hauling-7-38", workType: "haul" },
+    say: (m: string) => calls.said.push(m),
+    withdraw: (t: any) => {
+      calls.withdrawTarget = t;
+      return 0;
+    },
+    pickup: () => {
+      calls.pickups += 1;
+      return 0;
+    },
+    calls
+  };
+}
+
+/** A room whose spawn network is topped up (so no degraded-mode depot refill). */
+const room: any = {
+  name: "W1N1",
+  memory: {},
+  energyAvailable: 300,
+  energyCapacityAvailable: 300,
+  find: () => []
+};
+
+describe("scavenger at a container-backed stock (live incident 2026-07-17)", () => {
+  let prevRoomPosition: any;
+
+  beforeEach(() => {
+    prevRoomPosition = (global as any).RoomPosition;
+    (global as any).RoomPosition = StockRoomPosition;
+    (global as any).Game = { ...MockGame, creeps: {}, time: 100, getObjectById: () => null };
+    world.tombs = [];
+    world.ruins = [];
+    world.piles = [];
+    world.structures = [];
+  });
+
+  afterEach(() => {
+    (global as any).RoomPosition = prevRoomPosition;
+    (global as any).Game = { ...MockGame, creeps: {}, time: 100 };
+  });
+
+  it("withdraws from the FULL container instead of chasing the overflow trickle", () => {
+    const container = fullContainer(37, 38, 2000); // the stock's summed bulk
+    world.structures = [container];
+    world.piles = [{ resourceType: "energy", amount: 12, pos: { x: 37, y: 38 } }]; // this tick's spill
+
+    const creep = scavenger(744);
+    (scavCorp() as any).pickupEnergy(creep, room);
+
+    expect(creep.calls.withdrawTarget, "one withdraw fills the hauler AND reopens container capacity").to.equal(
+      container
+    );
+    expect(creep.calls.pickups, "must not peck at the per-tick trickle").to.equal(0);
+  });
+
+  it("departs with its partial load once the stock is gone, instead of freezing", () => {
+    // Nothing left at the stock: no pile, no tombstone, no container energy.
+    const creep = scavenger(744);
+    (scavCorp() as any).pickupEnergy(creep, room);
+
+    expect(creep.memory.working, "carries home what it has (the stand-down promise)").to.equal(true);
+    expect(creep.memory.deliverSinkId, "runs its normal delivery circuit").to.equal("spawn");
+  });
+
+  it("stays put when the stock is gone and it has nothing aboard", () => {
+    // An empty-handed scavenger has nothing to deliver: it waits for the corp to
+    // dissolve (re-detection drops the stock) and OrphanRescue to collect it.
+    const creep = scavenger(0);
+    (scavCorp() as any).pickupEnergy(creep, room);
+
+    expect(creep.memory.working).to.not.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a live incident (2026-07-17) where scavengers could not access the bulk of energy stored in containers that backed their assigned stocks. When a stock is detected on a container tile, `detectRoomStocks` sums the container's contents into the stock total, but `scavengeSpot` had no way to resolve and withdraw from that container—leaving scavengers to chase only the ~10-energy per-tick overflow pile while the stock's bulk remained inaccessible.

Additionally, fixes a state-machine deadlock where a scavenger with a partial load would freeze if its stock drained mid-fill, since the clean-bus departure logic only triggers on a FULL load.

## Key Changes

- **`scavengeSpot` now resolves containers**: Added container lookup (range 0, matching detection exactly) to the stock resolution logic. Containers are withdrawn from when:
  - The container is full (pile is overflow in progress, re-created every tick)
  - OR no pile exists at the stock location
  - Respects decay-first doctrine: drains piles before non-full containers
  
- **Scavenger departure on drained stock**: Extracted the departure logic into a new `depart()` method and call it when a scavenger's stock is gone but it still carries energy. This allows partial-load scavengers to begin their delivery leg instead of freezing.

- **Test coverage**: Added comprehensive unit tests (`scavengerContainerStock.test.ts`) covering the live incident end-to-end, plus extended `scavengePickup.test.ts` with container-backed stock scenarios.

## Implementation Details

- Container filtering uses `range: 0` to match detection's one-summed-stock rule exactly—adjacent containers belong to other routes and must not be stolen from
- Empty containers are filtered out (stock is gone, scavenger stands down)
- The `depart()` method encapsulates home-circuit assignment and destination-fixing logic, called both on normal full-load flip and on drained-stock early departure
- Scavengers with no load and no stock remain idle (waiting for OrphanRescue collection)

https://claude.ai/code/session_0151RuQxWQtKF65X56PNjaFk