### PR TITLE
telemetry: expose planned hauler + consumer body in the flow segment

### DIFF
--- a/src/economy/primitives.ts
+++ b/src/economy/primitives.ts
@@ -26,6 +26,22 @@ export const CARRY_CAPACITY = 50;
 /** Energy/tick a standard source yields (3000 capacity / 300 regen). */
 export const SOURCE_RATE = 10;
 
+/** Energy/tick a single WORK part moves, by work class (Screeps *_POWER). */
+export const HARVEST_ENERGY_PER_WORK = 2; // HARVEST_POWER: 2 energy/tick per WORK
+export const UPGRADE_ENERGY_PER_WORK = 1; // UPGRADE_CONTROLLER_POWER: 1 energy/tick per WORK
+export const BUILD_ENERGY_PER_WORK = 5; // BUILD_POWER: 5 energy/tick per WORK
+
+/**
+ * WORK parts needed to move `energyPerTick` at `energyPerWork` energy/tick per
+ * WORK - the single conversion behind every "energy rate -> WORK body" figure
+ * (miner harvest, upgrader burn, builder burn). Rounded up: a fractional WORK
+ * cannot be spawned. Zero/negative rate -> 0 parts.
+ */
+export function workPartsForEnergyRate(energyPerTick: number, energyPerWork: number): number {
+  if (energyPerTick <= 0) return 0;
+  return Math.ceil(energyPerTick / energyPerWork);
+}
+
 /**
  * Effective working life (ticks) of a creep posted `distance` tiles from its
  * spawn. It spends ~`distance` ticks walking to its post before it can work or

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -21,6 +21,22 @@
 import { Colony } from "../colony/Colony";
 import { Corp } from "../corps/Corp";
 import { FlowSolution } from "../flow/FlowTypes";
+import {
+  BUILD_ENERGY_PER_WORK,
+  HARVEST_ENERGY_PER_WORK,
+  UPGRADE_ENERGY_PER_WORK,
+  workPartsForEnergyRate
+} from "../economy/primitives";
+
+/**
+ * Energy/tick a single WORK part burns at a WORK-driven consumer sink, keyed by
+ * sink type. Sinks absent here are not WORK-driven, so they get no planned WORK
+ * figure (their plan currency is the energy allocation itself).
+ */
+const SINK_ENERGY_PER_WORK: Record<string, number> = {
+  controller: UPGRADE_ENERGY_PER_WORK,
+  construction: BUILD_ENERGY_PER_WORK
+};
 
 /**
  * One corp in the complete census (structurally compatible with
@@ -351,6 +367,29 @@ export interface FlowTelemetry {
     /** Distance from spawn */
     spawnDistance: number;
   }[];
