### PR TITLE
telemetry: room energy ledger + sizing records (spec 14 phases 1–2)

### DIFF
--- a/docs/specs/14-telemetry-observability.md
+++ b/docs/specs/14-telemetry-observability.md
@@ -1,7 +1,14 @@
 # 14 — Telemetry observability: answer the basic questions
 
-**Status:** proposed 2026-07-18. Phases 0 (actual bodies, PR #111) and 0b
-(plan-side bodies, PR #113) landed/in-review; phases 1–4 open.
+**Status:** phases 0/0b LANDED (PRs #111/#113); phases 1–2 implemented
+2026-07-18 (room energy ledger, core v4; sizing records, corps v4 — first
+stamper: UpgradingCorp via the shared `nodeEnergy.controllerSideStock`
+lens and `upgraderSizing`); phases 3–4 open.
+Deviation from the plan as written: phase 1 drops the
+`spawnEnergy`/`extensionEnergy` split — no decision reads a per-structure
+split (the lens decisions read is `energyAvailable`/`energyCapacity`,
+already exported), and the ledger carries only lenses decisions actually
+use.
 
 ## The problem, from evidence
 
@@ -56,6 +63,7 @@ Extend `CoreTelemetry.rooms[]` with the stocks decisions read:
 Acceptance (unit, census-test style): a mocked room with storage/container
 stocks lands each field in segment 0; a storage-less room reports nulls,
 not zeros. Core version 3 → 4.
+**DONE** — `test/unit/telemetry/roomLedger.test.ts`.
 
 ### Phase 2 — sizing records (the "why is it 2 WORK" question)
 
@@ -71,6 +79,8 @@ Acceptance: unit test drives `getSpawnDemand` with a known stock and
 asserts the corps segment carries the exact inputs the decision used
 (not recomputed values). Corps version 3 → 4 (one bump shared with any
 concurrently landing field).
+**DONE** — `test/unit/telemetry/sizingRecord.test.ts` (stamp verbatim
+export + UpgradingCorp decision-site stamp on the plan-trusted path).
 
 ### Phase 3 — spawn meter (the "what is spawn capacity at" question)
 

--- a/docs/specs/14-telemetry-observability.md
+++ b/docs/specs/14-telemetry-observability.md
@@ -1,0 +1,112 @@
+# 14 — Telemetry observability: answer the basic questions
+
+**Status:** proposed 2026-07-18. Phases 0 (actual bodies, PR #111) and 0b
+(plan-side bodies, PR #113) landed/in-review; phases 1–4 open.
+
+## The problem, from evidence
+
+A single owner session (2026-07-18) asked four ordinary questions of the
+live economy. Telemetry answered **none** of them without code spelunking,
+hand arithmetic, or the owner's own memory:
+
+| Question | Why telemetry couldn't answer |
+|---|---|
+| "What creep bodies does the plan want vs what we have?" | Actual bodies weren't captured at all (only counts); plan bodies existed for miners only. **Fixed** by phases 0/0b. |
+| "Why is the upgrader 2 WORK?" | The sizing inputs (`planAllocated`, controller-side stock, banked energy, inflow, `controllerFeederActive`) are live `Game` reads inside `UpgradingCorp.getSpawnDemand` — exported nowhere. |
+| "How much energy is in storage?" | The warchest balance is not in any segment. The owner had to say "200k+" from the game client. |
+| "What is spawn capacity at?" | No measured spawn utilization, no actual parts/tick, no queue depth. Derived by hand from `SPAWN_PARTS_PER_TICK` + fleet body counts. |
+
+The pattern: telemetry exports **outcomes** (counts, allocations, ROI) but
+not **stocks** or **decision inputs**. Sizing decisions read live Game state
+at the decision site (`container.store`, `storage.store.energy`,
+`room.memory.controllerFeederActive`); those reads are captured nowhere —
+not in segments, and not in `Memory` dumps either (store objects are not
+Memory). So every "why is X sized this way" requires reproducing the read,
+which sims can't do (live-only state) and captures can't recover after the
+fact.
+
+## Design principle: decision symmetry
+
+Generalize the staffsPost-symmetry doctrine to observability: **telemetry
+exports the same lens the decision read, stamped at the decision site.**
+Corps record the inputs of their last sizing decision when they make it;
+`Telemetry` exports the record verbatim. Telemetry never recomputes a
+decision input (recomputation can drift from the decision — the exact bug
+class the staffsPost trap documents).
+
+## Phases
+
+### Phase 0 / 0b — plan-vs-actual bodies (LANDED / IN REVIEW)
+
+Actual per-corp + colony body parts measured from `Creep.body` (segments
+0/4, v3; PR #111). Plan-side hauler CARRY + consumer WORK in the flow
+segment (v2; PR #113). Acceptance: `test/unit/telemetry/census.test.ts`,
+`test/unit/telemetry/flowPlan.test.ts`.
+
+### Phase 1 — room energy ledger (the "where is the energy" question)
+
+Extend `CoreTelemetry.rooms[]` with the stocks decisions read:
+
+- `storageEnergy` (warchest balance; null when no storage)
+- `controllerStock` (controller-side container energy — the
+  `controllerSideStock` lens)
+- `feederActive` (`room.memory.controllerFeederActive`)
+- `spawnEnergy` / `extensionEnergy` (fill state behind `energyAvailable`)
+
+Acceptance (unit, census-test style): a mocked room with storage/container
+stocks lands each field in segment 0; a storage-less room reports nulls,
+not zeros. Core version 3 → 4.
+
+### Phase 2 — sizing records (the "why is it 2 WORK" question)
+
+A generic optional `lastSizing` record on `Corp`, stamped inside
+`getSpawnDemand` where the decision is made; `updateCorpsTelemetry`
+exports it verbatim on the corp's segment-4 entry as `sizing`.
+
+First consumer: `UpgradingCorp` stamps
+`{ tick, planAllocated, stock, banked, inflow, allocated, targetCount }`.
+Same pattern then extends to CarryCorp/ConstructionCorp for free.
+
+Acceptance: unit test drives `getSpawnDemand` with a known stock and
+asserts the corps segment carries the exact inputs the decision used
+(not recomputed values). Corps version 3 → 4 (one bump shared with any
+concurrently landing field).
+
+### Phase 3 — spawn meter (the "what is spawn capacity at" question)
+
+Measured, windowed spawn utilization in a new `spawns[]` block (core
+segment): per spawn, over a rolling ~1500-tick window —
+`busyTicks / windowTicks`, actual `partsSpawned / tick`, and current
+agenda queue depth (from `Memory.spawnAgenda[spawnId].queue.length`).
+Sits next to the static ceiling (`SPAWN_PARTS_PER_TICK`) so
+"72% of ceiling" is read, not derived.
+
+Acceptance: unit test advances a mocked spawn through busy/idle ticks and
+asserts the meter; integration smoke: meter present and ≤ 1.0 after a
+`flow-handoff` run.
+
+### Phase 4 — NOW-plan mirror (actual-vs-NOW, spec 11 alignment)
+
+Export `Memory.spawnAgenda` heads + executed receipts (last ~8 per spawn)
+in a telemetry block, so the NOW plan and its execution receipts are
+visible without a `/user/memory` pull. Spec 11's tight-assertion pair
+(actual-vs-NOW) becomes dashboard-readable.
+
+Acceptance: unit test seeds a spawnAgenda and asserts the telemetry
+mirror; receipts match `executed` verbatim.
+
+## Non-goals
+
+- No new segments (0–6 have room; segment size is not a constraint — the
+  economy segments total ~11K of the 100K/segment limit).
+- No dashboards in this spec (telemetry-app consumes; it is not the
+  contract).
+- No telemetry-driven behavior: segments remain write-only observability.
+  Nothing in `src/` may read a decision from a segment.
+
+## Regression gate
+
+Phases touch telemetry only, but phase 2 adds a write inside
+`getSpawnDemand`: run the full gate (`npm run test-unit` + `flow-handoff`,
+`runt-economy`, `storage-depot`) for phase 2; unit suite alone suffices
+for 1, 3, 4 unless SpawnDirector is touched.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -41,6 +41,7 @@ Conventions used by every spec:
 | 11 | [Two plans: goal and now](11-two-plans.md) | phases 1-2 landed (agenda published + funding); phase 3 (transitions into agenda) open | P0 |
 | 12 | [Invader protocols: flight, and eventually fight](12-invader-protocols.md) | phase 1 (flight) **LANDED 2026-07-16**, stays as the fallback layer; phase 2 **LANDED 2026-07-17** via spec 13's CoreBusterCorp (kill + strip, corrected math), def-t5-core-buster cell green | landed |
 | 13 | [Invader economics: keep the remotes flowing](13-invader-economics.md) | **LANDED 2026-07-17** — scout-wipe fix, towers, raid meter + transit embargo, RaidGuardCorp (def-t4 green), CoreBusterCorp (def-t5 green), invader tax, BlackBox/intel telemetry; open: live tax calibration (≥15k-tick windows) | landed (calibration open) |
+| 14 | [Telemetry observability: answer the basic questions](14-telemetry-observability.md) | proposed 2026-07-18 — phases 0/0b landed/in-review (plan-vs-actual bodies, #111/#113); open: room energy ledger, sizing records, spawn meter, NOW-plan mirror | P1 |
 
 Recently completed (for context): economy consolidation onto
 `economy/primitives` + CorpPlanner (FlowSolver deleted); storage-as-core-depot

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -41,7 +41,7 @@ Conventions used by every spec:
 | 11 | [Two plans: goal and now](11-two-plans.md) | phases 1-2 landed (agenda published + funding); phase 3 (transitions into agenda) open | P0 |
 | 12 | [Invader protocols: flight, and eventually fight](12-invader-protocols.md) | phase 1 (flight) **LANDED 2026-07-16**, stays as the fallback layer; phase 2 **LANDED 2026-07-17** via spec 13's CoreBusterCorp (kill + strip, corrected math), def-t5-core-buster cell green | landed |
 | 13 | [Invader economics: keep the remotes flowing](13-invader-economics.md) | **LANDED 2026-07-17** — scout-wipe fix, towers, raid meter + transit embargo, RaidGuardCorp (def-t4 green), CoreBusterCorp (def-t5 green), invader tax, BlackBox/intel telemetry; open: live tax calibration (≥15k-tick windows) | landed (calibration open) |
-| 14 | [Telemetry observability: answer the basic questions](14-telemetry-observability.md) | proposed 2026-07-18 — phases 0/0b landed/in-review (plan-vs-actual bodies, #111/#113); open: room energy ledger, sizing records, spawn meter, NOW-plan mirror | P1 |
+| 14 | [Telemetry observability: answer the basic questions](14-telemetry-observability.md) | phases 0/0b landed (#111/#113); 1–2 implemented 2026-07-18 (room energy ledger core-v4, sizing records corps-v4); open: spawn meter, NOW-plan mirror | P1 |
 
 Recently completed (for context): economy consolidation onto
 `economy/primitives` + CorpPlanner (FlowSolver deleted); storage-as-core-depot

--- a/src/corps/Corp.ts
+++ b/src/corps/Corp.ts
@@ -54,6 +54,19 @@ export interface SerializedCorp {
  * Corp lifecycle (creation / retirement / removal) is driven by
  * materializeCommissions + hasLiveCreeps, NOT by any per-corp balance or ROI.
  */
+/**
+ * Inputs of a corp's most recent sizing decision, stamped at the decision site
+ * (getSpawnDemand) and exported verbatim by telemetry (spec 14 phase 2 -
+ * decision symmetry). Telemetry never recomputes these; the stamp IS the lens
+ * the decision read. `tick` discloses staleness (gated paths may skip a tick's
+ * stamp). Values are the decision's own units (energy/tick, counts); null
+ * means "unmeasurable this tick", which is a different fact from zero.
+ */
+export interface CorpSizingRecord {
+  tick: number;
+  [input: string]: number | boolean | null;
+}
+
 export abstract class Corp {
   /** Unique identifier for this corp */
   public readonly id: string;
@@ -66,6 +79,12 @@ export abstract class Corp {
 
   /** Tick when corp was created */
   public createdAt = 0;
+
+  /**
+   * Most recent sizing-decision inputs (spec 14 phase 2). Transient - never
+   * serialized; refreshed by getSpawnDemand each tick it runs to completion.
+   */
+  public lastSizing?: CorpSizingRecord;
 
   /** Last tick this corp performed work */
   public lastActivityTick = 0;

--- a/src/corps/UpgradingCorp.ts
+++ b/src/corps/UpgradingCorp.ts
@@ -7,7 +7,7 @@
  */
 
 import { Corp, SerializedCorp } from "./Corp";
-import { controllerInputSpot, controllerParkingTiles } from "./nodeEnergy";
+import { controllerInputSpot, controllerParkingTiles, controllerSideStock } from "./nodeEnergy";
 import { travelToBypass } from "./movement";
 import { driveRecycle } from "./recycle";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
@@ -70,15 +70,23 @@ export function upgraderTargetCount(
  * consumers scale up to eat it" - which a feeder-capped 2000 input stock
  * otherwise hides (measured live: 100k banked, upgraders sized to ~3.3 e/t).
  */
+export function upgraderSizing(
+  planAllocated: number,
+  stock: number | null,
+  bankedBehindFeeder: number | null
+): { allocated: number; inflow: number | null } {
+  if (stock === null) return { allocated: planAllocated, inflow: null };
+  const surplusRelay = bankedBehindFeeder !== null && bankSurplusRate(bankedBehindFeeder) > 0;
+  const inflow = surplusRelay ? feederRelayRate(bankedBehindFeeder!) : 2;
+  return { allocated: Math.max(2, Math.min(planAllocated, sustainableConsumptionRate(stock, inflow))), inflow };
+}
+
 export function upgraderAllocation(
   planAllocated: number,
   stock: number | null,
   bankedBehindFeeder: number | null
 ): number {
-  if (stock === null) return planAllocated;
-  const surplusRelay = bankedBehindFeeder !== null && bankSurplusRate(bankedBehindFeeder) > 0;
-  const inflow = surplusRelay ? feederRelayRate(bankedBehindFeeder!) : 2;
-  return Math.max(2, Math.min(planAllocated, sustainableConsumptionRate(stock, inflow)));
+  return upgraderSizing(planAllocated, stock, bankedBehindFeeder).allocated;
 }
 
 /**
@@ -413,7 +421,7 @@ export class UpgradingCorp extends Corp {
       spawn && spawn.room.memory.controllerFeederActive && spawn.room.storage?.my
         ? spawn.room.storage.store.energy ?? 0
         : null;
-    const allocated = upgraderAllocation(planAllocated, stock, bankedBehindFeeder);
+    const { allocated, inflow } = upgraderSizing(planAllocated, stock, bankedBehindFeeder);
 
     // One upgrader can only afford so many WORK parts at the current capacity;
     // a single small upgrader cannot consume a whole source. Size the COUNT to
@@ -429,6 +437,11 @@ export class UpgradingCorp extends Corp {
       ? controllerParkingTiles(controller, controllerInputSpot(controller).pos).length
       : UPGRADER_COUNT_CAP;
     const targetCount = upgraderTargetCount(allocated, affordableWork, parking, controller?.level);
+
+    // Decision-symmetry stamp (spec 14 phase 2): record the inputs THIS sizing
+    // read, for telemetry to export verbatim. Answers "why is the upgrader N
+    // WORK" from a capture: plan vs stock vs inflow vs what won.
+    this.lastSizing = { tick: ctx.tick, planAllocated, stock, banked: bankedBehindFeeder, inflow, allocated, targetCount };
     // Delivery-aware staffing (staffsPost): an upgrader inside its replacement
     // lead time (build + walk to the controller) keeps working but no longer
     // counts, so its successor spawns early enough for the controller's
@@ -514,17 +527,9 @@ export class UpgradingCorp extends Corp {
    * primitive piles and proper structures obey the same principle.
    */
   private controllerSideStock(controller: StructureController): number {
-    const spot = controllerInputSpot(controller).pos;
-    let stock = 0;
-    for (const s of controller.pos.findInRange(FIND_STRUCTURES, 4)) {
-      if (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) {
-        stock += (s as StructureContainer | StructureStorage).store[RESOURCE_ENERGY];
-      }
-    }
-    for (const r of spot.findInRange(FIND_DROPPED_RESOURCES, 2)) {
-      if (r.resourceType === RESOURCE_ENERGY) stock += r.amount;
-    }
-    return stock;
+    // Shared lens (nodeEnergy.controllerSideStock): the telemetry room ledger
+    // reads the SAME function, so the dashboard number is the decision's number.
+    return controllerSideStock(controller);
   }
 
   private effectiveAllocated(room: Room, base: number): number {

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -419,3 +419,24 @@ export function workSpot(creep: Creep, spot: EnergySpot, mode: "collect" | "depo
   else creep.drop(RESOURCE_ENERGY);
   return moved;
 }
+
+/**
+ * Energy actually pooled at the controller side: containers/storage within 4
+ * of the controller plus loose energy near the input spot. THE lens for
+ * stock-grounded upgrader sizing (UpgradingCorp) AND the telemetry room
+ * ledger (spec 14 phase 1) - both read this one function so the number a
+ * dashboard shows is the number the decision used.
+ */
+export function controllerSideStock(controller: StructureController): number {
+  const spot = controllerInputSpot(controller).pos;
+  let stock = 0;
+  for (const s of controller.pos.findInRange(FIND_STRUCTURES, 4)) {
+    if (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) {
+      stock += (s as StructureContainer | StructureStorage).store[RESOURCE_ENERGY];
+    }
+  }
+  for (const r of spot.findInRange(FIND_DROPPED_RESOURCES, 2)) {
+    if (r.resourceType === RESOURCE_ENERGY) stock += r.amount;
+  }
+  return stock;
+}

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -19,7 +19,8 @@
  */
 
 import { Colony } from "../colony/Colony";
-import { Corp } from "../corps/Corp";
+import { Corp, CorpSizingRecord } from "../corps/Corp";
+import { controllerSideStock } from "../corps/nodeEnergy";
 import { FlowSolution } from "../flow/FlowTypes";
 import {
   BUILD_ENERGY_PER_WORK,
@@ -222,6 +223,17 @@ export interface CoreTelemetry {
     rclProgressTotal: number;
     energyAvailable: number;
     energyCapacity: number;
+    /**
+     * Room energy ledger (spec 14 phase 1) - the stocks decisions read, via
+     * the same lenses. null = no such store exists (a storage-less room and an
+     * empty storage are different facts).
+     */
+    /** Warchest balance: storage energy, or null when the room has no storage. */
+    storageEnergy: number | null;
+    /** Energy pooled at the controller side (controllerSideStock lens). */
+    controllerStock: number | null;
+    /** Is the controller feeder actively relaying storage -> controller? */
+    feederActive: boolean;
   }[];
 }
 
@@ -337,6 +349,11 @@ export interface CorpsTelemetry {
     bodyParts: number;
     /** ACTUAL body parts by type for this corp's live creeps; {} when it has none. */
     body: { [part: string]: number };
+    /**
+     * Inputs of the corp's last sizing decision, exported verbatim from the
+     * decision-site stamp (spec 14 phase 2). Absent for corps that don't stamp.
+     */
+    sizing?: CorpSizingRecord;
     createdAt: number;
     lastActivityTick: number;
   }[];
@@ -543,13 +560,16 @@ export class Telemetry {
           rclProgress: room.controller.progress,
           rclProgressTotal: room.controller.progressTotal,
           energyAvailable: room.energyAvailable,
-          energyCapacity: room.energyCapacityAvailable
+          energyCapacity: room.energyCapacityAvailable,
+          storageEnergy: room.storage?.my ? room.storage.store.energy ?? 0 : null,
+          controllerStock: controllerSideStock(room.controller),
+          feederActive: !!room.memory.controllerFeederActive
         });
       }
     }
 
     const telemetry: CoreTelemetry = {
-      version: 3, // Version 3: added actual body-parts capture (measured from Creep.body)
+      version: 4, // Version 4: room energy ledger (storage/controller stocks, feeder state)
       tick: Game.time,
       shard: Game.shard?.name || "shard0",
       cpu: {
@@ -822,6 +842,7 @@ export class Telemetry {
         creepCount,
         bodyParts: body.total,
         body: body.byPart,
+        sizing: corp.lastSizing,
         createdAt: corp.createdAt,
         lastActivityTick: corp.lastActivityTick
       });
@@ -830,7 +851,7 @@ export class Telemetry {
     }
 
     const telemetry: CorpsTelemetry = {
-      version: 3, // Version 3: added actual body-parts capture (measured from Creep.body)
+      version: 4, // Version 4: sizing records (decision-site inputs, spec 14 phase 2)
       tick: Game.time,
       corps,
       summary: {

--- a/test/unit/telemetry/roomLedger.test.ts
+++ b/test/unit/telemetry/roomLedger.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { setupGlobals, Game, RawMemory } from "../mock";
+import { Telemetry } from "../../../src/telemetry/Telemetry";
+
+/**
+ * Spec 14 phase 1 - room energy ledger. The stocks decisions read (warchest
+ * balance, controller-side stock, feeder relay state) must be IN telemetry,
+ * via the same lenses the decisions use ("200k in storage" must be readable
+ * from a capture, not recalled by the owner). Null means "no such store",
+ * never zero - a storage-less room and an empty storage are different facts.
+ */
+describe("Telemetry room energy ledger (segment 0, spec 14 phase 1)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).RawMemory = RawMemory;
+    RawMemory.segments = {};
+    Game.time = 100;
+    Game.creeps = {};
+    (Game as any).gcl = { level: 1, progress: 0, progressTotal: 100 };
+    (Game as any).shard = { name: "shard1" };
+    // Lens constants used by controllerSideStock/controllerInputSpot.
+    (global as any).FIND_STRUCTURES = 107;
+    (global as any).FIND_DROPPED_RESOURCES = 106;
+    (global as any).STRUCTURE_CONTAINER = "container";
+    (global as any).STRUCTURE_STORAGE = "storage";
+    (global as any).STRUCTURE_LINK = "link";
+    (global as any).RESOURCE_ENERGY = "energy";
+    (global as any).TERRAIN_MASK_WALL = 1;
+    // Bare-controller rooms take controllerInputSpot's terrain-scan branch,
+    // which mints a RoomPosition for the chosen spot; its dropped-energy scan
+    // must return empty.
+    (global as any).RoomPosition = class {
+      public constructor(public x: number, public y: number, public roomName: string) {}
+      public findInRange(): any[] {
+        return [];
+      }
+    };
+  });
+
+  /** A controller whose pos serves the lens's findInRange calls from fixtures. */
+  const mkController = (structures: any[], dropped: any[]): any => {
+    const pos: any = {
+      x: 25,
+      y: 25,
+      findInRange: (find: number) => (find === (global as any).FIND_DROPPED_RESOURCES ? dropped : structures)
+    };
+    // The input-spot buffer branch reuses the container's own pos for the
+    // dropped-resource scan; point it at the same stub.
+    for (const s of structures) s.pos = pos;
+    const controller: any = { my: true, level: 5, progress: 1, progressTotal: 2, pos };
+    // Terrain for the input-spot fallback when no buffer structure exists.
+    controller.room = { name: "test", getTerrain: () => ({ get: () => 0 }) };
+    return controller;
+  };
+
+  it("exports storage balance, controller-side stock, and feeder state per owned room", () => {
+    const container = { structureType: "container", store: { energy: 1500 } };
+    Game.rooms = {
+      W43N23: {
+        name: "W43N23",
+        controller: mkController([container], [{ resourceType: "energy", amount: 250 }]),
+        storage: { my: true, store: { energy: 200000 } },
+        memory: { controllerFeederActive: true },
+        energyAvailable: 1800,
+        energyCapacityAvailable: 1800,
+        find: () => [] // nodes segment counts spawns per room
+      }
+    } as any;
+
+    new Telemetry().update(undefined, [], undefined);
+    const core = JSON.parse(RawMemory.segments[0]);
+
+    expect(core.version).to.equal(4);
+    const room = core.rooms[0];
+    expect(room.storageEnergy).to.equal(200000);
+    // 1500 in the controller-side container + 250 dropped at the input spot
+    expect(room.controllerStock).to.equal(1750);
+    expect(room.feederActive).to.equal(true);
+  });
+
+  it("reports null (not zero) when a room has no storage, and 0 stock for a bare controller", () => {
+    Game.rooms = {
+      W1N1: {
+        name: "W1N1",
+        controller: mkController([], []),
+        memory: {},
+        energyAvailable: 300,
+        energyCapacityAvailable: 300,
+        find: () => []
+      }
+    } as any;
+
+    new Telemetry().update(undefined, [], undefined);
+    const room = JSON.parse(RawMemory.segments[0]).rooms[0];
+
+    expect(room.storageEnergy).to.equal(null);
+    expect(room.controllerStock).to.equal(0);
+    expect(room.feederActive).to.equal(false);
+  });
+});

--- a/test/unit/telemetry/sizingRecord.test.ts
+++ b/test/unit/telemetry/sizingRecord.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { setupGlobals, Game, RawMemory } from "../mock";
+import { Telemetry, CorpCensusEntry } from "../../../src/telemetry/Telemetry";
+import { UpgradingCorp } from "../../../src/corps/UpgradingCorp";
+import { SinkAllocation } from "../../../src/flow/FlowTypes";
+
+/**
+ * Spec 14 phase 2 - sizing records, the decision-symmetry contract: a corp
+ * stamps the INPUTS of its last sizing decision at the decision site
+ * (getSpawnDemand), and telemetry exports the stamp verbatim. "Why is the
+ * upgrader 2 WORK" must be answerable from a capture: planAllocated vs stock
+ * vs inflow vs the allocation that won. Telemetry never recomputes an input -
+ * recomputation can drift from the decision (the staffsPost bug class).
+ */
+describe("Telemetry sizing records (segment 4, spec 14 phase 2)", () => {
+  beforeEach(() => {
+    setupGlobals();
+    (global as any).RawMemory = RawMemory;
+    RawMemory.segments = {};
+    Game.rooms = {};
+    Game.time = 100;
+    Game.creeps = {};
+    (Game as any).gcl = { level: 1, progress: 0, progressTotal: 100 };
+    (Game as any).shard = { name: "shard1" };
+  });
+
+  it("exports a corp's lastSizing verbatim as `sizing`; corps without one carry none", () => {
+    const sized: CorpCensusEntry = {
+      corpId: "upgrading-W1N1",
+      kind: "upgrade",
+      corp: {
+        id: "upgrading-W1N1",
+        type: "upgrading",
+        nodeId: "W1N1",
+        createdAt: 0,
+        lastActivityTick: 0,
+        getCreepCount: () => 1,
+        lastSizing: { tick: 99, planAllocated: 9, stock: 120, banked: 200000, inflow: 2, allocated: 2, targetCount: 1 }
+      } as any
+    };
+    const unsized: CorpCensusEntry = {
+      corpId: "harvest-s1",
+      kind: "harvest",
+      corp: { id: "harvest-s1", type: "mining", nodeId: "W1N1-1-1", createdAt: 0, lastActivityTick: 0, getCreepCount: () => 1 } as any
+    };
+
+    new Telemetry().update(undefined, [sized, unsized], undefined);
+    const corps = JSON.parse(RawMemory.segments[4]);
+
+    expect(corps.version).to.equal(4);
+    const u = corps.corps.find((c: any) => c.id === "upgrading-W1N1");
+    expect(u.sizing).to.deep.equal({ tick: 99, planAllocated: 9, stock: 120, banked: 200000, inflow: 2, allocated: 2, targetCount: 1 });
+    const h = corps.corps.find((c: any) => c.id === "harvest-s1");
+    expect(h).to.not.have.property("sizing");
+  });
+
+  it("UpgradingCorp stamps its sizing inputs at the decision site (plan-trusted path)", () => {
+    // Game-free harness: no spawn resolves, so stock/banked are unmeasurable
+    // (null) and the decision trusts the plan - the stamp must record exactly
+    // that, not zeros.
+    const corp = new UpgradingCorp("W1N1-upgrading", "spawn1");
+    corp.setSinkAllocation({
+      sinkId: "controller-x",
+      sinkType: "controller",
+      allocated: 5,
+      demand: 5,
+      unmet: 0,
+      priority: 65
+    } as SinkAllocation);
+
+    corp.getSpawnDemand({ energyCapacity: 550, tick: 100 });
+
+    const s = corp.lastSizing!;
+    expect(s.tick).to.equal(100);
+    expect(s.planAllocated).to.equal(5);
+    expect(s.stock).to.equal(null);
+    expect(s.banked).to.equal(null);
+    expect(s.inflow).to.equal(null);
+    expect(s.allocated).to.equal(5); // null stock -> trust the plan
+    expect(s.targetCount).to.be.a("number");
+  });
+});


### PR DESCRIPTION
Implements phases 1–2 of **spec 14 — telemetry observability** (the spec doc is in this PR too; it was authored after the #113 squash). Follow-up to #111 (actual bodies) and #113 (plan-side bodies): two more of the assessment's "basic questions" become readable from a capture instead of requiring code spelunking or the owner's memory.

## Phase 1 — room energy ledger (core segment, v3 → v4)

*"How much energy is in storage?"* — `rooms[]` gains:

- `storageEnergy` — warchest balance; **null when the room has no storage** (a different fact from an empty one)
- `controllerStock` — energy pooled at the controller side
- `feederActive` — is the storage→controller relay running

`controllerStock` is read through the **same `controllerSideStock` lens the upgrader decision uses** — extracted from `UpgradingCorp` into `nodeEnergy.ts`, both callers now share the one function, so the dashboard number is the decision's number by construction.

## Phase 2 — sizing records (corps segment, v3 → v4)

*"Why is the upgrader 2 WORK?"* — decision symmetry: a corp stamps the inputs of its last sizing decision at the decision site (`getSpawnDemand`); telemetry exports the stamp **verbatim**, never recomputing (recomputation drift is the staffsPost bug class). First stamper: `UpgradingCorp` records `{tick, planAllocated, stock, banked, inflow, allocated, targetCount}` via the new `upgraderSizing` — the existing `upgraderAllocation` delegates to it, so its unit tests are unchanged. The pattern extends to other consumer corps for free.

## Deviation from spec as written

Phase 1 drops the `spawnEnergy`/`extensionEnergy` split — no decision reads a per-structure split (the lens decisions read is `energyAvailable`/`energyCapacity`, already exported). The ledger carries only lenses decisions actually use.

## Verification

- New unit tests: `roomLedger.test.ts` (ledger fields, null-vs-zero semantics), `sizingRecord.test.ts` (verbatim export + decision-site stamp on the plan-trusted path)
- Full unit suite **860 passing**
- `npm run build` clean
- Full regression gate (phase 2 touches `getSpawnDemand`): `flow-handoff`, `runt-economy`, `storage-depot` — **all green**

## Deploy note

Core/corps v4 fields appear in live telemetry after this deploys; a fresh `capture:telemetry` then answers the storage-balance and upgrader-sizing questions directly. Phases 3 (spawn meter) and 4 (NOW-plan mirror) remain open in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhyB2hx7MsgB9kHEVq8YGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhyB2hx7MsgB9kHEVq8YGg)_