### PR TITLE
Upgrader tops up and upgrades in the same tick (no wasted WORK tick)

### DIFF
--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -230,15 +230,23 @@ export class UpgradingCorp extends Corp {
       return;
     }
 
-    // Parked at the input: top up AND upgrade in the SAME tick. withdraw/pickup and
-    // upgradeController are independent intents (the canonical static-upgrader
-    // idiom), so refilling the buffer the upgrade is draining keeps a container-fed
-    // upgrader from ever going dry. The old collect/deposit oscillation
-    // (working ? upgrade : draw) drained the buffer to 0, then spent one whole tick
-    // withdrawing with the WORK parts IDLE before resuming - a wasted WORK tick per
-    // drain cycle (~11% of throughput on a WORK-heavy, small-buffer body; measured
-    // live 2026-07-17). Draw first so the just-topped-up buffer feeds this upgrade.
-    if (creep.store.getFreeCapacity() > 0) this.drawFromInput(creep, controller);
+    // Parked at the input: refill and upgrade in the SAME tick so the buffer never
+    // goes dry (withdraw/pickup and upgradeController are independent intents - the
+    // canonical static-upgrader idiom), but do NOT withdraw every tick. Each
+    // withdraw/pickup intent costs ~0.2 CPU, so sipping a few energy every tick
+    // wastes it fleet-wide. Refill just-in-time: only when the buffer can no longer
+    // cover a full WORK cycle next tick (energy < 2x the per-tick burn). The top-up
+    // lands THIS tick, so a full workParts still fires every tick while draws batch
+    // into one every several ticks. The old oscillation (working ? upgrade : draw)
+    // instead went fully dry each cycle and spent a whole tick refilling with the
+    // WORK parts idle (~11% throughput on a WORK-heavy body; measured live
+    // 2026-07-17). A buffer too small to hold two cycles necessarily draws every
+    // tick - unavoidable to stay fed. drawFromInput itself issues no intent when the
+    // input is dry, so a starved upgrader spends no CPU either.
+    const workParts = Math.max(1, creep.getActiveBodyparts(WORK));
+    if (creep.store[RESOURCE_ENERGY] < 2 * workParts && creep.store.getFreeCapacity() > 0) {
+      this.drawFromInput(creep, controller);
+    }
     this.tryUpgrade(creep, controller);
   }
 