+  /**
+   * PLANNED haulers (goal-plan side). Each solver hauler assignment with the
+   * CARRY parts it is sized to field - the plan-side analog to `sources[].
+   * workParts`. Compare `carryParts` here against the actual CARRY on the
+   * matching hauling corp in segment 4.
+   */
+  haulers: {
+    edgeId: string;
+    /** Energy source (fromId) */
+    sourceId: string;
+    /** Destination sink (toId) */
+    sinkId: string;
+    /** PLANNED CARRY parts the solver sized this route to */
+    carryParts: number;
+    /** Energy/tick transported */
+    flowRate: number;
+    /** Walking distance one way */
+    distance: number;
+    /** Spawn these haulers come from */
+    spawnId: string;
+    /** CARRY:MOVE ratio the variant optimizer chose ("2:1" paved, "1:1", "1:2") */
+    ratio?: string;
+  }[];
   /** Sink nodes (energy consumers) - spawns, controllers, construction */
   sinks: {
     id: string;
@@ -360,6 +399,15 @@ export interface FlowTelemetry {
     allocated: number;
     unmet: number;
     priority: number;
+    /**
+     * PLANNED WORK parts implied by `allocated` for WORK-driven consumer sinks
+     * (controller=upgrade, construction=build); absent for non-WORK sinks
+     * (spawn/extension/tower/...). This is the GOAL-plan sizing - consumers are
+     * actually sized from live stock (sustainableConsumptionRate), so read it as
+     * a ramp gauge, and compare against the actual WORK on the matching upgrade/
+     * construction corp in segment 4.
+     */
+    workParts?: number;
   }[];
   /** Flow summary */
   summary: {
@@ -802,6 +850,7 @@ export class Telemetry {
   private updateFlowTelemetry(flowSolution?: FlowSolution): void {
     // Build source data from miner assignments
     const sources: FlowTelemetry["sources"] = [];
+    const haulers: FlowTelemetry["haulers"] = [];
     const sinks: FlowTelemetry["sinks"] = [];
 
     if (flowSolution) {
@@ -811,17 +860,37 @@ export class Telemetry {
           id: miner.sourceId,
           nodeId: miner.nodeId || "",
           harvestRate: miner.harvestRate,
-          // PLANNED work parts, derived from the solver's harvest rate (2
-          // energy/tick per WORK part). The ACTUAL work parts spawned are the
-          // measured bodies on the matching harvest corp in segments 0/4.
-          workParts: Math.ceil(miner.harvestRate / 2),
+          // PLANNED work parts, from the solver's harvest rate via the shared
+          // energy-rate->WORK primitive (harvest = 2 energy/tick per WORK). The
+          // ACTUAL work parts spawned are the measured bodies on the matching
+          // harvest corp in segments 0/4.
+          workParts: workPartsForEnergyRate(miner.harvestRate, HARVEST_ENERGY_PER_WORK),
           efficiency: miner.efficiency,
           spawnDistance: miner.spawnDistance
         });
       }
 
+      // Collect PLANNED haulers - the plan-side carry-part budget per route, the
+      // analog of sources[].workParts for the hauling half of the economy.
+      for (const hauler of flowSolution.haulers) {
+        haulers.push({
+          edgeId: hauler.edgeId,
+          sourceId: hauler.fromId,
+          sinkId: hauler.toId,
+          carryParts: hauler.carryParts,
+          flowRate: hauler.flowRate,
+          distance: hauler.distance,
+          spawnId: hauler.spawnId,
+          ratio: hauler.haulerRatio
+        });
+      }
+
       // Collect sinks from sink allocations
       for (const sink of flowSolution.sinkAllocations) {
+        // WORK-driven consumers (upgrade/build) get a planned WORK figure derived
+        // from their energy allocation; others carry none (undefined is dropped
+        // from the JSON, keeping non-WORK sinks unchanged).
+        const perWork = SINK_ENERGY_PER_WORK[sink.sinkType];
         sinks.push({
           id: sink.sinkId,
           // nodeId not available in SinkAllocation - could be derived from sinkId if needed
@@ -829,15 +898,17 @@ export class Telemetry {
           demand: sink.demand,
           allocated: sink.allocated,
           unmet: sink.unmet,
-          priority: sink.priority
+          priority: sink.priority,
+          workParts: perWork === undefined ? undefined : workPartsForEnergyRate(sink.allocated, perWork)
         });
       }
     }
 
     const telemetry: FlowTelemetry = {
-      version: 1,
+      version: 2, // Version 2: added planned hauler carry + consumer WORK (full plan-side body)
       tick: Game.time,
       sources,
+      haulers,
       sinks,
       summary: flowSolution
         ? {

--- a/test/fixtures/telemetry/shard1-t72397930.json
+++ b/test/fixtures/telemetry/shard1-t72397930.json
@@ -1,0 +1,740 @@
+{
+  "shard": "shard1",
+  "capturedAt": "2026-07-18T00:13:09.570Z",
+  "tick": 72397930,
+  "segments": [
+    0,
+    4,
+    6
+  ],
+  "data": {
+    "core": {
+      "version": 3,
+      "tick": 72397930,
+      "shard": "shard1",
+      "cpu": {
+        "used": 76.95200479999949,
+        "limit": 300,
+        "bucket": 10000,
+        "tickLimit": 500
+      },
+      "gcl": {
+        "level": 32,
+        "progress": 273500053.58056545,
+        "progressTotal": 300508132.580564
+      },
+      "colony": {
+        "nodeCount": 480,
+        "totalCorps": 39,
+        "activeCorps": 27
+      },
+      "creeps": {
+        "total": 33,
+        "tracked": 30,
+        "untracked": 3,
+        "bootstrap": 0,
+        "miners": 7,
+        "haulers": 11,
+        "upgraders": 1,
+        "scouts": 0,
+        "builders": 3,
+        "reservers": 4,
+        "tankers": 3,
+        "feeders": 1,
+        "claimers": 0
+      },
+      "bodyParts": {
+        "total": 362,
+        "byPart": {
+          "work": 41,
+          "move": 151,
+          "claim": 8,
+          "carry": 162
+        }
+      },
+      "rooms": [
+        {
+          "name": "W43N23",
+          "rcl": 5,
+          "rclProgress": 503878,
+          "rclProgressTotal": 1215000,
+          "energyAvailable": 1800,
+          "energyCapacity": 1800
+        }
+      ]
+    },
+    "corps": {
+      "version": 3,
+      "tick": 72397931,
+      "corps": [
+        {
+          "id": "mining-W43N23-harvest-cd92",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W43N23-harvest-cd92",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "mining-W43N23-harvest-cd90",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W43N23-harvest-cd90",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-cd92",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-cd92",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 10,
+          "body": {
+            "carry": 5,
+            "move": 5
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-cd90",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-cd90",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 14,
+          "body": {
+            "carry": 7,
+            "move": 7
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "upgrading-W43N23-upgrading",
+          "kind": "upgrade",
+          "type": "upgrading",
+          "nodeId": "W43N23-upgrading",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 4,
+          "body": {
+            "work": 2,
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "building-W43N23-construction",
+          "kind": "construction",
+          "type": "building",
+          "nodeId": "W43N23-construction",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 16,
+          "body": {
+            "work": 2,
+            "carry": 9,
+            "move": 5
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "reservation-W43N23-reservation",
+          "kind": "reservation",
+          "type": "reservation",
+          "nodeId": "W43N23-reservation",
+          "roomName": "W43N23",
+          "creepCount": 4,
+          "bodyParts": 16,
+          "body": {
+            "claim": 8,
+            "move": 8
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "scout-W43N23-scout",
+          "kind": "scout",
+          "type": "scout",
+          "nodeId": "W43N23-scout",
+          "roomName": "W43N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "moving-W43N23-tender",
+          "kind": "tender",
+          "type": "moving",
+          "nodeId": "W43N23-tender",
+          "roomName": "W43N23",
+          "creepCount": 3,
+          "bodyParts": 72,
+          "body": {
+            "carry": 54,
+            "move": 18
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "moving-W43N23-controllerFeeder",
+          "kind": "controllerFeeder",
+          "type": "moving",
+          "nodeId": "W43N23-controllerFeeder",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 20,
+          "body": {
+            "carry": 10,
+            "move": 10
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "mining-W44N23-harvest-cbd5",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W44N23-harvest-cbd5",
+          "roomName": "W44N23",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "mining-W43N24-harvest-cd8d",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W43N24-harvest-cd8d",
+          "roomName": "W43N24",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W42N22-hauling-cee0",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W42N22-hauling-cee0",
+          "roomName": "W42N22",
+          "creepCount": 1,
+          "bodyParts": 24,
+          "body": {
+            "carry": 12,
+            "move": 12
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N24-hauling-cd8e",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N24-hauling-cd8e",
+          "roomName": "W43N24",
+          "creepCount": 1,
+          "bodyParts": 30,
+          "body": {
+            "carry": 15,
+            "move": 15
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W44N23-hauling-cbd5",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W44N23-hauling-cbd5",
+          "roomName": "W44N23",
+          "creepCount": 0,
+          "bodyParts": 24,
+          "body": {
+            "carry": 12,
+            "move": 12
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N24-hauling-cd8d",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N24-hauling-cd8d",
+          "roomName": "W43N24",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "building-W43N24-construction",
+          "kind": "construction",
+          "type": "building",
+          "nodeId": "W43N24-construction",
+          "roomName": "W43N24",
+          "creepCount": 1,
+          "bodyParts": 3,
+          "body": {
+            "work": 1,
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W42N23-hauling-cedc",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W42N23-hauling-cedc",
+          "roomName": "W42N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "building-W42N23-construction",
+          "kind": "construction",
+          "type": "building",
+          "nodeId": "W42N23-construction",
+          "roomName": "W42N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W42N22-hauling--8-7",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W42N22-hauling--8-7",
+          "roomName": "W42N22",
+          "creepCount": 1,
+          "bodyParts": 28,
+          "body": {
+            "carry": 14,
+            "move": 14
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W44N23-hauling-4-30",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W44N23-hauling-4-30",
+          "roomName": "W44N23",
+          "creepCount": 1,
+          "bodyParts": 30,
+          "body": {
+            "carry": 15,
+            "move": 15
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N24-hauling-0-20",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N24-hauling-0-20",
+          "roomName": "W43N24",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "mining-W43N24-harvest-cd8e",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W43N24-harvest-cd8e",
+          "roomName": "W43N24",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "mining-W42N22-harvest-cee0",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W42N22-harvest-cee0",
+          "roomName": "W42N22",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "mining-W42N23-harvest-cedc",
+          "kind": "harvest",
+          "type": "mining",
+          "nodeId": "W42N23-harvest-cedc",
+          "roomName": "W42N23",
+          "creepCount": 1,
+          "bodyParts": 8,
+          "body": {
+            "work": 5,
+            "move": 3
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-2-33",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-2-33",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 4,
+          "body": {
+            "carry": 2,
+            "move": 2
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "coreBuster-W43N23-coreBuster",
+          "kind": "coreBuster",
+          "type": "coreBuster",
+          "nodeId": "W43N23-coreBuster",
+          "roomName": "W43N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "raidGuard-W43N23-raidGuard",
+          "kind": "raidGuard",
+          "type": "raidGuard",
+          "nodeId": "W43N23-raidGuard",
+          "roomName": "W43N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-8-27",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-8-27",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 2,
+          "body": {
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-5-26",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-5-26",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 2,
+          "body": {
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "building-W42N22-construction",
+          "kind": "construction",
+          "type": "building",
+          "nodeId": "W42N22-construction",
+          "roomName": "W42N22",
+          "creepCount": 1,
+          "bodyParts": 3,
+          "body": {
+            "work": 1,
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-5-24",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-5-24",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 2,
+          "body": {
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-7-12",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-7-12",
+          "roomName": "W43N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "building-W44N23-construction",
+          "kind": "construction",
+          "type": "building",
+          "nodeId": "W44N23-construction",
+          "roomName": "W44N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "hauling-W43N23-hauling-4-37",
+          "kind": "carry",
+          "type": "hauling",
+          "nodeId": "W43N23-hauling-4-37",
+          "roomName": "W43N23",
+          "creepCount": 1,
+          "bodyParts": 2,
+          "body": {
+            "carry": 1,
+            "move": 1
+          },
+          "createdAt": 0,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "bootstrap-W52N54-bootstrap",
+          "kind": "bootstrap",
+          "type": "bootstrap",
+          "nodeId": "W52N54-bootstrap",
+          "roomName": "W52N54",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 67539147,
+          "lastActivityTick": 67540007
+        },
+        {
+          "id": "bootstrap-W43N23-bootstrap",
+          "kind": "bootstrap",
+          "type": "bootstrap",
+          "nodeId": "W43N23-bootstrap",
+          "roomName": "W43N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 71517050,
+          "lastActivityTick": 72397931
+        },
+        {
+          "id": "spawning-W52N54-spawn-da09",
+          "kind": "spawning",
+          "type": "spawning",
+          "nodeId": "W52N54-spawn-da09",
+          "roomName": "W52N54",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 67539147,
+          "lastActivityTick": 67540007
+        },
+        {
+          "id": "spawning-W43N23-spawn-16a5",
+          "kind": "spawning",
+          "type": "spawning",
+          "nodeId": "W43N23-spawn-16a5",
+          "roomName": "W43N23",
+          "creepCount": 0,
+          "bodyParts": 0,
+          "body": {},
+          "createdAt": 71517050,
+          "lastActivityTick": 72397931
+        }
+      ],
+      "summary": {
+        "totalCorps": 39,
+        "activeCorps": 25,
+        "corpsByKind": {
+          "harvest": 7,
+          "carry": 16,
+          "upgrade": 1,
+          "construction": 5,
+          "reservation": 1,
+          "scout": 1,
+          "tender": 1,
+          "controllerFeeder": 1,
+          "coreBuster": 1,
+          "raidGuard": 1,
+          "bootstrap": 2,
+          "spawning": 2
+        }
+      }
+    },
+    "flow": {
+      "version": 1,
+      "tick": 72397931,
+      "sources": [
+        {
+          "id": "source-5982fc1db097071b4adbcd92",
+          "nodeId": "W43N23-37-40",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 92.4110141034251,
+          "spawnDistance": 11
+        },
+        {
+          "id": "source-5982fc1db097071b4adbcd90",
+          "nodeId": "W43N23-40-4",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 91.31313131313131,
+          "spawnDistance": 15
+        },
+        {
+          "id": "source-5982fc1db097071b4adbcd8e",
+          "nodeId": "W43N24-36-39",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 84.73653395784544,
+          "spawnDistance": 36
+        },
+        {
+          "id": "source-5982fc28b097071b4adbcee0",
+          "nodeId": "W42N22-9-3",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 81.8854391825506,
+          "spawnDistance": 46
+        },
+        {
+          "id": "source-5982fc11b097071b4adbcbd5",
+          "nodeId": "W44N23-33-22",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 79.86622568861685,
+          "spawnDistance": 53
+        },
+        {
+          "id": "source-5982fc1db097071b4adbcd8d",
+          "nodeId": "W43N24-27-22",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 79.57617071724957,
+          "spawnDistance": 54
+        },
+        {
+          "id": "source-5982fc28b097071b4adbcedc",
+          "nodeId": "W42N23-22-9",
+          "harvestRate": 10,
+          "workParts": 5,
+          "efficiency": 79.57617071724957,
+          "spawnDistance": 54
+        }
+      ],
+      "sinks": [
+        {
+          "id": "controller-5982fc1db097071b4adbcd91",
+          "type": "controller",
+          "demand": 423.3066666666667,
+          "allocated": 2,
+          "unmet": 421.3066666666667,
+          "priority": 49.88175644789577
+        },
+        {
+          "id": "spawn-6a261309c1ca830013f516a5",
+          "type": "spawn",
+          "demand": 46,
+          "allocated": 46,
+          "unmet": 0,
+          "priority": 100
+        },
+        {
+          "id": "construction-6a5ab8d073952b5bc1695a21",
+          "type": "construction",
+          "demand": 355,
+          "allocated": 90.30666666666667,
+          "unmet": 264.6933333333333,
+          "priority": 70
+        }
+      ],
+      "summary": {
+        "totalHarvest": 138.30666666666667,
+        "totalOverhead": 14.710121320190778,
+        "netEnergy": 123.59654534647589,
+        "efficiency": 89.36412707014067,
+        "isSustainable": true,
+        "minerCount": 7,
+        "haulerCount": 13
+      },
+      "warnings": []
+    }
+  },
+  "note": "economy segments only (core/corps/flow); topology (nodes/edges/intel) and blackbox dropped as noise for the body-parts reference"
+}

--- a/test/unit/telemetry/flowPlan.test.ts
+++ b/test/unit/telemetry/flowPlan.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { setupGlobals, Game, RawMemory } from "../mock";
+import { Telemetry } from "../../../src/telemetry/Telemetry";
+
+/**
+ * The flow segment IS the goal-plan side (segments 0/4 are the measured
+ * actual). Miners already carry a plan-side `workParts`; haulers and consumers
+ * did not, so their planned body was untellable from telemetry - you had to pull
+ * Memory. These assertions pin the plan side for every body-bearing role:
+ * hauler carry (solver) and consumer WORK (derived from the sink allocation),
+ * so a dashboard can sit each against the actual body in segment 4.
+ */
+describe("Telemetry flow plan: hauler + consumer planned body (segment 6)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).RawMemory = RawMemory;
+    RawMemory.segments = {};
+    Game.rooms = {};
+    Game.time = 100;
+    (Game as any).gcl = { level: 1, progress: 0, progressTotal: 100 };
+    (Game as any).shard = { name: "shard1" };
+    Game.creeps = {};
+  });
+
+  const solution: any = {
+    miners: [{ sourceId: "s1", nodeId: "W1N1-1-1", harvestRate: 10, efficiency: 90, spawnDistance: 12 }],
+    haulers: [
+      { edgeId: "e1", fromId: "s1", toId: "controller-W1N1", distance: 20, carryParts: 8, flowRate: 10, spawnCostPerTick: 0.5, spawnId: "spawn1", haulerRatio: "1:1" },
+      { edgeId: "e2", fromId: "s1", toId: "spawn-W1N1", distance: 5, carryParts: 3, flowRate: 6, spawnCostPerTick: 0.2, spawnId: "spawn1" }
+    ],
+    sinkAllocations: [
+      { sinkId: "controller-W1N1", sinkType: "controller", allocated: 9, demand: 12, unmet: 3, priority: 60, sourceFlows: [] },
+      { sinkId: "site-W1N1", sinkType: "construction", allocated: 10, demand: 10, unmet: 0, priority: 70, sourceFlows: [] },
+      { sinkId: "spawn-W1N1", sinkType: "spawn", allocated: 5, demand: 5, unmet: 0, priority: 100, sourceFlows: [] }
+    ],
+    totalHarvest: 10,
+    totalOverhead: 1,
+    netEnergy: 9,
+    efficiency: 90,
+    isSustainable: true,
+    unmetDemand: new Map(),
+    warnings: [],
+    computedAt: 100
+  };
+
+  it("exports the solver's PLANNED hauler carry parts (the plan side for haulers)", () => {
+    new Telemetry().update(undefined, [], solution);
+    const flow = JSON.parse(RawMemory.segments[6]);
+
+    expect(flow.haulers).to.have.length(2);
+    const h = flow.haulers.find((x: any) => x.sinkId === "controller-W1N1");
+    expect(h.carryParts).to.equal(8);
+    expect(h.flowRate).to.equal(10);
+    expect(h.distance).to.equal(20);
+    expect(h.ratio).to.equal("1:1");
+    // total planned hauler carry, directly comparable to actual carry in segment 4
+    expect(flow.haulers.reduce((a: number, x: any) => a + x.carryParts, 0)).to.equal(11);
+  });
+
+  it("derives PLANNED WORK for WORK-driven consumer sinks (upgrade 1:1, build 5:1)", () => {
+    new Telemetry().update(undefined, [], solution);
+    const flow = JSON.parse(RawMemory.segments[6]);
+
+    // upgrade burns 1 energy/tick per WORK -> 9 allocated => 9 WORK
+    const ctrl = flow.sinks.find((s: any) => s.type === "controller");
+    expect(ctrl.workParts).to.equal(9);
+    // build burns 5 energy/tick per WORK -> 10 allocated => 2 WORK
+    const site = flow.sinks.find((s: any) => s.type === "construction");
+    expect(site.workParts).to.equal(2);
+    // non-WORK sinks (spawn/extension/tower/...) carry no workParts figure
+    const spawn = flow.sinks.find((s: any) => s.type === "spawn");
+    expect(spawn.workParts).to.be.undefined;
+  });
+
+  it("routes miner workParts through the same shared primitive (behaviour preserved)", () => {
+    new Telemetry().update(undefined, [], solution);
+    const flow = JSON.parse(RawMemory.segments[6]);
+    expect(flow.sources[0].workParts).to.equal(5); // ceil(10 / 2 energy-per-WORK)
+  });
+
+  it("bumps the flow segment version for the new plan fields", () => {
+    new Telemetry().update(undefined, [], solution);
+    const flow = JSON.parse(RawMemory.segments[6]);
+    expect(flow.version).to.equal(2);
+  });
+});


### PR DESCRIPTION
Follow-up to #111 (actual creep-body capture, now squash-merged into `master`). That PR made the **actual** body measurable in segments 0/4; this one completes the **plan** side so plan-vs-actual is readable for *every* body-bearing role straight from telemetry — no `Memory` pull.

The flow segment is the goal-plan side. Miners already carried a plan-side `workParts` there; haulers and consumers did not, so their planned body was untellable from telemetry alone.

## Changes (flow segment version 1 → 2)

- **`haulers[]`** — the solver's planned `carryParts` per route (+ `flowRate`, `distance`, `ratio`, `sourceId`/`sinkId`). The hauling analog to `sources[].workParts`; sum it against actual CARRY on the matching hauling corp in segment 4.
- **sink `workParts`** — planned WORK for WORK-driven consumer sinks (`controller` = upgrade 1:1, `construction` = build 5:1), derived from the energy allocation. Absent for non-WORK sinks. Labelled in-code as the **goal-plan** implication (consumers are actually sized from live stock per the macro doctrine), i.e. a ramp gauge — compare against actual WORK on the matching upgrade/construction corp in segment 4.
- **`primitives.ts`** — the energy→WORK conversion now lives in one helper (`workPartsForEnergyRate`) with `HARVEST/UPGRADE/BUILD_ENERGY_PER_WORK` constants. The existing miner `workParts` routes through it too (same value), honoring the "all economics in `primitives.ts`" rule.
- **fixture** — first prod capture on the v3 schema, slimmed to the three economy segments (~19K; the ~150K of nodes/edges/intel topology is dropped as noise for a body-parts reference).

## Verification

- 4 new flow-plan unit tests (planned hauler carry; consumer WORK 1:1 & 5:1; non-WORK sink has none; miner reroute preserves value; version bump)
- Full unit suite **856 passing** (incl. the kind-conformance suite guarding the primitives rule)
- `npm run build` clean; `flow-handoff` integration test green (bootstrap→flow transition intact)

## Deploy note

The flow v2 fields appear in live telemetry only after this build deploys. The committed fixture still shows flow v1 (haulers absent) because prod hasn't got this yet; a fresh `capture:telemetry` post-deploy will show v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhyB2hx7MsgB9kHEVq8YGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhyB2hx7MsgB9kHEVq8YGg)_