### PR TITLE
Fix empty hauler drag-home by gating depot refill to nearby range

### DIFF
--- a/src/corps/CarryCorp.ts
+++ b/src/corps/CarryCorp.ts
@@ -161,6 +161,43 @@ export function shouldDrainDedicatedSource(
 }
 
 /**
+ * Should an empty spawn-circuit hauler REFILL from the core depot (the degraded,
+ * tender-less bridge) instead of trekking to its own source this tick? Only when
+ * the depot is a real, NEARBY bank that is at least as close as the hauler's own
+ * source pickup.
+ *
+ * The depot short-circuit (see pickupEnergy) exists to save a spawn-side hauler a
+ * full source round-trip when the bank sits one tile from the spawn. Without a
+ * sense of distance it had none: an empty hauler out at - or walking toward - a
+ * far or remote source was hauled all the way back to the core depot every tick
+ * the home network was short, delivering already-home energy to the spawn while
+ * its source's pile stranded, and U-turning across the room border mid-route.
+ * That is the observed "empty hauler heading back home" symptom.
+ *
+ * `rangeToDepot` is Infinity when the depot is a room away (it lives beside the
+ * home spawn, so off-room it is never the near bank); `rangeToPickup` is Infinity
+ * when the source is out of the creep's room this tick, so a hauler AT HOME still
+ * tops up from the depot rather than run a whole remote round-trip. Pure so the
+ * locality rule is unit-testable.
+ */
+export function shouldRefillFromDepot(params: {
+  /** Energy banked in the core depot right now. */
+  depotEnergy: number;
+  /** Free energy capacity across the spawn network (capacity - available). */
+  networkNeed: number;
+  /** Tiles from the hauler to the depot, or Infinity when the depot is off-room. */
+  rangeToDepot: number;
+  /** Tiles from the hauler to its source pickup, or Infinity when off-room/unknown. */
+  rangeToPickup: number;
+}): boolean {
+  if (params.depotEnergy <= 0) return false; // nothing banked to lend
+  if (params.networkNeed <= 0) return false; // spawn network already full
+  // The depot must be a real, nearby bank (finite range) AND no farther than the
+  // source - otherwise the hauler just heads to its source and picks up as usual.
+  return Number.isFinite(params.rangeToDepot) && params.rangeToDepot <= params.rangeToPickup;
+}
+
+/**
  * Is the spawn network critically low ENOUGH to steal a controller-bound
  * hauler's trip, given the energy already aboard fleet-mates committed to the
  * spawn this trip? "Critical" must mean "and help is not already on the way":
@@ -528,6 +565,19 @@ export class CarryCorp extends Corp {
     // until the build finishes) so the construction tankers get its full output.
     if (this.yieldsToBuild()) return;
 
+    // Resolve this hauler's ONE pickup stop first: both the degraded-refill
+    // locality check below and the normal pickup leg need it, and getAssignedSource
+    // carries memory side effects that must run exactly once per tick.
+    const sources = room.find(FIND_SOURCES);
+    const assignedSource = this.getAssignedSource(creep, sources);
+    let targetPos: RoomPosition | null = null;
+    if (assignedSource) {
+      targetPos = assignedSource.pos;
+    } else if (creep.memory.assignedSourcePos) {
+      const p = creep.memory.assignedSourcePos;
+      targetPos = new RoomPosition(p.x, p.y, p.roomName);
+    }
+
     // DEGRADED-MODE REFILL (owner SLA 2026-07-10: extensions refill before the
     // draining spawn finishes): when NO tender is alive, the depot's bank is
     // otherwise invisible to refill - only tenders move depot -> extensions -
@@ -538,30 +588,38 @@ export class CarryCorp extends Corp {
     // stays the tender's exclusive reserve).
     // Unassigned haulers (pre-first-circuit) count as spawn-circuit here: the
     // earliest drains land exactly when nothing has flipped to working yet.
+    //
+    // LOCALITY GATE (fixes "an empty hauler heading back home"): this is a
+    // reload-from-the-NEARBY-bank shortcut, so it fires only when the depot is
+    // actually the shorter reload than the trek to this hauler's own source. The
+    // depot lives beside the home spawn, so its range only counts when the creep
+    // is in that room; a room away it is never the near bank. The source pickup
+    // range is Infinity when the source is out of the creep's room this tick, so a
+    // hauler AT HOME still tops up from the depot rather than run a whole remote
+    // round-trip - but one out at (or walking toward) its far/remote source is left
+    // to pick up there instead of being dragged home (see shouldRefillFromDepot).
     if ((creep.memory.homeSink ?? "spawn") === "spawn" && room.memory.extensionTenderActive !== true) {
-      const need = room.energyCapacityAvailable - room.energyAvailable;
-      if (need > 0) {
-        const depot = coreDepot(room);
-        if (depot && depot.store[RESOURCE_ENERGY] > 0) {
-          if (creep.withdraw(depot, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-            travelTo(creep, depot, { range: 1, visualizePathStyle: { stroke: "#ffff88" } });
-          }
-          return;
+      const depot = coreDepot(room);
+      const rangeToDepot = depot && creep.room.name === room.name ? creep.pos.getRangeTo(depot) : Infinity;
+      const rangeToPickup =
+        targetPos && targetPos.roomName === creep.room.name ? creep.pos.getRangeTo(targetPos) : Infinity;
+      if (
+        depot &&
+        shouldRefillFromDepot({
+          depotEnergy: depot.store[RESOURCE_ENERGY],
+          networkNeed: room.energyCapacityAvailable - room.energyAvailable,
+          rangeToDepot,
+          rangeToPickup
+        })
+      ) {
+        if (creep.withdraw(depot, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+          travelTo(creep, depot, { range: 1, visualizePathStyle: { stroke: "#ffff88" } });
         }
+        return;
       }
     }
 
-    const sources = room.find(FIND_SOURCES);
-    const assignedSource = this.getAssignedSource(creep, sources);
-
     // The one fixed pickup stop on this hauler's bus route: its assigned source.
-    let targetPos: RoomPosition | null = null;
-    if (assignedSource) {
-      targetPos = assignedSource.pos;
-    } else if (creep.memory.assignedSourcePos) {
-      const p = creep.memory.assignedSourcePos;
-      targetPos = new RoomPosition(p.x, p.y, p.roomName);
-    }
     if (!targetPos) return;
 
     if (targetPos.roomName !== creep.room.name) {

--- a/test/unit/corps/CarryCorp.behavior.test.ts
+++ b/test/unit/corps/CarryCorp.behavior.test.ts
@@ -6,10 +6,11 @@ import {
   pickRuntToRecycle,
   pickDeliverySink,
   shouldBankControllerLoad,
+  shouldRefillFromDepot,
   CONTROLLER_STARVE_FLOOR
 } from "../../../src/corps/CarryCorp";
 import { HaulerAssignment } from "../../../src/flow/FlowTypes";
-import { Game as MockGame } from "../mock";
+import { Game as MockGame, setupGlobals } from "../mock";
 
 /**
  * Trivial, deterministic scenarios that pin down a CarryCorp's *observable*
@@ -416,6 +417,149 @@ describe("CarryCorp behaviour (trivial scenarios)", () => {
       expect(
         shouldBankControllerLoad({ hasBankCapacity: false, feederActive: true, controllerInputStock: 5000 })
       ).to.equal(false);
+    });
+  });
+
+  // The degraded, tender-less depot refill (pickupEnergy) is a reload-from-the-
+  // NEARBY-bank shortcut. Without a locality gate it dragged an empty spawn-homed
+  // hauler back to the core depot even when the hauler was out at (or walking
+  // toward) its own far/remote source - the observed "empty hauler heading back
+  // home". shouldRefillFromDepot restricts the shortcut to when the depot really
+  // is the shorter reload.
+  describe("degraded depot refill fires only when the depot is the nearer reload", () => {
+    it("refills when the depot is at least as close as the source pickup", () => {
+      expect(shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 100, rangeToDepot: 2, rangeToPickup: 16 })).to.equal(
+        true
+      );
+      expect(shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 100, rangeToDepot: 5, rangeToPickup: 5 })).to.equal(
+        true
+      );
+    });
+
+    it("treks to the source when the depot is farther (no empty drag home)", () => {
+      // The bug: an empty hauler 2 tiles from its source was hauled 16 tiles home.
+      expect(shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 100, rangeToDepot: 16, rangeToPickup: 2 })).to.equal(
+        false
+      );
+    });
+
+    it("refills at home when the source is out of the creep's room this tick", () => {
+      // A hauler AT HOME whose source is remote: top up from the near depot rather
+      // than run a whole remote round-trip (rangeToPickup is Infinity off-room).
+      expect(
+        shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 100, rangeToDepot: 3, rangeToPickup: Infinity })
+      ).to.equal(true);
+    });
+
+    it("never diverts to a depot a room away (the U-turn across the border)", () => {
+      // Creep out at its remote source: the depot is off-room (Infinity) so the
+      // hauler picks up locally instead of heading home.
+      expect(
+        shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 100, rangeToDepot: Infinity, rangeToPickup: 3 })
+      ).to.equal(false);
+      expect(
+        shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 100, rangeToDepot: Infinity, rangeToPickup: Infinity })
+      ).to.equal(false);
+    });
+
+    it("does not refill when the depot is empty or the network is already full", () => {
+      expect(shouldRefillFromDepot({ depotEnergy: 0, networkNeed: 100, rangeToDepot: 1, rangeToPickup: 50 })).to.equal(
+        false
+      );
+      expect(shouldRefillFromDepot({ depotEnergy: 500, networkNeed: 0, rangeToDepot: 1, rangeToPickup: 50 })).to.equal(
+        false
+      );
+    });
+  });
+
+  // End-to-end wiring: pickupEnergy computes the two ranges and routes the empty
+  // hauler accordingly. Proves the locality gate is actually connected.
+  describe("pickupEnergy routing (the drag, end to end)", () => {
+    const mkPos = (x: number, y: number, roomName: string) => ({ x, y, roomName });
+
+    /** Stand an empty spawn-homed hauler up in `creepRoom`, its source in
+     * `sourceRoom`, and a stocked storage depot in the home room; run pickupEnergy
+     * and report where it tried to go. */
+    function runPickup(opts: {
+      creepRoom: string;
+      sourceRoom: string;
+      withdrawResult?: number;
+    }): { withdrawTarget: unknown; moveTo: { x: number; y: number; roomName: string } | null } {
+      const HOME = "W1N1";
+      const depot = { structureType: "storage", my: true, pos: mkPos(24, 24, HOME), store: { energy: 2000 } };
+      const source = { id: "src1", pos: mkPos(10, 10, opts.sourceRoom) };
+      const rec = { withdrawTarget: null as unknown, moveTo: null as { x: number; y: number; roomName: string } | null };
+
+      const creep: any = {
+        name: "h1",
+        memory: { corpId: "W1N1-hauling-src1", workType: "haul", homeSink: "spawn" },
+        room: { name: opts.creepRoom },
+        store: { energy: 0 },
+        pos: {
+          x: 25,
+          y: 25,
+          roomName: opts.creepRoom,
+          getRangeTo: (t: any) => {
+            const p = t?.pos ?? t;
+            return Math.max(Math.abs(25 - p.x), Math.abs(25 - p.y));
+          },
+          isEqualTo: (t: any) => {
+            const p = t?.pos ?? t;
+            return p.x === 25 && p.y === 25;
+          },
+          isNearTo: () => false,
+          findInRange: () => []
+        },
+        withdraw: (t: any) => {
+          rec.withdrawTarget = t;
+          return opts.withdrawResult ?? OK;
+        },
+        moveTo: (t: any) => {
+          rec.moveTo = t?.pos ?? t;
+          return OK;
+        },
+        say: () => {}
+      };
+
+      const room: any = {
+        name: HOME,
+        memory: {},
+        storage: depot,
+        energyCapacityAvailable: 550,
+        energyAvailable: 100, // networkNeed 450 > 0
+        find: () => []
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).Game = {
+        ...MockGame,
+        time: 100,
+        creeps: { h1: creep },
+        getObjectById: (id: string) => (id === "src1" ? source : null)
+      };
+
+      const corp = carryCorp("W1N1-hauling-src1");
+      corp.setHaulerAssignments([route("spawn1", 5, 2)]); // fromId "source-src1"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (corp as any).pickupEnergy(creep, room);
+      return rec;
+    }
+
+    it("does NOT drag an empty hauler home when it is out near its source", () => {
+      // Creep is in a room away from home, its source one room further out. The
+      // stocked home depot must NOT pull it back: it keeps heading to its source.
+      const rec = runPickup({ creepRoom: "W2N1", sourceRoom: "W3N1" });
+      expect(rec.withdrawTarget, "must not touch the home depot").to.equal(null);
+      expect(rec.moveTo, "keeps moving toward its source").to.not.equal(null);
+      expect(rec.moveTo!.roomName).to.equal("W3N1");
+    });
+
+    it("still tops up from the depot when the hauler is AT HOME (source remote)", () => {
+      // Same energy conditions, but the hauler is in the home room: the near depot
+      // is the shorter reload, so the degraded shortcut still fires.
+      const rec = runPickup({ creepRoom: "W1N1", sourceRoom: "W2N1" });
+      expect(rec.withdrawTarget, "reloads from the home depot").to.not.equal(null);
+      expect((rec.withdrawTarget as any).structureType).to.equal("storage");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the "empty hauler heading back home" bug where spawn-circuit haulers were being pulled back to the core depot even when stationed at or walking toward their assigned remote sources. The issue was that the degraded-mode depot refill (used when no tender is alive) lacked a locality gate and would unconditionally redirect any empty hauler to the nearby depot whenever the spawn network needed energy.

## Changes

- **Added `shouldRefillFromDepot()` function** (`src/corps/CarryCorp.ts`): A pure decision function that gates the depot refill shortcut to fire only when the depot is actually the nearer reload than the hauler's assigned source. The function checks:
  - Depot has energy available (`depotEnergy > 0`)
  - Network has unmet demand (`networkNeed > 0`)
  - Depot is in-room and reachable (`rangeToDepot` is finite)
  - Depot is no farther than the source (`rangeToDepot <= rangeToPickup`)
  - Handles remote sources correctly: `rangeToPickup = Infinity` when source is off-room, allowing haulers at home to still top up from the nearby depot rather than run a full remote round-trip

- **Refactored `pickupEnergy()` in CarryCorp** to:
  - Compute the assigned source and its target position once at the start (moving this logic before the depot refill check)
  - Calculate both `rangeToDepot` and `rangeToPickup` with proper off-room handling (Infinity when target is not in creep's current room)
  - Apply the `shouldRefillFromDepot()` gate before attempting depot withdrawal
  - Prevents the U-turn behavior where haulers would abandon their route to distant sources

- **Added comprehensive unit tests** covering:
  - Depot refill fires when depot is closer or equidistant to source
  - Hauler stays on course to source when source is nearer
  - Hauler at home still refills from depot when source is remote (Infinity range)
  - Hauler never diverts to off-room depot (prevents cross-border U-turns)
  - Refill blocked when depot is empty or network is full
  - End-to-end integration test (`pickupEnergy routing`) verifying the locality gate is wired correctly and prevents the drag-home symptom

## Implementation Details

The locality gate uses `Number.isFinite()` to detect off-room targets (which have `Infinity` range). This allows the logic to distinguish between:
- A hauler in the home room with a remote source: refill from nearby depot (shorter trip)
- A hauler at a remote source with the depot off-room: pick up locally (depot is not the near bank)
- A hauler walking toward a remote source: continue to source (don't interrupt the route)

The fix is purely additive to the decision logic and does not change the refill mechanism itself—only when it fires.

https://claude.ai/code/session_01ACp48hzkGJ7RB9ZcbjKgfy