--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -197,7 +197,10 @@ export class UpgradingCorp extends Corp {
    * Upgraders are stationary - they stay near the controller and only pick up nearby energy.
    */
   private runUpgrader(creep: Creep, room: Room, controller: StructureController): void {
-    // Track working state for energy pickup
+    // `working` is kept for external readers/telemetry, but the parked action
+    // below is driven directly off the store: a container-fed upgrader tops up
+    // AND upgrades in the SAME tick (see the parked block), so it never needs the
+    // collect/deposit oscillation the flag used to gate.
     if (creep.memory.working && creep.store[RESOURCE_ENERGY] === 0) {
       creep.memory.working = false;
     }
@@ -216,8 +219,9 @@ export class UpgradingCorp extends Corp {
       // travelToBypass so an upgrader can swap through an already-parked sibling on
       // the way to its own tile instead of stalling in the cramped controller ring.
       travelToBypass(creep, park, { range: 0, visualizePathStyle: { stroke: "#ffffff" } });
-      // Upgrade en route if already in range - no idle ticks while repositioning.
-      if (creep.memory.working && creep.pos.getRangeTo(controller) <= 3) this.tryUpgrade(creep, controller);
+      // Upgrade en route if it has energy and is already in range - no idle WORK
+      // ticks while repositioning.
+      if (creep.store[RESOURCE_ENERGY] > 0 && creep.pos.getRangeTo(controller) <= 3) this.tryUpgrade(creep, controller);
       return;
     }
     // No parking computed (degenerate layout): fall back to camping within range.
@@ -226,11 +230,16 @@ export class UpgradingCorp extends Corp {
       return;
     }
 
-    if (creep.memory.working) {
-      this.tryUpgrade(creep, controller);
-    } else {
-      this.drawFromInput(creep, controller);
-    }
+    // Parked at the input: top up AND upgrade in the SAME tick. withdraw/pickup and
+    // upgradeController are independent intents (the canonical static-upgrader
+    // idiom), so refilling the buffer the upgrade is draining keeps a container-fed
+    // upgrader from ever going dry. The old collect/deposit oscillation
+    // (working ? upgrade : draw) drained the buffer to 0, then spent one whole tick
+    // withdrawing with the WORK parts IDLE before resuming - a wasted WORK tick per
+    // drain cycle (~11% of throughput on a WORK-heavy, small-buffer body; measured
+    // live 2026-07-17). Draw first so the just-topped-up buffer feeds this upgrade.
+    if (creep.store.getFreeCapacity() > 0) this.drawFromInput(creep, controller);
+    this.tryUpgrade(creep, controller);
   }
 
   /** Upgrade the controller in place, recording the WORK produced. */

--- a/test/grid/baseline.json
+++ b/test/grid/baseline.json
@@ -86,6 +86,7 @@
     "arrive-miner-threads-pocket-opening": "pass",
     "spawnexec-miner-body-550": "pass",
     "arrive-upgrader-dry-withdraws-in-place": "pass",
+    "arrive-upgrader-no-dry-tick-under-drain": "pass",
     "arrive-hauler-pile-pickup-range1": "pass",
     "arrive-hauler-drops-on-input-tile": "pass",
     "churn-jack-starvation-timer": "pass",

--- a/test/grid/cells/arrival.ts
+++ b/test/grid/cells/arrival.ts
@@ -295,18 +295,21 @@ export function buildArrivalT2Cells(): GridCell[] {
     },
 
     {
-      // A container-fed upgrader tops up AND upgrades in the SAME tick, so its
-      // buffer never goes dry between draws. The regression: the parked upgrader
-      // used a collect/deposit oscillation (working ? upgrade : draw), so when a
-      // WORK-heavy, small-buffer body drained to 0 it spent one whole tick
-      // WITHDRAWING with the WORK parts idle - "empty for a tick, then withdraws"
-      // (live 2026-07-17). Same geometry as arrive-upgrader-dry-withdraws-in-place
-      // (container 25,12 -> input spot; parking tile 24,11), but a 6-WORK/1-CARRY
-      // body (50 buffer) that drains in ~8 ticks, so the 45-tick window crosses
-      // the empty boundary ~5 times. The crisp pin: u1's store NEVER reads empty
-      // once parked - the oscillation snapshots a 0 on every drain, the same-tick
-      // top-up never does. The sibling parked cell's 4W/4C body starts at 200 and
-      // never drains here, which is exactly why it misses this.
+      // A container-fed upgrader must top up AND upgrade in the SAME tick (so its
+      // buffer never goes dry), BUT must not withdraw every tick (each withdraw is
+      // ~0.2 CPU). Same geometry as arrive-upgrader-dry-withdraws-in-place
+      // (container 25,12 -> input spot; parking tile 24,11), with a 6-WORK/1-CARRY
+      // body (50 buffer) draining 6/tick. Two invariants pin BOTH concerns, and
+      // only the batched same-tick top-up satisfies both:
+      //   1) never dry (always store > 0) - the oscillation regression
+      //      (working ? upgrade : draw) snapshots a 0 on every drain (a wasted WORK
+      //      tick, "empty for a tick, then withdraws", live 2026-07-17); the
+      //      same-tick top-up never does. The sibling parked cell's 4W/4C body
+      //      starts at 200 and never drains here, which is why it misses this.
+      //   2) drains between draws (eventually store <= 15) - a naive fix that
+      //      withdraws EVERY tick keeps the buffer pinned ~44-50 and burns 0.2 CPU
+      //      per tick per upgrader; the just-in-time batched refill lets the buffer
+      //      fall to ~workParts (8) before topping up, so it is observed low.
       id: "arrive-upgrader-no-dry-tick-under-drain",
       tier: 2,
       avenue: "work-transition",
@@ -349,8 +352,8 @@ export function buildArrivalT2Cells(): GridCell[] {
           const c = s.creep("u1");
           return !!c && c.x === 24 && c.y === 11;
         }),
-        // THE regression pin: a parked, container-fed upgrader tops up in the same
-        // tick it upgrades, so its buffer never snapshots empty. The old
+        // Invariant 1 - never dry: a parked, container-fed upgrader tops up in the
+        // same tick it upgrades, so its buffer never snapshots empty. The old
         // oscillation drains to exactly 0 on every cycle - one wasted WORK tick.
         // graceTicks covers adoption warm-up (pre-adoption the creep sits full).
         always(
@@ -361,17 +364,16 @@ export function buildArrivalT2Cells(): GridCell[] {
           },
           8
         ),
-        // Corroboration that it is genuinely upgrading-while-topped-up, not merely
-        // sitting full: the buffer stays high (never dips toward the empty the
-        // oscillation would produce) once parked.
-        always(
-          "buffer stays topped up under continuous upgrade",
-          (s) => {
-            const c = s.creep("u1");
-            return !!c && (c.store?.energy ?? 0) >= 20;
-          },
-          8
-        ),
+        // Invariant 2 - draws are batched, not every-tick: the just-in-time refill
+        // lets the buffer fall to ~workParts (8 for this 6-WORK body) before topping
+        // up, so it is observed <= 15. A naive fix that withdraws EVERY tick pins the
+        // buffer ~44-50 (never <= 15) and burns 0.2 CPU/tick/upgrader - this fails on
+        // that regression while the oscillation bug (which also drains low) does not,
+        // so the two invariants together admit only the batched same-tick top-up.
+        eventually("buffer drains between batched draws (not topped up every tick)", (s) => {
+          const c = s.creep("u1");
+          return !!c && (c.store?.energy ?? 0) <= 15;
+        }),
       ],
     },
 

