### PR TITLE
Fix stranded-reserver incident: plan-couple targeting, vision-free

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ whose operators are corps. Read order for architecture truth:
 - **staffsPost symmetry**: every consumer of "how many creeps does this post
   have" must use the SAME `staffsPost` lens as the demand side, or newborns
   get recycled at the spawn door (~25t churn loop, measured).
+- **Room state from intel, never creep positions or vision**: a trigger keyed
+  to "one of our creeps is standing there" flaps on every death AND goes blind
+  with the vision the dead creep provided (stranded-reserver incident: target
+  revoked mid-route, the 1300-energy reserver idled out its CLAIM lifetime, 10
+  reserver spawns in 2400 ticks). Durable signals only: the draft plan's
+  commissions (`CorpKind.propose(problem, draft)`) for "do we work this room",
+  the shared `RoomDiscovery` lenses (`isReservableRoom`, `hostileRooms`) for
+  room state — and work()/getSpawnDemand() must read the SAME lens.
 - **Grid staging**: `addBot`'s `gcl` is POINTS, not level (1e6 = GCL 2). The
   mockup db's `$set` with dotted paths (`"store.energy"`) silently NO-OPS —
   write whole objects. Staged storage needs the OWNED schema

--- a/docs/specs/00-corp-framework.md
+++ b/docs/specs/00-corp-framework.md
@@ -74,7 +74,8 @@ export interface CorpKind<C extends Corp = Corp> {
   /** PLAN (pure): propose commissions this kind can fulfil in this world.
    *  Producer/transport/consumer kinds usually return [] here because the
    *  central solver emits them; auxiliary kinds implement their trigger here
-   *  (e.g. reserver: "a miner works an unowned controllered room"). */
+   *  (e.g. reserver: "the draft plan MINES an unowned, controllered room" -
+   *  the DURABLE signal; never live creep positions or room vision). */
   propose(problem: ColonyProblem, plan: ReadonlyDraftPlan): Commission[];
   /** MATERIALIZE: create-or-update the runtime corp for a commission. */
   materialize(c: Commission, existing: C | undefined): C;

--- a/src/corps/ReservationCorp.ts
+++ b/src/corps/ReservationCorp.ts
@@ -6,17 +6,28 @@
  * This is the one genuinely room-specific part of remote mining: a source in an
  * unowned room is throttled to half output unless we hold its controller. A
  * reserver (CLAIM + MOVE) parks on the controller and reserves it continuously.
- * We only bother for rooms we are actually mining - the trigger is "one of our
- * miners is working in an unowned, controllered room" - so the claimer's cost is
- * always set against real extra harvest.
+ *
+ * TARGETING IS COMMISSION-OWNED and vision-free. The kind's propose() derives
+ * target rooms from the draft plan's remote harvest commissions ("the plan
+ * mines this room" - durable across miner deaths), and materialize() refreshes
+ * them here every round, exactly like spawnId. At runtime the targets are
+ * gated by the shared reservability lens (isReservableRoom: live vision when
+ * available, scout intel otherwise). Both work() and getSpawnDemand() read the
+ * SAME reservableTargets() - the staffsPost-symmetry rule.
+ *
+ * NEVER key targeting to live creep positions: "a miner is standing there this
+ * tick" flaps on every miner death, and the dead miner takes the room's vision
+ * with it. Measured live (shard1 t72378345): an in-flight reserver's target
+ * was revoked mid-route the tick its remote's miner died; the 1300-energy
+ * creep idled out its CLAIM lifetime while the room's reservation decayed, and
+ * the corp churned 10 reserver spawns in 2400 ticks.
  *
  * @module corps/ReservationCorp
  */
 
 import { Corp, SerializedCorp } from "./Corp";
-import { hostileRooms } from "../utils/RoomDiscovery";
+import { hostileRooms, isReservableRoom } from "../utils/RoomDiscovery";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
-import { MAX_SCOUT_DISTANCE } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { buildReserverBody } from "../spawn/BodyBuilder";
 import { travelTo } from "./movement";
@@ -26,6 +37,8 @@ import { travelTo } from "./movement";
  */
 export interface SerializedReservationCorp extends SerializedCorp {
   spawnId: string;
+  /** Commission-owned planned remotes; refreshed by materialize every round. */
+  targetRooms?: string[];
 }
 
 /**
@@ -33,6 +46,7 @@ export interface SerializedReservationCorp extends SerializedCorp {
  */
 export class ReservationCorp extends Corp {
   private spawnId: string;
+  private targetRooms: string[] = [];
 
   public constructor(nodeId: string, spawnId: string, customId?: string) {
     super("reservation", nodeId, customId);
@@ -52,6 +66,20 @@ export class ReservationCorp extends Corp {
    */
   public setSpawnId(spawnId: string): void {
     this.spawnId = spawnId;
+  }
+
+  /**
+   * Rebind to the commission's CURRENT target rooms - the remote rooms the
+   * draft plan mines. Commission-owned like spawnId: materialize() refreshes
+   * this every round, so targets follow the plan (a closed mine drops out, a
+   * newly opened remote joins) instead of following creep positions.
+   */
+  public setTargetRooms(rooms: string[]): void {
+    this.targetRooms = [...rooms];
+  }
+
+  public getTargetRooms(): string[] {
+    return [...this.targetRooms];
   }
 
   public getPosition(): Position {
@@ -74,26 +102,14 @@ export class ReservationCorp extends Corp {
   }
 
   /**
-   * Rooms worth reserving from this home: unowned, controllered rooms within
-   * scouting range where one of our miners is currently working, and which no
-   * other player owns or reserves (we cannot reserve over them). Reserving a room
-   * we are mining roughly doubles that source's output, so the trigger is simply
-   * "are we mining here".
+   * The rooms currently worth holding: the plan's remotes (targetRooms), gated
+   * by the vision-free reservability lens. THE single lens for this corp -
+   * work() assigns from it and getSpawnDemand() prices from it, so an
+   * assignment the demand side paid for can never be revoked by a different
+   * predicate on the work side (the staffsPost-symmetry rule).
    */
-  private targetRooms(homeRoom: string, myUsername: string | undefined): string[] {
-    const targets = new Set<string>();
-    for (const name in Game.creeps) {
-      const creep = Game.creeps[name];
-      if (creep.memory.workType !== "harvest") continue;
-      const controller = creep.room.controller;
-      if (!controller) continue; // Source Keeper / controller-less rooms: not reservable
-      if (controller.my) continue; // our own room needs no reservation
-      if (controller.owner) continue; // owned by another player: cannot reserve
-      if (controller.reservation && controller.reservation.username !== myUsername) continue; // someone else reserves it
-      if (Game.map.getRoomLinearDistance(homeRoom, creep.room.name) > MAX_SCOUT_DISTANCE) continue;
-      targets.add(creep.room.name);
-    }
-    return [...targets];
+  private reservableTargets(myUsername: string | undefined): string[] {
+    return this.targetRooms.filter(r => isReservableRoom(r, myUsername));
   }
 
   public work(tick: number): void {
@@ -101,16 +117,16 @@ export class ReservationCorp extends Corp {
 
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
     if (!spawn) return;
-    const homeRoom = spawn.room.name;
-    const myUsername = spawn.owner?.username;
 
-    const targets = this.targetRooms(homeRoom, myUsername);
+    const targets = this.reservableTargets(spawn.owner?.username);
     const covered = new Set<string>();
 
     for (const creep of this.getActiveCreeps()) {
       let target = creep.memory.targetRoom;
-      // (Re)assign if the creep has no target, its target is no longer worth
-      // reserving, or another reserver already covers it.
+      // (Re)assign only when the PLAN moved: the creep has no target, its
+      // target left the plan / became unreservable per intel, or another
+      // reserver already covers it. A miner dying or vision dropping does NOT
+      // change `targets`, so an in-flight reserver keeps its assignment.
       if (!target || !targets.includes(target) || covered.has(target)) {
         target = targets.find(r => !covered.has(r));
         creep.memory.targetRoom = target;
@@ -143,8 +159,8 @@ export class ReservationCorp extends Corp {
    * Request one reserver while a target room lacks one. Reservers are an income
    * optimisation (they lift a remote source from 1500 to 3000), so they rank
    * below the core mining/hauling that produces the base income, and are only
-   * requested for rooms we already mine. Gated by affordability: CLAIM costs 600,
-   * so a low-capacity room asks for nothing until it can build one.
+   * requested for rooms the plan already mines. Gated by affordability: CLAIM
+   * costs 600, so a low-capacity room asks for nothing until it can build one.
    */
   public getSpawnDemand(ctx: SpawnDemandContext): SpawnDemand[] {
     const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
@@ -152,8 +168,9 @@ export class ReservationCorp extends Corp {
 
     // DEFENSE ECONOMICS (owner 2026-07-10): don't send reservers into rooms
     // held by hostiles (sighted, or inside a sighted hostile's TTL bound).
+    // Demand-side only: an already-fielded reserver runs out (v1 doctrine).
     const danger = hostileRooms();
-    const targets = this.targetRooms(spawn.room.name, spawn.owner?.username).filter(r => !danger.has(r));
+    const targets = this.reservableTargets(spawn.owner?.username).filter(r => !danger.has(r));
     if (targets.length === 0) return [];
 
     const covered = new Set(
@@ -203,12 +220,14 @@ export class ReservationCorp extends Corp {
   public serialize(): SerializedReservationCorp {
     return {
       ...super.serialize(),
-      spawnId: this.spawnId
+      spawnId: this.spawnId,
+      targetRooms: [...this.targetRooms]
     };
   }
 
   public deserialize(data: SerializedReservationCorp): void {
     super.deserialize(data);
     this.spawnId = data.spawnId ?? this.spawnId;
+    this.targetRooms = data.targetRooms ?? [];
   }
 }

--- a/src/corps/kinds/reservationKind.ts
+++ b/src/corps/kinds/reservationKind.ts
@@ -2,11 +2,20 @@
  * @fileoverview reservationKind - ReservationCorp as a registered CorpKind:
  * the second port onto the corp framework (docs/specs/00-corp-framework.md).
  *
- * Auxiliary shape, like scout. The economically interesting trigger ("one of
- * our miners works an unowned, controllered room") lives at RUNTIME inside the
- * corp (targetRooms gates both work() and getSpawnDemand()), because it reads
- * live creeps; propose() commissions one reservation corp per spawn room
- * unconditionally - a corp with no targets and no creeps costs nothing.
+ * Auxiliary shape, like scout - and the poster child for the propose()
+ * contract: THE TRIGGER READS THE DRAFT. A room is worth reserving exactly
+ * when the draft plan mines it (a remote harvest commission targets one of its
+ * sources), so propose() derives each home's targetRooms from the draft and
+ * bakes them into the commission assignment. materialize() refreshes them on
+ * the live corp every round, exactly like spawnId - commission-owned state.
+ *
+ * The trigger must NOT read live creep positions ("a miner is standing there
+ * this tick") and must NOT require room vision. Both were the stranded-
+ * reserver incident (shard1 t72378345): the remote's miner died, taking the
+ * trigger and the room's vision with it; the in-flight reserver was revoked
+ * mid-route and idled out its CLAIM lifetime while the reservation decayed.
+ * Runtime reservability (owned/reserved by others, hostiles) is gated inside
+ * the corp by the shared vision-free lenses (isReservableRoom, hostileRooms).
  *
  * Spawning stays on the value-ranked SpawnDirector path: the director reads
  * this corp's getSpawnDemand() through the commission store, so reservers keep
@@ -22,23 +31,38 @@ import { ColonyProblem } from "../../economy/CorpPlanner";
 import { SerializedCorp } from "../Corp";
 import { ReservationCorp, SerializedReservationCorp } from "../ReservationCorp";
 import { buildReserverBody } from "../../spawn/BodyBuilder";
+import { roomLinearDistance } from "../../utils/RoomDiscovery";
+import { MAX_SCOUT_DISTANCE } from "../CorpConstants";
 
-/** The reservation commission's binding: which home room, which spawn. */
+/**
+ * The reservation commission's binding: which home room, which spawn, and
+ * which remote rooms the draft plan mines from there (the reserve-worthy set).
+ */
 export interface ReservationAssignment {
   roomName: string;
   spawnId: string;
+  targetRooms: string[];
 }
 
 export const reservationKind: CorpKind<ReservationCorp> = {
   kind: "reservation",
   runOrder: 40,
 
-  propose(problem: ColonyProblem): Commission[] {
+  propose(problem: ColonyProblem, draft: readonly Commission[] = []): Commission[] {
     const homeSpawnByRoom = new Map<string, string>();
     for (const s of problem.spawns) {
       if (!homeSpawnByRoom.has(s.pos.roomName)) {
         homeSpawnByRoom.set(s.pos.roomName, s.id);
       }
+    }
+    // The trigger, on the DURABLE signal: rooms the draft plan MINES that are
+    // not our own spawn rooms. Solver harvest commissions carry the source
+    // position in produces.at, so no Game/vision/creep lookup is needed here.
+    const minedRemotes = new Set<string>();
+    for (const c of draft) {
+      if (c.kind !== "harvest") continue;
+      const room = c.produces.at?.roomName;
+      if (room && !homeSpawnByRoom.has(room)) minedRemotes.add(room);
     }
     return [...homeSpawnByRoom].map(([roomName, spawnId]) => ({
       corpId: corpIdFor("reservation", roomName),
@@ -48,7 +72,11 @@ export const reservationKind: CorpKind<ReservationCorp> = {
       // sources), priced by the SpawnDirector's value ranking, not the planner.
       consumes: { spawnPartsPerTick: 0 },
       produces: { valuePerTick: 0 },
-      assignment: { roomName, spawnId } as ReservationAssignment
+      assignment: {
+        roomName,
+        spawnId,
+        targetRooms: [...minedRemotes].filter(r => roomLinearDistance(roomName, r) <= MAX_SCOUT_DISTANCE).sort()
+      } as ReservationAssignment
     }));
   },
 
@@ -56,11 +84,14 @@ export const reservationKind: CorpKind<ReservationCorp> = {
     const a = c.assignment as ReservationAssignment;
     if (existing) {
       existing.setSpawnId(a.spawnId); // commission-owned: never let it go stale
+      existing.setTargetRooms(a.targetRooms ?? []); // ditto - targets follow the PLAN
       return existing;
     }
     // Legacy nodeId convention preserves the pre-port runtime corp id, so live
     // reservers' memory.corpId still resolves across the migration.
-    return new ReservationCorp(`${a.roomName}-reservation`, a.spawnId);
+    const corp = new ReservationCorp(`${a.roomName}-reservation`, a.spawnId);
+    corp.setTargetRooms(a.targetRooms ?? []);
+    return corp;
   },
 
   run(corp: ReservationCorp, tick: number): void {

--- a/src/economy/CorpKind.ts
+++ b/src/economy/CorpKind.ts
@@ -36,9 +36,11 @@ export interface CorpKind<C extends Corp = Corp> {
    * PLAN (pure): propose commissions this kind can fulfil in this world.
    * Central shapes (produce/transport/consume) normally return [] - the
    * solver emits them - while auxiliary kinds implement their trigger here
-   * (e.g. reserver: "a miner works an unowned controllered room"), reading
-   * the draft commissions for preconditions instead of inventing a private
-   * side-channel.
+   * (e.g. reserver: "the draft plan MINES an unowned, controllered room"),
+   * reading the draft commissions for preconditions instead of inventing a
+   * private side-channel. The draft is the DURABLE signal: never trigger on
+   * live creep positions or room vision, which flap on every creep death
+   * (the stranded-reserver incident - see corps/kinds/reservationKind).
    */
   propose(problem: ColonyProblem, draft: readonly Commission[]): Commission[];
   /** BIND: create the runtime corp for a commission, or update the existing one. */

--- a/src/execution/IncrementalAnalysis.ts
+++ b/src/execution/IncrementalAnalysis.ts
@@ -21,7 +21,7 @@ import { Node, NodeSurveyor, calculateNodeROI, createNode } from "../nodes";
 import { RESERVER_BODY_COST } from "../corps/economics";
 import { SiteNode, SiteSource, marginalSiteValue } from "../economy/siteValue";
 import { Colony } from "../colony";
-import { get7x7BoxAroundOwnedRooms } from "../utils";
+import { get7x7BoxAroundOwnedRooms, isReservableRoom } from "../utils";
 
 // =============================================================================
 // CONSTANTS
@@ -637,13 +637,10 @@ function populateNodeResources(
       // the moment a miner gives us vision of the remote (which would make the
       // planner thrash on a remote that is only worthwhile reserved). Owned/already-
       // reserved rooms already read 3000 from source.energyCapacity, so this only
-      // lifts the reservable-but-not-yet-reserved gap.
-      const ctrl = room.controller;
-      const couldReserveLive =
-        !!ctrl &&
-        !ctrl.owner &&
-        (!ctrl.reservation || ctrl.reservation.username === myUsername) &&
-        homeCapacity >= RESERVER_BODY_COST;
+      // lifts the reservable-but-not-yet-reserved gap. isReservableRoom is the
+      // SHARED lens (RoomDiscovery) - the ReservationCorp gates its dispatch on
+      // the same predicate, so valuation and execution cannot disagree.
+      const couldReserveLive = isReservableRoom(roomName, myUsername) && homeCapacity >= RESERVER_BODY_COST;
 
       // Add sources within territory. Remote (unowned-room) sources wait for
       // home saturation - see remotesUnlocked above.
@@ -728,11 +725,9 @@ function populateNodeResources(
         // op should rank like the 3000 it becomes. Over-commitment and too-far rooms
         // are held back downstream by the source's own net-energy gate and the
         // dynamic spawn-time budget, so no distance check is needed here.
-        const couldReserve =
-          !!intel.controllerPos &&
-          !intel.controllerOwner &&
-          (!intel.controllerReservation || intel.controllerReservation === myUsername) &&
-          homeCapacity >= RESERVER_BODY_COST;
+        // isReservableRoom is the SHARED lens (RoomDiscovery): no vision here, so
+        // it reads this same intel - and the ReservationCorp dispatches on it.
+        const couldReserve = isReservableRoom(roomName, myUsername) && homeCapacity >= RESERVER_BODY_COST;
 
         // Source capacity: 3000 for owned/reserved/reservable rooms, 1500 otherwise.
         const sourceCapacity = isOwnedRoom || isReservedByUs || couldReserve ? 3000 : 1500;

--- a/src/utils/RoomDiscovery.ts
+++ b/src/utils/RoomDiscovery.ts
@@ -286,6 +286,55 @@ export function isSourceKeeperRoom(name: string): boolean {
   return inBand(h) && inBand(v) && !(h === 5 && v === 5);
 }
 
+/**
+ * Pure room-name port of Game.map.getRoomLinearDistance: Chebyshev distance on
+ * the room lattice, with the W/E and N/S seams handled (Wn -> -n-1 / En -> n on
+ * x; Nn -> -n-1 / Sn -> n on y). Pure so PLANNING code (CorpKind.propose) can
+ * gate by distance without touching Game. Malformed names -> Infinity.
+ */
+export function roomLinearDistance(a: string, b: string): number {
+  const pa = parseRoomName(a);
+  const pb = parseRoomName(b);
+  if (!pa || !pb) return Infinity;
+  const wx = (p: { xDir: string; x: number }): number => (p.xDir === "W" ? -p.x - 1 : p.x);
+  const wy = (p: { yDir: string; y: number }): number => (p.yDir === "N" ? -p.y - 1 : p.y);
+  return Math.max(Math.abs(wx(pa) - wx(pb)), Math.abs(wy(pa) - wy(pb)));
+}
+
+/**
+ * THE room-reservability lens: could `myUsername` hold this room's controller?
+ * Prefers live vision when the room happens to be visible, and falls back to
+ * scout intel (Memory.roomIntel) - it NEVER reads creep positions, so the
+ * answer cannot flap when a creep dies or vision is lost. This is the same
+ * predicate the planner's source valuation uses (IncrementalAnalysis
+ * couldReserve: sources in reservable rooms are worth the reserved 3000), so
+ * "valued as reservable" and "reserver dispatched" can never disagree.
+ *
+ * Stranded-reserver incident (shard1 t72378345): ReservationCorp derived its
+ * targets from "a miner creep is standing in the room THIS TICK" - the dead
+ * miner took both the trigger and the room's vision with it, an in-flight
+ * 1300-energy reserver was revoked mid-route and idled out its CLAIM lifetime,
+ * and the blackbox showed 10 reserver spawns in 2400 ticks of churn. Room
+ * state must come from durable signals: this lens, or the plan's commissions.
+ *
+ * Unknown rooms (no vision, no intel) default to reservable: reservation
+ * targets only come from the plan, and the plan only mines rooms it has seen.
+ */
+export function isReservableRoom(roomName: string, myUsername: string | undefined): boolean {
+  const room = typeof Game !== "undefined" && Game.rooms ? Game.rooms[roomName] : undefined;
+  if (room) {
+    const ctrl = room.controller;
+    return !!ctrl && !ctrl.owner && (!ctrl.reservation || ctrl.reservation.username === myUsername);
+  }
+  const intel = typeof Memory !== "undefined" ? Memory.roomIntel?.[roomName] : undefined;
+  if (!intel) return true;
+  return (
+    !!intel.controllerPos &&
+    !intel.controllerOwner &&
+    (!intel.controllerReservation || intel.controllerReservation === myUsername)
+  );
+}
+
 /** The Invader NPC's username: invader creeps and invader-core reservations. */
 export const INVADER_USERNAME = "Invader";
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,5 +16,7 @@ export {
   getRoomBox,
   getRoomBoxAroundOwnedRooms,
   get7x7RoomBox,
-  get7x7BoxAroundOwnedRooms
+  get7x7BoxAroundOwnedRooms,
+  isReservableRoom,
+  roomLinearDistance
 } from "./RoomDiscovery";

--- a/test/grid/cells/multiroom.ts
+++ b/test/grid/cells/multiroom.ts
@@ -147,13 +147,19 @@ export function buildMultiroomT5Cells(): GridCell[] {
     },
 
     {
-      // A worked remote room's reserver ranks as STARTED INCOME: with the
-      // trigger armed (rh standing by the east source) and 650 affordable,
-      // the reserver is fielded and walks into the east room.
+      // A worked remote room's reserver ranks as STARTED INCOME: once the
+      // PLAN opens the east mine (the rh's vision feeds the solver) and 650
+      // is affordable, the reserver is fielded and walks into the east room.
+      // The trigger is plan-coupled - the draft's remote harvest commission,
+      // NOT "a creep is standing there" (the stranded-reserver incident) - so
+      // dispatch waits on the node-resource refresh (50t) + re-solve (10t)
+      // before the spawn hold even arms: the old 90t window was structurally
+      // too short. Measured post-fix: fielded @324, enters east @353; 600
+      // leaves multi-draw headroom.
       id: "spawn-reserver-started-income",
       tier: 5,
       avenue: "spawn-decision",
-      window: 90,
+      window: 600,
       rooms: {
         home: homeEast((b) => b.controller(25, 10).source(25, 40)),
         east: eastRoom((b) => b.controller(10, 10).source(25, 25)),
@@ -190,10 +196,12 @@ export function buildMultiroomT5Cells(): GridCell[] {
       // behind the ENTIRE income expansion (fresh miner ~95, its hauler
       // ~157, the remote source's miner ~234 - the staged rh gives vision,
       // so the solver legitimately opens the remote mine) and rides its
-      // income starved-hold (~315) to the spawn. NOTE for spec 01: value 92
-      // underprices reservation (650 energy doubles a remote source, beating
-      // a scaling hauler's marginal value 110) - a candidate energy lever.
-      window: 400,
+      // income starved-hold to the spawn (measured post plan-coupling: the
+      // reserver follows @356; 600 leaves multi-draw headroom). NOTE for
+      // spec 01: value 92 underprices reservation (650 energy doubles a
+      // remote source, beating a scaling hauler's marginal value 110) - a
+      // candidate energy lever.
+      window: 600,
       rooms: {
         home: homeEast((b) => b.controller(25, 10).source(25, 40).source(10, 30)),
         east: eastRoom((b) => b.controller(10, 10).source(25, 25)),
@@ -231,11 +239,15 @@ export function buildMultiroomT5Cells(): GridCell[] {
     {
       // Body scaling across rooms: at 1300 capacity the reserver carries the
       // full 2x(CLAIM+MOVE) pair set and physically reaches the remote
-      // controller.
+      // controller. Plan-coupled dispatch (see spawn-reserver-started-income)
+      // arms the demand only after the node refresh (50t) + re-solve opens
+      // the east mine, and the 1300 holdToFund bank (vs 650 in the RCL3
+      // cells) adds ~190t on a one-source income. Measured post-fix: body
+      // fielded @514, reaches the controller @560; 800 leaves headroom.
       id: "spawnexec-reserver-body-multiroom",
       tier: 5,
       avenue: "spawn-execution",
-      window: 110,
+      window: 800,
       rooms: {
         home: homeEast((b) => b.controller(25, 10).source(25, 40)),
         east: eastRoom((b) => b.controller(10, 10).source(25, 25)),

--- a/test/unit/corps/ReservationCorp.test.ts
+++ b/test/unit/corps/ReservationCorp.test.ts
@@ -1,15 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "chai";
 import "../../../src/types/Memory";
-import { Game as MockGame } from "../mock";
+import { Game as MockGame, Memory as MockMemory, setupGlobals } from "../mock";
 import { buildReserverBody } from "../../../src/spawn/BodyBuilder";
 import { ReservationCorp } from "../../../src/corps/ReservationCorp";
+
+setupGlobals();
 
 /**
  * Reservation is the one genuinely room-specific part of remote mining: holding a
  * remote controller lifts its sources from 1500 back to the full 3000. These
- * scenarios pin down (a) the reserver body math and (b) the corp's trigger - it
- * asks for a reserver exactly when one of our miners is working in an unowned,
- * controllered room within range, and stops once that room is covered.
+ * scenarios pin down (a) the reserver body math and (b) the corp's targeting:
+ * targets are the PLAN's remote mining rooms (commission-owned, set via
+ * setTargetRooms), gated by the vision-free reservability lens (scout intel) -
+ * NEVER by where miner creeps happen to be standing. The stranded-reserver
+ * incident (shard1 t72378345): the old creep-position trigger revoked an
+ * in-flight reserver's target the tick its remote's miner died, because the dead
+ * miner took both the trigger AND the room's vision with it. The creep idled out
+ * its remaining ~250 ticks of CLAIM lifetime mid-route while the room's
+ * reservation decayed.
  */
 
 describe("buildReserverBody", () => {
@@ -32,68 +41,192 @@ describe("buildReserverBody", () => {
   });
 });
 
-/** A fake miner working in a room with the given controller state. */
-function minerIn(roomName: string, controller: unknown): unknown {
-  return { memory: { workType: "harvest" }, room: { name: roomName, controller } };
-}
+// hostileRooms() memoizes per Game.time - every test gets a fresh tick so one
+// test's danger set never replays into the next.
+let tick = 50_000;
 
-/** Stub Game with a home spawn, a fleet, and a fixed inter-room distance. */
-function setWorld(creeps: Record<string, unknown>, distance = 1): void {
+/**
+ * Stub Game/Memory: a home spawn and NOTHING else - no vision of any remote
+ * (Game.rooms empty) and, unless the test adds them, no creeps. This is the
+ * incident's shape: targeting must work from intel alone.
+ */
+function setWorld(creeps: Record<string, unknown> = {}): void {
+  tick += 100;
   const spawn = { id: "spawn1", room: { name: "W0N0" }, owner: { username: "me" } };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).Game = {
     ...MockGame,
     creeps,
-    time: 100,
-    getObjectById: (id: string) => (id === "spawn1" ? spawn : null),
-    map: { ...MockGame.map, getRoomLinearDistance: () => distance },
+    rooms: {},
+    time: tick,
+    getObjectById: (id: string) => (id === "spawn1" ? spawn : null)
+  };
+  (global as any).Memory = { creeps: {}, roomIntel: {} };
+}
+
+/** Scout intel for a room: unowned + controllered unless overridden. */
+function intel(roomName: string, over: Record<string, unknown> = {}): void {
+  (Memory as any).roomIntel[roomName] = {
+    lastVisit: tick - 10,
+    sourceCount: 1,
+    sourcePositions: [{ x: 10, y: 10 }],
+    mineralType: null,
+    mineralPos: null,
+    controllerLevel: 0,
+    controllerPos: { x: 5, y: 5 },
+    controllerOwner: null,
+    controllerReservation: null,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    isSafe: true,
+    ...over
   };
 }
 
-function corp(): ReservationCorp {
-  return new ReservationCorp("W0N0-reservation", "spawn1");
+/** A corp whose commission planned these remote mining rooms. */
+function corp(targets: string[]): ReservationCorp {
+  const c = new ReservationCorp("W0N0-reservation", "spawn1");
+  c.setTargetRooms(targets);
+  return c;
 }
 
-const ctx = { energyCapacity: 800, tick: 100 };
+const ctx = { energyCapacity: 800, tick: 100 } as any;
 
-describe("ReservationCorp demand (reserve rooms we mine)", () => {
+describe("ReservationCorp demand (reserve rooms the PLAN mines - no vision, no miners needed)", () => {
   afterEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).Game = { ...MockGame, creeps: {}, time: 100 };
+    (global as any).Game = { ...MockGame, creeps: {}, time: tick };
+    (global as any).Memory = MockMemory;
   });
 
-  it("requests a reserver when a miner works an unowned, controllered room", () => {
-    setWorld({ m1: minerIn("W1N0", { my: false, owner: undefined, reservation: undefined }) });
-    const demand = corp().getSpawnDemand(ctx);
+  it("requests a reserver for a planned remote with NO vision and NO miner alive (stranding regression)", () => {
+    setWorld({}); // zero creeps: the remote's miner is dead, its replacement unspawned
+    intel("W1N0");
+    const demand = corp(["W1N0"]).getSpawnDemand(ctx);
     expect(demand).to.have.length(1);
     expect(demand[0]).to.include({ role: "reserver", producesIncome: true });
   });
 
-  it("does not reserve our own room, or rooms owned/reserved by others", () => {
-    setWorld({
-      home: minerIn("W0N0", { my: true }), // our room - no reservation needed
-      enemy: minerIn("W2N0", { my: false, owner: { username: "rival" } }), // owned by another
-      taken: minerIn("W3N0", { my: false, reservation: { username: "rival" } }), // reserved by another
-    });
-    expect(corp().getSpawnDemand(ctx)).to.have.length(0);
+  it("does not reserve rooms intel says are owned or reserved by others", () => {
+    setWorld();
+    intel("W2N0", { controllerOwner: "rival" });
+    intel("W3N0", { controllerReservation: "rival" });
+    expect(corp(["W2N0", "W3N0"]).getSpawnDemand(ctx)).to.have.length(0);
   });
 
-  it("does not reserve a Source-Keeper / controller-less room", () => {
-    setWorld({ m1: minerIn("W5N5", null) });
-    expect(corp().getSpawnDemand(ctx)).to.have.length(0);
+  it("keeps reserving a room WE already hold - the reservation decays without a reserver", () => {
+    setWorld();
+    intel("W1N0", { controllerReservation: "me" });
+    expect(corp(["W1N0"]).getSpawnDemand(ctx)).to.have.length(1);
+  });
+
+  it("does not reserve a controller-less room", () => {
+    setWorld();
+    intel("W5N5", { controllerPos: null });
+    expect(corp(["W5N5"]).getSpawnDemand(ctx)).to.have.length(0);
   });
 
   it("stops requesting once a reserver already covers the room", () => {
-    const c = corp();
+    const c = corp(["W1N0"]);
     setWorld({
-      m1: minerIn("W1N0", { my: false, owner: undefined, reservation: undefined }),
-      r1: { memory: { corpId: c.id, workType: "reserve", targetRoom: "W1N0" }, spawning: false },
+      r1: { memory: { corpId: c.id, workType: "reserve", targetRoom: "W1N0" }, spawning: false }
     });
+    intel("W1N0");
     expect(c.getSpawnDemand(ctx)).to.have.length(0);
   });
 
-  it("asks for nothing when no miner is working a remote room", () => {
-    setWorld({ home: minerIn("W0N0", { my: true }) });
-    expect(corp().getSpawnDemand(ctx)).to.have.length(0);
+  it("asks for nothing when the plan mines no remote", () => {
+    setWorld();
+    expect(corp([]).getSpawnDemand(ctx)).to.have.length(0);
+  });
+
+  it("does not fund a reserver for a hostile-marked room (defense defund, vision-free)", () => {
+    setWorld();
+    intel("W1N0", { hostileUntil: tick + 200 });
+    expect(corp(["W1N0"]).getSpawnDemand(ctx)).to.have.length(0);
+  });
+});
+
+describe("ReservationCorp work (assignments survive miner death and vision loss)", () => {
+  afterEach(() => {
+    (global as any).Game = { ...MockGame, creeps: {}, time: tick };
+    (global as any).Memory = MockMemory;
+  });
+
+  /** A reserver creep mid-route in some hallway room, recording its moves. */
+  function reserverCreep(c: ReservationCorp, targetRoom?: string): any {
+    const moves: any[] = [];
+    return {
+      name: "r1",
+      spawning: false,
+      memory: { corpId: c.id, workType: "reserve", targetRoom },
+      room: { name: "W0N5" },
+      pos: { x: 25, y: 25, roomName: "W0N5", isNearTo: () => false, isEqualTo: () => false },
+      moveTo: (...args: any[]) => {
+        moves.push(args);
+        return 0;
+      },
+      move: () => 0,
+      moves
+    };
+  }
+
+  it("assigns a planned room to an idle reserver without any vision or miners", () => {
+    const c = corp(["W1N0"]);
+    setWorld();
+    intel("W1N0");
+    const creep = reserverCreep(c);
+    Game.creeps.r1 = creep;
+    c.work(tick);
+    expect(creep.memory.targetRoom).to.equal("W1N0");
+    expect(creep.moves, "the reserver travels toward its target").to.have.length.greaterThan(0);
+    expect(creep.moves[0][0].roomName).to.equal("W1N0");
+  });
+
+  it("keeps an in-flight assignment when the remote's miner dies (the stranding bug)", () => {
+    const c = corp(["W1N0"]);
+    setWorld(); // NO miners anywhere, NO vision of W1N0
+    intel("W1N0");
+    const creep = reserverCreep(c, "W1N0");
+    Game.creeps.r1 = creep;
+    c.work(tick);
+    expect(creep.memory.targetRoom, "target must not flap with creep deaths").to.equal("W1N0");
+    expect(creep.moves).to.have.length.greaterThan(0);
+  });
+
+  it("revokes the assignment when the room leaves the plan", () => {
+    const c = corp([]);
+    setWorld();
+    const creep = reserverCreep(c, "W1N0");
+    Game.creeps.r1 = creep;
+    c.work(tick);
+    expect(creep.memory.targetRoom).to.equal(undefined);
+    expect(creep.moves).to.have.length(0);
+  });
+
+  it("revokes the assignment when intel says another player took the controller", () => {
+    const c = corp(["W1N0"]);
+    setWorld();
+    intel("W1N0", { controllerOwner: "rival" });
+    const creep = reserverCreep(c, "W1N0");
+    Game.creeps.r1 = creep;
+    c.work(tick);
+    expect(creep.memory.targetRoom).to.equal(undefined);
+  });
+
+  it("reserves the controller once in the target room", () => {
+    const c = corp(["W1N0"]);
+    setWorld();
+    intel("W1N0");
+    const controller = { id: "ctrl1" };
+    const reserved: any[] = [];
+    const creep = reserverCreep(c, "W1N0");
+    creep.room = { name: "W1N0", controller };
+    creep.pos.isNearTo = () => true;
+    creep.reserveController = (t: any) => {
+      reserved.push(t);
+      return 0;
+    };
+    Game.creeps.r1 = creep;
+    c.work(tick);
+    expect(reserved).to.deep.equal([controller]);
   });
 });

--- a/test/unit/framework/reservationKind.test.ts
+++ b/test/unit/framework/reservationKind.test.ts
@@ -1,15 +1,20 @@
 /**
  * ReservationCorp ported onto the corp framework - proof ladder rungs 1-4
- * (docs/specs/00-corp-framework.md). Mirrors the scout port; the reservation-
- * specific proof is rung 3's runtime trigger: targetRooms gates work() and
- * getSpawnDemand() on "one of OUR miners is harvesting an unowned,
- * controllered room" - the spec's poster auxiliary trigger.
+ * (docs/specs/00-corp-framework.md). The reservation-specific proof is rung 2's
+ * DRAFT-READING trigger: propose() derives target rooms from the draft plan's
+ * remote harvest commissions - the durable "we mine this room" signal - exactly
+ * as the propose() contract prescribes for auxiliaries. The trigger must NOT
+ * read live creep positions or require room vision: the stranded-reserver
+ * incident (shard1 t72378345) came from keying targets to "a miner is standing
+ * there right now", which flaps on every miner death and goes blind with the
+ * vision the dead miner was providing.
  */
 
 import { expect } from "chai";
 import { setupGlobals, Game, Memory } from "../mock";
 import { Position } from "../../../src/types/Position";
 import { ColonyProblem } from "../../../src/economy/CorpPlanner";
+import { Commission } from "../../../src/economy/Commission";
 import {
   CorpStore,
   deserializeStore,
@@ -21,11 +26,12 @@ import {
 } from "../../../src/economy/CorpKind";
 import { planCommissions } from "../../../src/economy/commissionPlan";
 import { ReservationCorp } from "../../../src/corps/ReservationCorp";
-import { reservationKind } from "../../../src/corps/kinds/reservationKind";
+import { reservationKind, ReservationAssignment } from "../../../src/corps/kinds/reservationKind";
 import { describeCorpKindConformance } from "./conformance";
 
 const HOME = "W1N1";
 const REMOTE = "W1N2";
+const TOO_FAR = "W1N9"; // linear distance 8 from HOME > MAX_SCOUT_DISTANCE (5)
 
 function installGlobals(): void {
   setupGlobals();
@@ -47,17 +53,22 @@ const world: ColonyProblem = {
   dist: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y)
 };
 
+// hostileRooms() memoizes per Game.time - unique ticks per test, never replayed.
+let tick = 60_000;
+
 function resetWorld(): void {
   installGlobals();
+  tick += 100;
   Game.creeps = {};
   Game.rooms = {};
-  Game.time = 12345;
+  Game.time = tick;
   Game.getObjectById = () => null;
   (Memory as Record<string, unknown>).creeps = {};
+  (Memory as Record<string, unknown>).roomIntel = {};
 }
 
-/** Home spawn plus one of OUR miners harvesting an unowned remote room. */
-function installMinedRemote(): void {
+/** Home spawn resolvable by id - no vision of anything else. */
+function installHomeSpawn(): void {
   const spawn = {
     id: "spawn1",
     pos: { x: 25, y: 25, roomName: HOME },
@@ -65,11 +76,36 @@ function installMinedRemote(): void {
     room: { name: HOME, controller: { my: true, level: 3 } }
   };
   Game.getObjectById = (id: string) => (id === "spawn1" ? spawn : null);
-  Game.creeps.miner1 = {
-    name: "miner1",
-    spawning: false,
-    memory: { workType: "harvest", corpId: "harvest-x" },
-    room: { name: REMOTE, controller: { my: false, owner: undefined, reservation: undefined } }
+}
+
+/** Scout intel: an unowned, controllered room unless overridden. */
+function intel(roomName: string, over: Record<string, unknown> = {}): void {
+  (Memory as Record<string, Record<string, unknown>>).roomIntel[roomName] = {
+    lastVisit: tick - 10,
+    sourceCount: 1,
+    sourcePositions: [{ x: 10, y: 10 }],
+    mineralType: null,
+    mineralPos: null,
+    controllerLevel: 0,
+    controllerPos: { x: 5, y: 5 },
+    controllerOwner: null,
+    controllerReservation: null,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    isSafe: true,
+    ...over
+  };
+}
+
+/** A solver harvest commission for a source in `roomName` - the draft signal. */
+function harvestDraft(sourceId: string, roomName: string): Commission {
+  return {
+    corpId: `harvest-${sourceId}`,
+    kind: "harvest",
+    shape: "produce",
+    consumes: { spawnPartsPerTick: 0.1 },
+    produces: { energyRate: 10, at: { x: 30, y: 30, roomName } },
+    assignment: { sourceId }
   };
 }
 
@@ -90,43 +126,74 @@ describe("reservation kind on the corp framework (rungs 2-4)", () => {
     expect(res).to.have.length(1);
     expect(res[0].corpId).to.equal("reservation-W1N1");
     expect(res[0].shape).to.equal("auxiliary");
-    expect(res[0].assignment).to.deep.equal({ roomName: HOME, spawnId: "spawn1" });
+    // The solver mines only the HOME source here, so no remote targets yet.
+    expect(res[0].assignment).to.deep.equal({ roomName: HOME, spawnId: "spawn1", targetRooms: [] });
   });
 
-  it("rung 3 - BIND: materialize keeps the LEGACY runtime corp id", () => {
+  it("rung 2 - TRIGGER: targets come from the draft plan's REMOTE harvest commissions", () => {
+    const draft = [
+      harvestDraft("srcHome", HOME), // mined, but it's a spawn room: excluded
+      harvestDraft("srcRemote", REMOTE), // mined remote: targeted
+      harvestDraft("srcFar", TOO_FAR) // mined but out of reserver range: excluded
+    ];
+    const res = reservationKind.propose(world, draft);
+    expect(res).to.have.length(1);
+    const a = res[0].assignment as ReservationAssignment;
+    expect(a.targetRooms).to.deep.equal([REMOTE]);
+  });
+
+  it("rung 3 - BIND: materialize keeps the LEGACY runtime corp id and adopts the targets", () => {
+    const draft = [harvestDraft("srcRemote", REMOTE)];
     const store: CorpStore = new Map();
-    materializeCommissions(planCommissions(world).commissions, store);
+    materializeCommissions([...draft, ...reservationKind.propose(world, draft)], store);
     const corp = store.get("reservation-W1N1")!.corp as ReservationCorp;
     expect(corp.id).to.equal("reservation-W1N1-reservation");
     expect(corp.getSpawnId()).to.equal("spawn1");
+    expect(corp.getTargetRooms()).to.deep.equal([REMOTE]);
   });
 
-  it("rung 3 - TRIGGER: demands a reserver only while a miner works an unowned room", () => {
+  it("rung 3 - BIND: materialize refreshes targetRooms on an existing corp (stale-assignment regression)", () => {
+    // A persisted corp outlives plan changes; targets are commission-owned
+    // state like spawnId - every round's materialize must adopt the CURRENT
+    // plan's rooms, or live corps keep chasing a mine the planner closed.
+    const first = reservationKind.propose(world, [harvestDraft("srcRemote", REMOTE)])[0];
+    const corp = reservationKind.materialize(first, undefined) as ReservationCorp;
+    expect(corp.getTargetRooms()).to.deep.equal([REMOTE]);
+    const second = reservationKind.propose(world, [])[0];
+    const rebound = reservationKind.materialize(second, corp as never) as ReservationCorp;
+    expect(rebound.getTargetRooms()).to.deep.equal([]);
+  });
+
+  it("rung 3 - TRIGGER: demands a reserver while the plan mines an unowned remote - no miner, no vision", () => {
+    const draft = [harvestDraft("srcRemote", REMOTE)];
     const store: CorpStore = new Map();
-    materializeCommissions(planCommissions(world).commissions, store);
+    materializeCommissions([...draft, ...reservationKind.propose(world, draft)], store);
     const corp = store.get("reservation-W1N1")!.corp as ReservationCorp;
     const ctx = { energyCapacity: 1300 } as never;
 
-    expect(corp.getSpawnDemand(ctx)).to.have.length(0); // no miner abroad yet
-
-    installMinedRemote();
+    installHomeSpawn();
+    intel(REMOTE); // scouted: unowned, controllered
+    // Game.creeps is EMPTY (the remote's miner is dead) and Game.rooms has no
+    // vision of REMOTE - the demand must hold anyway. This is the stranded-
+    // reserver regression: the old creep-position trigger reported no targets
+    // here, revoking in-flight reservers and flapping demand with every death.
     const demands = corp.getSpawnDemand(ctx);
     expect(demands).to.have.length(1);
     expect(demands[0].role).to.equal("reserver");
     expect(demands[0].producesIncome).to.equal(true);
     expect(demands[0].desiredCost).to.equal(1300); // 2x (CLAIM+MOVE) @ 650
 
-    // an owned remote (someone else's room) must NOT be targeted
-    (Game.creeps.miner1 as { room: { controller: { owner?: unknown } } }).room.controller.owner = {
-      username: "enemy"
-    };
+    // A rival takes the controller (seen by the next scout pass): demand stops.
+    intel(REMOTE, { controllerOwner: "enemy" });
     expect(corp.getSpawnDemand(ctx)).to.have.length(0);
   });
 
   it("rung 3 - EXECUTE/PERSIST: run() never throws; store round-trips with state", () => {
-    installMinedRemote();
+    installHomeSpawn();
+    intel(REMOTE);
+    const draft = [harvestDraft("srcRemote", REMOTE)];
     const store: CorpStore = new Map();
-    materializeCommissions(planCommissions(world).commissions, store);
+    materializeCommissions([...draft, ...reservationKind.propose(world, draft)], store);
     expect(() => runCommissionedCorps(store, Game.time)).to.not.throw();
 
     const corp = store.get("reservation-W1N1")!.corp as ReservationCorp;
@@ -135,6 +202,7 @@ describe("reservation kind on the corp framework (rungs 2-4)", () => {
     const back = restored.get("reservation-W1N1")!.corp as ReservationCorp;
     expect(back.id).to.equal(corp.id);
     expect(back.getSpawnId()).to.equal("spawn1");
+    expect(back.getTargetRooms()).to.deep.equal([REMOTE]);
     expect(back.unitsProduced).to.equal(7);
   });
 
@@ -157,7 +225,7 @@ describe("reservation kind rung 1", () => {
       shape: "auxiliary",
       consumes: { spawnPartsPerTick: 0 },
       produces: { valuePerTick: 0 },
-      assignment: { roomName: HOME, spawnId: "spawn1" }
+      assignment: { roomName: HOME, spawnId: "spawn1", targetRooms: [REMOTE] }
     },
     expectedSpawnPartsPerTick: 0
   });

--- a/test/unit/utils/roomDiscovery.test.ts
+++ b/test/unit/utils/roomDiscovery.test.ts
@@ -14,7 +14,7 @@
  */
 import "../../../src/types/Memory";
 import { expect } from "chai";
-import { hostileRooms } from "../../../src/utils/RoomDiscovery";
+import { hostileRooms, isReservableRoom, roomLinearDistance } from "../../../src/utils/RoomDiscovery";
 
 const FIND_HOSTILE_CREEPS = 103;
 
@@ -116,5 +116,89 @@ describe("utils/RoomDiscovery - hostileRooms invader-reservation marking", () =>
     const after = observe({ E1N1: mockRoom("E1N1", { reservation: { username: "Invader", ticksToEnd: 4996 } }) });
     expect(after.has("E1N1"), "reservation alone keeps the room defunded").to.equal(true);
     expect(g.Memory.roomIntel.E1N1.hostileUntil).to.equal(undefined);
+  });
+});
+
+describe("utils/RoomDiscovery - roomLinearDistance (pure room-name arithmetic)", () => {
+  it("matches Game.map.getRoomLinearDistance, including the axis zero-crossings", () => {
+    expect(roomLinearDistance("W43N23", "W43N23")).to.equal(0);
+    expect(roomLinearDistance("W43N23", "W43N24")).to.equal(1);
+    expect(roomLinearDistance("W43N23", "W42N22")).to.equal(1);
+    expect(roomLinearDistance("W43N23", "W40N29")).to.equal(6); // Chebyshev: max(3, 6)
+    expect(roomLinearDistance("W0N0", "E0N0")).to.equal(1); // across the W/E seam
+    expect(roomLinearDistance("W0N0", "W0S0")).to.equal(1); // across the N/S seam
+    expect(roomLinearDistance("W2N0", "E1N0")).to.equal(4);
+  });
+
+  it("is symmetric and returns Infinity for malformed names", () => {
+    expect(roomLinearDistance("W1N1", "W4N1")).to.equal(roomLinearDistance("W4N1", "W1N1"));
+    expect(roomLinearDistance("sim", "W1N1")).to.equal(Infinity);
+  });
+});
+
+describe("utils/RoomDiscovery - isReservableRoom (the vision-free reservability lens)", () => {
+  const g = globalThis as unknown as { Game?: any; Memory?: any };
+  let savedGame: unknown;
+  let savedMemory: unknown;
+
+  beforeEach(() => {
+    savedGame = g.Game;
+    savedMemory = g.Memory;
+    g.Game = { rooms: {} }; // NO vision anywhere - the incident's shape
+    g.Memory = { roomIntel: {} };
+  });
+  afterEach(() => {
+    g.Game = savedGame;
+    g.Memory = savedMemory;
+  });
+
+  function intel(roomName: string, over: Record<string, unknown> = {}): void {
+    g.Memory.roomIntel[roomName] = {
+      lastVisit: 100,
+      sourceCount: 1,
+      sourcePositions: [{ x: 10, y: 10 }],
+      mineralType: null,
+      mineralPos: null,
+      controllerLevel: 0,
+      controllerPos: { x: 5, y: 5 },
+      controllerOwner: null,
+      controllerReservation: null,
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      isSafe: true,
+      ...over
+    };
+  }
+
+  it("reads intel, not vision: an unowned controllered room is reservable with zero visibility", () => {
+    intel("W1N0");
+    expect(isReservableRoom("W1N0", "me")).to.equal(true);
+  });
+
+  it("rejects rooms intel says another player owns", () => {
+    intel("W1N0", { controllerOwner: "rival" });
+    expect(isReservableRoom("W1N0", "me")).to.equal(false);
+  });
+
+  it("rejects rooms another player reserves, but accepts OUR reservation (it must be maintained)", () => {
+    intel("W1N0", { controllerReservation: "rival" });
+    expect(isReservableRoom("W1N0", "me")).to.equal(false);
+    intel("W1N0", { controllerReservation: "me" });
+    expect(isReservableRoom("W1N0", "me")).to.equal(true);
+  });
+
+  it("rejects controller-less rooms (Source Keeper / highway)", () => {
+    intel("W5N5", { controllerPos: null });
+    expect(isReservableRoom("W5N5", "me")).to.equal(false);
+  });
+
+  it("prefers live vision when the room IS visible (fresher than intel)", () => {
+    intel("W1N0"); // intel says reservable...
+    g.Game.rooms.W1N0 = { controller: { owner: { username: "rival" } } }; // ...but live says taken
+    expect(isReservableRoom("W1N0", "me")).to.equal(false);
+  });
+
+  it("treats an unknown room (no vision, no intel) as reservable - targets only come from the plan", () => {
+    expect(isReservableRoom("W9N9", "me")).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the stranded-reserver incident (shard1 t72378345) where an in-flight reserver's target was revoked mid-route when its remote's miner died, causing the creep to idle out its CLAIM lifetime while the room's reservation decayed. The root cause: ReservationCorp derived targets from live creep positions ("a miner is standing there this tick"), which flaps on every miner death AND goes blind with the vision the dead miner provided.

**Solution**: Decouple targeting from creep positions. Targets now come from the draft plan's remote harvest commissions (durable across miner deaths), gated by a shared vision-free reservability lens that reads live vision when available and falls back to scout intel.

## Key Changes

- **ReservationCorp targeting** (`src/corps/ReservationCorp.ts`):
  - Replaced `targetRooms(homeRoom, myUsername)` method that scanned live creeps with `setTargetRooms(rooms)` / `getTargetRooms()` that hold commission-owned state
  - Introduced `reservableTargets()` that gates the plan's targets through `isReservableRoom()` — the shared vision-free lens
  - Both `work()` and `getSpawnDemand()` now read the same `reservableTargets()` (staffsPost-symmetry rule)
  - Removed dependency on `MAX_SCOUT_DISTANCE` (now gated in the planner)

- **reservationKind.propose()** (`src/corps/kinds/reservationKind.ts`):
  - Now reads the draft plan's harvest commissions to derive `targetRooms` (rooms the solver mines)
  - Filters to remote rooms only (excludes spawn rooms) and gates by `roomLinearDistance()` ≤ `MAX_SCOUT_DISTANCE`
  - Bakes targets into the commission assignment (commission-owned like `spawnId`)
  - `materialize()` refreshes targets on the live corp every round, so targets follow the plan

- **New vision-free lens** (`src/utils/RoomDiscovery.ts`):
  - `isReservableRoom(roomName, myUsername)`: prefers live vision when available, falls back to scout intel, never reads creep positions
  - `roomLinearDistance(a, b)`: pure room-name arithmetic (Chebyshev distance with W/E and N/S seam handling) for planning code
  - Both exported via `src/utils/index.ts`

- **IncrementalAnalysis** (`src/execution/IncrementalAnalysis.ts`):
  - Switched to shared `isReservableRoom()` lens for source valuation (so "valued as reservable" and "reserver dispatched" cannot disagree)

- **Test coverage**:
  - Expanded `ReservationCorp.test.ts` with regression tests: stranding scenario (no vision, no miners), assignment persistence across miner death, hostile-room defense defund
  - Added `reservationKind.test.ts` conformance suite (rungs 2-4): trigger reads draft, materialize refreshes targets, demand holds without vision
  - Added `roomDiscovery.test.ts` tests for `roomLinearDistance()` and `isReservableRoom()`
  - Updated grid cells: increased window from 90t/400t to 600t (plan-coupling adds ~50t node-resource refresh + 10t re-solve before spawn hold arms)

## Notable Implementation Details

- **Stranded-reserver regression test**: creep with zero vision of remote, zero miners alive, yet demand holds and assignment persists — the exact incident shape
- **Shared lens principle**: `isReservableRoom()` is used by both the planner (source valuation) and the corp (dispatch), enforcing consistency
- **Commission-owned targets**: like `spawnId`, targets are refreshed by `materialize()` every round, so a closed mine drops out and a newly opened remote joins without creep-position flapping
- **Vision-free planning**: `roomLinearDistance()` is pure (no Game/Memory reads), enabling the planner

https://claude.ai/code/session_01NMhBSiJFKpoUGHvD3TJ5Sr