### PR TITLE
Measure actual creep body parts from Creep.body

### DIFF
--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -66,6 +66,64 @@ function corpRoomName(corp: Corp): string {
 }
 
 /**
+ * A measured body: total part count plus a per-type breakdown (only non-zero
+ * types present). Keys are the raw Screeps part types ("work", "carry", ...).
+ */
+export interface BodyAggregate {
+  total: number;
+  byPart: { [part: string]: number };
+}
+
+/** Fresh, empty aggregate. */
+function emptyBody(): BodyAggregate {
+  return { total: 0, byPart: {} };
+}
+
+/**
+ * Aggregate ACTUAL body parts from every live creep (`Creep.body`), grouped by
+ * the corp that owns it (`memory.corpId`). This is measured ground truth - NOT
+ * reconstructed from planner harvest rates (the flow segment's `workParts` is
+ * the PLAN side; this is the ACTUAL side) - so a dashboard can sit the planner's
+ * committed parts next to the parts actually walking around.
+ *
+ * One pass yields both views: `perCorp` (keyed by corpId, for the corps
+ * segment) and `colony` (every creep, orphans included, for the core segment) -
+ * a creep we are paying for counts colony-wide even when no live corp claims it.
+ */
+function aggregateActualBodies(): { perCorp: Map<string, BodyAggregate>; colony: BodyAggregate } {
+  const perCorp = new Map<string, BodyAggregate>();
+  const colony = emptyBody();
+
+  for (const name in Game.creeps) {
+    const creep = Game.creeps[name];
+    const body = creep.body ?? []; // spawning/mocked creeps may lack a body
+    if (body.length === 0) continue;
+
+    const corpId = creep.memory?.corpId;
+    let bucket: BodyAggregate | undefined;
+    if (corpId) {
+      bucket = perCorp.get(corpId);
+      if (!bucket) {
+        bucket = emptyBody();
+        perCorp.set(corpId, bucket);
+      }
+    }
+
+    for (const part of body) {
+      const t = part.type;
+      colony.total++;
+      colony.byPart[t] = (colony.byPart[t] || 0) + 1;
+      if (bucket) {
+        bucket.total++;
+        bucket.byPart[t] = (bucket.byPart[t] || 0) + 1;
+      }
+    }
+  }
+
+  return { perCorp, colony };
+}
+
+/**
  * Segment assignments for telemetry data.
  */
 export const TELEMETRY_SEGMENTS = {
@@ -133,6 +191,13 @@ export interface CoreTelemetry {
     feeders: number;
     claimers: number;
   };
+  /**
+   * ACTUAL body parts across every live creep, measured from `Creep.body` (not
+   * reconstructed from planner rates). `total` is every part in the world;
+   * `byPart` breaks it down by type ("work"/"carry"/"move"/...). This is the
+   * measured "what we have" for the plan-vs-actual body-parts gauge.
+   */
+  bodyParts: BodyAggregate;
   /** Owned rooms summary */
   rooms: {
     name: string;
@@ -252,6 +317,10 @@ export interface CorpsTelemetry {
     nodeId: string;
     roomName: string;
     creepCount: number;
+    /** Total ACTUAL body parts across this corp's live creeps (measured, 0 if none). */
+    bodyParts: number;
+    /** ACTUAL body parts by type for this corp's live creeps; {} when it has none. */
+    body: { [part: string]: number };
     createdAt: number;
     lastActivityTick: number;
   }[];
@@ -355,8 +424,12 @@ export class Telemetry {
 
     if (!shouldUpdate) return;
 
+    // Measure ACTUAL bodies once (single pass over Game.creeps); core wants the
+    // colony total, corps wants the per-corp breakdown.
+    const bodies = aggregateActualBodies();
+
     // Update core telemetry (always)
-    this.updateCoreTelemetry(colony, census);
+    this.updateCoreTelemetry(colony, census, bodies.colony);
 
     // Update nodes telemetry
     this.updateNodesTelemetry(colony);
@@ -368,7 +441,7 @@ export class Telemetry {
     this.updateIntelTelemetry();
 
     // Update corps telemetry
-    this.updateCorpsTelemetry(census);
+    this.updateCorpsTelemetry(census, bodies.perCorp);
 
     // Update flow telemetry (sources, sinks, allocations)
     this.updateFlowTelemetry(flowSolution);
@@ -377,7 +450,7 @@ export class Telemetry {
   /**
    * Updates core telemetry (Segment 0).
    */
-  private updateCoreTelemetry(colony: Colony | undefined, census: CorpCensusEntry[]): void {
+  private updateCoreTelemetry(colony: Colony | undefined, census: CorpCensusEntry[], bodyParts: BodyAggregate): void {
     // Creep census: one bucket per creep-owning kind, summed from the complete
     // corp list so every kind is counted (no more silent undercount).
     const creeps: CoreTelemetry["creeps"] = {
@@ -428,7 +501,7 @@ export class Telemetry {
     }
 
     const telemetry: CoreTelemetry = {
-      version: 2, // Version 2: complete creep census, dropped colony.averageROI
+      version: 3, // Version 3: added actual body-parts capture (measured from Creep.body)
       tick: Game.time,
       shard: Game.shard?.name || "shard0",
       cpu: {
@@ -448,6 +521,7 @@ export class Telemetry {
         activeCorps: stats.activeCorps
       },
       creeps,
+      bodyParts,
       rooms
     };
 
@@ -681,13 +755,16 @@ export class Telemetry {
   /**
    * Updates corps telemetry (Segment 4).
    */
-  private updateCorpsTelemetry(census: CorpCensusEntry[]): void {
+  private updateCorpsTelemetry(census: CorpCensusEntry[], perCorpBody: Map<string, BodyAggregate>): void {
     const corps: CorpsTelemetry["corps"] = [];
     const corpsByKind: { [kind: string]: number } = {};
     let activeCorps = 0;
 
     for (const { kind, corp } of census) {
       const creepCount = corpCreepCount(corp);
+      // ACTUAL body of this corp's live creeps (measured), or empty when it owns
+      // none - never a reconstruction from planned rates.
+      const body = perCorpBody.get(corp.id) ?? emptyBody();
       corps.push({
         id: corp.id,
         kind,
@@ -695,6 +772,8 @@ export class Telemetry {
         nodeId: corp.nodeId || "",
         roomName: corpRoomName(corp),
         creepCount,
+        bodyParts: body.total,
+        body: body.byPart,
         createdAt: corp.createdAt,
         lastActivityTick: corp.lastActivityTick
       });
@@ -703,7 +782,7 @@ export class Telemetry {
     }
 
     const telemetry: CorpsTelemetry = {
-      version: 2, // Version 2: dropped money accounting, keyed by kind, full census
+      version: 3, // Version 3: added actual body-parts capture (measured from Creep.body)
       tick: Game.time,
       corps,
       summary: {
@@ -732,7 +811,9 @@ export class Telemetry {
           id: miner.sourceId,
           nodeId: miner.nodeId || "",
           harvestRate: miner.harvestRate,
-          // Work parts calculated from harvest rate (2 energy/tick per WORK part)
+          // PLANNED work parts, derived from the solver's harvest rate (2
+          // energy/tick per WORK part). The ACTUAL work parts spawned are the
+          // measured bodies on the matching harvest corp in segments 0/4.
           workParts: Math.ceil(miner.harvestRate / 2),
           efficiency: miner.efficiency,
           spawnDistance: miner.spawnDistance

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -14,6 +14,7 @@ export {
   PUBLIC_SEGMENTS,
   DEFAULT_TELEMETRY_CONFIG,
   type TelemetryConfig,
+  type BodyAggregate,
   type CoreTelemetry,
   type NodeTelemetry,
   type EdgesTelemetry,

--- a/test/unit/telemetry/census.test.ts
+++ b/test/unit/telemetry/census.test.ts
@@ -90,3 +90,83 @@ describe("Telemetry creep census (segments 0 & 4)", () => {
     expect(core.colony).to.not.have.property("averageROI");
   });
 });
+
+/**
+ * Actual body capture. "What creep body parts do we actually have" must be
+ * MEASURED from live Creep.body, not reconstructed from planner rates (the flow
+ * segment's workParts is the PLAN side; this is the ACTUAL side). Per corp so a
+ * dashboard can sit the planner's committed parts next to the parts actually
+ * walking around, and colony-wide so the plan-vs-actual gauge has one number.
+ */
+describe("Telemetry actual body capture (segments 0 & 4)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).RawMemory = RawMemory;
+    RawMemory.segments = {};
+    Game.rooms = {};
+    Game.time = 100;
+    (Game as any).gcl = { level: 1, progress: 0, progressTotal: 100 };
+    (Game as any).shard = { name: "shard1" };
+    // Real bodies, each owned by a corp via memory.corpId. `orphan` belongs to
+    // no census corp - it still has a body we are paying for, so the colony
+    // total must count it while no per-corp bucket claims it.
+    Game.creeps = {
+      miner1: { body: [{ type: "work" }, { type: "work" }, { type: "move" }], memory: { corpId: "harvest-s1" } },
+      miner2: { body: [{ type: "work" }, { type: "move" }], memory: { corpId: "harvest-s1" } },
+      hauler1: { body: [{ type: "carry" }, { type: "carry" }, { type: "move" }, { type: "move" }], memory: { corpId: "carry-s1" } },
+      orphan: { body: [{ type: "move" }], memory: { corpId: "ghost-x" } }
+    } as any;
+  });
+
+  const bodyCensus: CorpCensusEntry[] = [
+    {
+      corpId: "harvest-s1",
+      kind: "harvest",
+      corp: { id: "harvest-s1", type: "mining", nodeId: "W1N1-1-1", createdAt: 0, lastActivityTick: 0, getCreepCount: () => 2 } as any
+    },
+    {
+      corpId: "carry-s1",
+      kind: "carry",
+      corp: { id: "carry-s1", type: "hauling", nodeId: "W1N1-1-1", createdAt: 0, lastActivityTick: 0, getCreepCount: () => 1 } as any
+    }
+  ];
+
+  it("corps segment carries each corp's ACTUAL aggregate body, summed from Creep.body", () => {
+    new Telemetry().update(undefined, bodyCensus, undefined);
+    const corps = JSON.parse(RawMemory.segments[4]);
+
+    const harvest = corps.corps.find((c: any) => c.id === "harvest-s1");
+    // two miners: (2 work + 1 move) + (1 work + 1 move) => 3 work, 2 move
+    expect(harvest.bodyParts).to.equal(5);
+    expect(harvest.body).to.deep.equal({ work: 3, move: 2 });
+
+    const carry = corps.corps.find((c: any) => c.id === "carry-s1");
+    expect(carry.bodyParts).to.equal(4);
+    expect(carry.body).to.deep.equal({ carry: 2, move: 2 });
+  });
+
+  it("core segment totals ACTUAL body parts colony-wide, including orphans", () => {
+    new Telemetry().update(undefined, bodyCensus, undefined);
+    const core = JSON.parse(RawMemory.segments[0]);
+
+    // harvest (3w 2m) + carry (2c 2m) + orphan (1m) => work 3, carry 2, move 5
+    expect(core.bodyParts.total).to.equal(10);
+    expect(core.bodyParts.byPart).to.deep.equal({ work: 3, carry: 2, move: 5 });
+  });
+
+  it("a corp with no live creeps reports an empty actual body, never a reconstruction", () => {
+    const emptyCensus: CorpCensusEntry[] = [
+      {
+        corpId: "carry-empty",
+        kind: "carry",
+        corp: { id: "carry-empty", type: "hauling", nodeId: "W1N1", createdAt: 0, lastActivityTick: 0, getCreepCount: () => 0 } as any
+      }
+    ];
+    new Telemetry().update(undefined, emptyCensus, undefined);
+    const corps = JSON.parse(RawMemory.segments[4]);
+
+    const empty = corps.corps.find((c: any) => c.id === "carry-empty");
+    expect(empty.bodyParts).to.equal(0);
+    expect(empty.body).to.deep.equal({});
+  });
+});


### PR DESCRIPTION
## Summary

Add telemetry capture of ACTUAL body parts measured from live `Creep.body`, enabling plan-vs-actual comparison on the dashboard. This is the measured "what we have" side, complementing the planner's committed parts (the "what we planned" side in the flow segment's `workParts`).

## Key Changes

- **New `BodyAggregate` interface**: Captures total part count plus per-type breakdown (only non-zero types present)
- **`aggregateActualBodies()` function**: Single-pass measurement over `Game.creeps` yielding both per-corp and colony-wide aggregates
  - Handles spawning/mocked creeps that may lack a body
  - Includes orphaned creeps in colony total (they still consume energy)
  - Never reconstructs from planner rates—purely measured ground truth
- **Core telemetry (Segment 0)**: Added `bodyParts` field with colony-wide aggregate
- **Corps telemetry (Segment 4)**: Added `bodyParts` (total) and `body` (by-type breakdown) per corp
- **Version bumps**: Core and Corps segments both incremented to v3
- **Test coverage**: Three new test cases validating per-corp aggregation, colony-wide totals including orphans, and empty-corp handling

## Implementation Details

The measurement happens once per telemetry update in a single pass over `Game.creeps`, with results split into two views:
- `perCorp`: Keyed by `corpId` from creep memory, for the corps segment
- `colony`: Every creep regardless of corp ownership, for the core segment and plan-vs-actual gauges

Corps with no live creeps report `bodyParts: 0` and `body: {}` (never a reconstruction from planned rates). This allows dashboards to directly compare the planner's committed parts against the parts actually walking around.

https://claude.ai/code/session_01NhyB2hx7MsgB9kHEVq8YGg