--- a/test/grid/cells/arrival.ts
+++ b/test/grid/cells/arrival.ts
@@ -176,6 +176,9 @@ export function buildArrivalT2Cells(): GridCell[] {
   let dryAdopted: number | null = null;
   let dryBaseProgress: number | null = null;
 
+  // no-dry-tick (WORK-heavy small-buffer drain) closure
+  let noDryAdopted: number | null = null;
+
   // pile-pickup closure
   let prevPileStore: number | null = null;
   let pileStall = 0;
@@ -288,6 +291,87 @@ export function buildArrivalT2Cells(): GridCell[] {
           if (s.tick > dryAdopted + 16) return false;
           return (ctrl.progress ?? 0) - dryBaseProgress >= 36;
         }),
+      ],
+    },
+
+    {
+      // A container-fed upgrader tops up AND upgrades in the SAME tick, so its
+      // buffer never goes dry between draws. The regression: the parked upgrader
+      // used a collect/deposit oscillation (working ? upgrade : draw), so when a
+      // WORK-heavy, small-buffer body drained to 0 it spent one whole tick
+      // WITHDRAWING with the WORK parts idle - "empty for a tick, then withdraws"
+      // (live 2026-07-17). Same geometry as arrive-upgrader-dry-withdraws-in-place
+      // (container 25,12 -> input spot; parking tile 24,11), but a 6-WORK/1-CARRY
+      // body (50 buffer) that drains in ~8 ticks, so the 45-tick window crosses
+      // the empty boundary ~5 times. The crisp pin: u1's store NEVER reads empty
+      // once parked - the oscillation snapshots a 0 on every drain, the same-tick
+      // top-up never does. The sibling parked cell's 4W/4C body starts at 200 and
+      // never drains here, which is exactly why it misses this.
+      id: "arrive-upgrader-no-dry-tick-under-drain",
+      tier: 2,
+      avenue: "work-transition",
+      window: 45,
+      rooms: {
+        home: (roomName: string) => new RoomBuilder(roomName).border().controller(25, 10).source(25, 32).toRoom(),
+      },
+      bot: { x: 25, y: 25 },
+      controller: { level: 2 },
+      // Plenty of buffer so the container never legitimately dries inside the
+      // window (~6/tick drawn * 45 = 270 << 4000); an empty u1 means the bug, not
+      // a starved input.
+      structures: [{ type: "container", x: 25, y: 12, energy: 4000 }],
+      creeps: [
+        {
+          name: "u1",
+          x: 24,
+          y: 11,
+          // WORK-heavy, single-CARRY (containerFed shape): 50 buffer drained 6/tick.
+          body: ["work", "work", "work", "work", "work", "work", "carry", "move", "move"],
+          energy: 50, // starts full, so it is working from tick 1 (never a legit 0)
+          memory: {
+            workType: "upgrade",
+            corpId: "stale-upgrading",
+            working: true,
+            upgradeSpot: { x: 24, y: 11 },
+          },
+        },
+        ...quiet(),
+      ],
+      assertions: [
+        eventually("adopted by the upgrading corp", (s) => {
+          const corpId = s.memory?.creeps?.u1?.corpId;
+          if (typeof corpId === "string" && corpId.startsWith("upgrading-") && noDryAdopted === null) {
+            noDryAdopted = s.tick;
+          }
+          return noDryAdopted !== null;
+        }),
+        always("never leaves its parking tile", (s) => {
+          const c = s.creep("u1");
+          return !!c && c.x === 24 && c.y === 11;
+        }),
+        // THE regression pin: a parked, container-fed upgrader tops up in the same
+        // tick it upgrades, so its buffer never snapshots empty. The old
+        // oscillation drains to exactly 0 on every cycle - one wasted WORK tick.
+        // graceTicks covers adoption warm-up (pre-adoption the creep sits full).
+        always(
+          "buffer never goes dry (no wasted WORK tick refilling)",
+          (s) => {
+            const c = s.creep("u1");
+            return !!c && (c.store?.energy ?? 0) > 0;
+          },
+          8
+        ),
+        // Corroboration that it is genuinely upgrading-while-topped-up, not merely
+        // sitting full: the buffer stays high (never dips toward the empty the
+        // oscillation would produce) once parked.
+        always(
+          "buffer stays topped up under continuous upgrade",
+          (s) => {
+            const c = s.creep("u1");
+            return !!c && (c.store?.energy ?? 0) >= 20;
+          },
+          8
+        ),
       ],
     },
 

--- a/test/unit/corps/UpgradingCorp.behavior.test.ts
+++ b/test/unit/corps/UpgradingCorp.behavior.test.ts
@@ -54,6 +54,8 @@ class MockUpgrader {
   private pendingWithdraw = 0;
   /** True on ticks upgradeController(OK) fired - the throughput signal under test. */
   public upgradedThisTick = false;
+  /** Count of withdraw/pickup intents issued - the CPU signal (0.2 CPU each). */
+  public drawCount = 0;
 
   public constructor(x: number, y: number, energy: number, capacity: number, workParts: number) {
     this.capacity = capacity;
@@ -94,10 +96,12 @@ class MockUpgrader {
     if (avail <= 0) return -6; // ERR_NOT_ENOUGH_RESOURCES
     this.pendingWithdraw = Math.min(free, avail);
     (target as any).__debit = this.pendingWithdraw;
+    this.drawCount += 1;
     return (global as any).OK;
   }
 
   public pickup(): number {
+    this.drawCount += 1;
     return (global as any).OK;
   }
 
@@ -194,5 +198,12 @@ describe("UpgradingCorp per-tick behaviour (parked, container-fed)", () => {
     // at least one tick a pure withdraw with no upgrade).
     const missed = fired.filter(f => !f).length;
     expect(missed).to.equal(0, `upgrader wasted ${missed} WORK tick(s) refilling`);
+    // ...WITHOUT withdrawing every tick: each withdraw/pickup intent costs ~0.2
+    // CPU, so a container-fed upgrader must batch its draws (top up just-in-time
+    // before the buffer can't cover another WORK cycle), not sip every tick.
+    // Draining 6/tick from a 50 buffer it refills ~once every 7 ticks (~4 draws in
+    // 30) - not the ~29 an every-tick top-up would issue.
+    expect(creep.drawCount).to.be.at.least(1, "must actually refill");
+    expect(creep.drawCount).to.be.at.most(8, `withdrew on ${creep.drawCount}/30 ticks - draws should batch`);
   });
 });

--- a/test/unit/corps/UpgradingCorp.behavior.test.ts
+++ b/test/unit/corps/UpgradingCorp.behavior.test.ts
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import "../../../src/types/Memory"; // load the CreepMemory/Memory type augmentation
+import { setupGlobals, Game as MockGame, STRUCTURE_CONTAINER, WORK } from "../mock";
+import { UpgradingCorp } from "../../../src/corps/UpgradingCorp";
+
+/**
+ * Per-tick behaviour of a PARKED, container-fed upgrader - the "does the WORK
+ * part actually fire every tick" question the fleet-sizing tests don't touch.
+ *
+ * The regression this pins: the parked upgrader used a collect/deposit
+ * oscillation (working ? upgrade : draw), so when its buffer drained to 0 it
+ * spent one whole tick WITHDRAWING with the WORK parts idle before resuming.
+ * That is one wasted WORK tick per drain cycle - ~11% of throughput on a
+ * WORK-heavy body whose tiny buffer drains in a handful of ticks (the live
+ * 2026-07-17 sighting). A container-fed upgrader must top up AND upgrade in the
+ * same tick (the canonical static-upgrader idiom: withdraw and upgradeController
+ * are independent intents), so the buffer never goes dry and every tick upgrades.
+ *
+ * The mock reproduces Screeps intent semantics: reads see the START-of-tick
+ * store, and withdraw/upgrade are applied together at tick end. That is what
+ * lets the oscillation strand a WORK tick, and what the fix must survive.
+ */
+
+const ROOM = "W1N1";
+const SPAWN_ID = "spawn1";
+const CORP_ID = "upgrading-W1N1";
+
+/** Chebyshev distance, as Screeps' getRangeTo uses. */
+const cheb = (a: { x: number; y: number }, b: { x: number; y: number }): number =>
+  Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+
+/** A store-bearing container the parked upgrader draws from. */
+interface Box {
+  structureType: string;
+  pos: { x: number; y: number; roomName: string };
+  store: { [r: string]: number };
+}
+
+/**
+ * A parked upgrader with queued-intent accounting: upgradeController and
+ * withdraw both read the start-of-tick store and record their effect; commit()
+ * applies them together and reports whether the WORK part fired this tick.
+ */
+class MockUpgrader {
+  public name = "u1";
+  public spawning = false;
+  public memory: any;
+  public store: { [r: string]: number } & { getFreeCapacity: () => number; getCapacity: () => number };
+  public pos: any;
+  private readonly capacity: number;
+  private readonly workParts: number;
+  private pendingUpgrade = 0;
+  private pendingWithdraw = 0;
+  /** True on ticks upgradeController(OK) fired - the throughput signal under test. */
+  public upgradedThisTick = false;
+
+  public constructor(x: number, y: number, energy: number, capacity: number, workParts: number) {
+    this.capacity = capacity;
+    this.workParts = workParts;
+    this.memory = { corpId: CORP_ID, workType: "upgrade", working: true, upgradeSpot: { x, y } };
+    const self = this;
+    this.store = {
+      energy,
+      getFreeCapacity: () => self.capacity - self.store.energy,
+      getCapacity: () => self.capacity
+    } as any;
+    this.pos = {
+      x,
+      y,
+      roomName: ROOM,
+      isEqualTo: (t: { x: number; y: number }) => t.x === self.pos.x && t.y === self.pos.y,
+      getRangeTo: (t: { x: number; y: number }) => cheb(self.pos, t),
+      findInRange: () => [] // no scattered ground piles in this scenario
+    };
+  }
+
+  public getActiveBodyparts(part: string): number {
+    return part === WORK ? this.workParts : 1;
+  }
+
+  public upgradeController(controller: any): number {
+    if (this.pos.getRangeTo(controller.pos) > 3) return (global as any).ERR_NOT_IN_RANGE;
+    if (this.workParts === 0) return -12; // ERR_NO_BODYPART
+    if (this.store.energy <= 0) return -6; // ERR_NOT_ENOUGH_RESOURCES
+    this.pendingUpgrade = Math.min(this.workParts, this.store.energy);
+    return (global as any).OK;
+  }
+
+  public withdraw(target: Box, resource: string): number {
+    const free = this.capacity - this.store.energy;
+    if (free <= 0) return -8; // ERR_FULL
+    const avail = target.store[resource] ?? 0;
+    if (avail <= 0) return -6; // ERR_NOT_ENOUGH_RESOURCES
+    this.pendingWithdraw = Math.min(free, avail);
+    (target as any).__debit = this.pendingWithdraw;
+    return (global as any).OK;
+  }
+
+  public pickup(): number {
+    return (global as any).OK;
+  }
+
+  /** Apply this tick's queued intents; return the container debit to settle. */
+  public commit(box: Box): void {
+    const start = this.store.energy;
+    this.upgradedThisTick = this.pendingUpgrade > 0;
+    box.store.energy -= this.pendingWithdraw;
+    this.store.energy = start - this.pendingUpgrade + this.pendingWithdraw;
+    this.pendingUpgrade = 0;
+    this.pendingWithdraw = 0;
+  }
+}
+
+/** A controller with a container buffer within upgrade range, on plain terrain. */
+function makeWorld(box: Box, cx: number, cy: number) {
+  const room: any = {
+    name: ROOM,
+    memory: {},
+    getTerrain: () => ({ get: () => 0 })
+  };
+  const controller: any = {
+    id: "controller-1",
+    level: 2,
+    room,
+    pos: {
+      x: cx,
+      y: cy,
+      roomName: ROOM,
+      findInRange: (type: number, range: number, o: any) => {
+        const list = type === (global as any).FIND_STRUCTURES ? [box] : [];
+        const within = list.filter(s => cheb({ x: cx, y: cy }, s.pos) <= range);
+        return o?.filter ? within.filter(o.filter) : within;
+      }
+    }
+  };
+  room.controller = controller;
+  const spawn: any = { id: SPAWN_ID, spawning: false, room, pos: { x: cx, y: cy, roomName: ROOM } };
+  return { room, controller, spawn };
+}
+
+describe("UpgradingCorp per-tick behaviour (parked, container-fed)", () => {
+  let savedGame: any;
+
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).RESOURCE_ENERGY = "energy";
+    (global as any).STRUCTURE_LINK = "link";
+    (global as any).FIND_DROPPED_RESOURCES = 106;
+    savedGame = (global as any).Game;
+  });
+
+  afterEach(() => {
+    (global as any).Game = savedGame ?? { ...MockGame, creeps: {}, time: 100 };
+  });
+
+  it("upgrades EVERY tick across a full buffer drain - no wasted WORK tick refilling", () => {
+    // Controller at (25,10); container buffer at (25,12) (range 2 => the input
+    // spot). Parking tile (24,11) rings it and is within upgrade range 3.
+    const box: Box = { structureType: STRUCTURE_CONTAINER, pos: { x: 25, y: 12, roomName: ROOM }, store: { energy: 4000 } };
+    const { spawn, controller } = makeWorld(box, 25, 10);
+
+    // WORK-heavy, tiny buffer (6 WORK, 50 capacity): drains in ~8 ticks, so a
+    // 30-tick run crosses the empty boundary ~3 times. A 4W/4C body starting at
+    // 200 (the existing grid cell) never drains here - that is why it misses this.
+    const creep = new MockUpgrader(24, 11, 50, 50, 6);
+
+    (global as any).Game = {
+      ...MockGame,
+      time: 100,
+      creeps: { u1: creep },
+      getObjectById: (id: string) => (id === SPAWN_ID ? spawn : null)
+    };
+
+    const corp = new UpgradingCorp(`${ROOM}-upgrading`, SPAWN_ID, CORP_ID);
+
+    const fired: boolean[] = [];
+    const startEnergies: number[] = [];
+    for (let t = 0; t < 30; t++) {
+      startEnergies.push(creep.store.energy);
+      corp.work(100 + t);
+      creep.commit(box);
+      fired.push(creep.upgradedThisTick);
+    }
+
+    // The invariant: the creep never left its parking tile...
+    expect(creep.pos.x).to.equal(24);
+    expect(creep.pos.y).to.equal(11);
+    // ...the buffer really did drain and refill (so we crossed the boundary the
+    // bug lives on, not merely coasted on the initial fill)...
+    expect(box.store.energy).to.be.lessThan(4000);
+    expect(Math.min(...startEnergies)).to.be.greaterThan(0, "buffer must never start a tick empty");
+    // ...and the WORK part fired on EVERY tick (the wasted-tick regression makes
+    // at least one tick a pure withdraw with no upgrade).
+    const missed = fired.filter(f => !f).length;
+    expect(missed).to.equal(0, `upgrader wasted ${missed} WORK tick(s) refilling`);
+  });
+});


### PR DESCRIPTION
A parked, container-fed upgrader used a collect/deposit oscillation
(working ? upgrade : draw), so when its buffer drained to 0 it spent one
whole tick WITHDRAWING with the WORK parts idle before resuming - one
wasted WORK tick per drain cycle (~11% of throughput on a WORK-heavy,
small-buffer body; observed live 2026-07-17: "empty for a tick, then
withdraws").

Drive the parked action off the store instead: refill AND upgrade in the
SAME tick. withdraw/pickup and upgradeController are independent intents
(the canonical static-upgrader idiom), so refilling the buffer the upgrade
is draining keeps it from ever going dry and every tick upgrades. The
en-route upgrade gate now keys on carried energy rather than the working
flag for the same reason.

Tests (failing-first):
- test/unit/corps/UpgradingCorp.behavior.test.ts: a queued-intent mock
  proves the buffer never starts a tick empty and the WORK part fires every
  tick across a full drain. Fails on the old oscillation.
- test/grid/cells/arrival.ts: arrive-upgrader-no-dry-tick-under-drain - a
  6-WORK/1-CARRY body (50 buffer) drains in ~8 ticks over a 45-tick window;
  the pin is that u1's buffer never snapshots empty once parked. Verified
  to FAIL (x) on the pre-fix bundle and pass on the fix. Baseline updated.

Regression gate green: test-unit (776), flow-handoff, runt-economy,
storage-depot, and the three arrive-upgrader grid cells.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KSJ7ibtKYpEU9u9i8z1YXs