### PR TITLE
Fix structure placement beside room exits (W43N23 incident)

### DIFF
--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -887,7 +887,7 @@ export class ConstructionCorp extends Corp {
     const spawn = room.find(FIND_MY_SPAWNS)[0];
     if (!spawn) return null;
     if (this.hasContainerNear(room, spawn.pos, 1)) return null;
-    const tile = bestAdjacentTile(room, spawn.pos, 1, spawn.pos);
+    const tile = bestAdjacentTile(room, spawn.pos, 1, spawn.pos, STRUCTURE_CONTAINER);
     return tile ? { x: tile.x, y: tile.y } : null;
   }
 
@@ -910,7 +910,7 @@ export class ConstructionCorp extends Corp {
     if (hasTower) return null;
     const spawn = room.find(FIND_MY_SPAWNS)[0];
     if (!spawn) return null;
-    const tile = bestAdjacentTile(room, spawn.pos, 3, spawn.pos);
+    const tile = bestAdjacentTile(room, spawn.pos, 3, spawn.pos, STRUCTURE_TOWER);
     return tile ? { x: tile.x, y: tile.y } : null;
   }
 
@@ -921,7 +921,7 @@ export class ConstructionCorp extends Corp {
     if (hasSite) return null;
     const spawn = room.find(FIND_MY_SPAWNS)[0];
     if (!spawn) return null;
-    const tile = bestAdjacentTile(room, spawn.pos, 2, spawn.pos);
+    const tile = bestAdjacentTile(room, spawn.pos, 2, spawn.pos, STRUCTURE_STORAGE);
     return tile ? { x: tile.x, y: tile.y } : null;
   }
 
@@ -981,7 +981,7 @@ export class ConstructionCorp extends Corp {
 
     // 1) Core link beside the storage.
     if (!linkNear(storage.pos, 2)) {
-      const tile = bestAdjacentTile(room, storage.pos, 1, storage.pos);
+      const tile = bestAdjacentTile(room, storage.pos, 1, storage.pos, STRUCTURE_LINK);
       return tile ? { x: tile.x, y: tile.y } : null;
     }
 
@@ -993,7 +993,7 @@ export class ConstructionCorp extends Corp {
       .sort((a, b) => b.pos.getRangeTo(storage.pos) - a.pos.getRangeTo(storage.pos));
     for (const source of candidates) {
       const spot = sourceHarvestSpot(source, spawn?.pos);
-      const tile = bestAdjacentTile(room, spot, 1, spawn?.pos);
+      const tile = bestAdjacentTile(room, spot, 1, spawn?.pos, STRUCTURE_LINK);
       if (tile) return { x: tile.x, y: tile.y };
     }
     return null;

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -100,12 +100,23 @@ export interface EnergySpot {
  * STAND), and - via {@link sourceHarvestSpot} - the drop pile, so all three
  * converge on ONE tile instead of three different ones. That convergence is what
  * stops a miner dropping energy on a tile the haulers never visit.
+ *
+ * `forStructure` applies the engine's placement legality for that structure
+ * type. Without it the tile is only guaranteed STANDABLE - fine for creeps,
+ * and for the exempt structures (roads, containers), but the engine refuses
+ * most structure types on a tile one step from the room edge unless every
+ * edge tile beside it is a natural wall (see {@link besideOpenExit}). Pass
+ * the type whenever the tile is for createConstructionSite, or the picker
+ * re-picks the same illegal tile every cooldown and the structure never
+ * places (the W43N23 link incident: a source pocketed against an open east
+ * exit, "Failed to place link at W43N23 (48, 13): -7" forever).
  */
 export function bestAdjacentTile(
   room: Room,
   target: RoomPosition,
   range: number,
-  spawnPos?: RoomPosition
+  spawnPos?: RoomPosition,
+  forStructure?: BuildableStructureConstant
 ): RoomPosition | null {
   const terrain = room.getTerrain();
   const occupied = new Set<string>();
@@ -120,6 +131,9 @@ export function bestAdjacentTile(
   for (const s of room.find(FIND_SOURCES)) occupied.add(`${s.pos.x},${s.pos.y}`);
   for (const m of room.find(FIND_MINERALS)) occupied.add(`${m.pos.x},${m.pos.y}`);
 
+  const shunExitBuffer =
+    forStructure !== undefined && forStructure !== STRUCTURE_ROAD && forStructure !== STRUCTURE_CONTAINER;
+
   let best: { x: number; y: number; d: number } | null = null;
   for (let dx = -range; dx <= range; dx++) {
     for (let dy = -range; dy <= range; dy++) {
@@ -129,11 +143,32 @@ export function bestAdjacentTile(
       if (x < 1 || x > 48 || y < 1 || y > 48) continue;
       if (terrain.get(x, y) === TERRAIN_MASK_WALL) continue;
       if (occupied.has(`${x},${y}`)) continue;
+      if (shunExitBuffer && besideOpenExit(terrain, x, y)) continue;
       const d = spawnPos ? Math.max(Math.abs(spawnPos.x - x), Math.abs(spawnPos.y - y)) : 0;
       if (!best || d < best.d) best = { x, y, d };
     }
   }
   return best ? new RoomPosition(best.x, best.y, room.name) : null;
+}
+
+/**
+ * The engine's exit-buffer rule (checkConstructionSite): a tile one step from
+ * the room edge (x or y == 1 or 48) can host a non-exempt structure only when
+ * all three edge tiles beside it are natural walls - one open exit tile there
+ * and createConstructionSite returns ERR_INVALID_TARGET. Only roads and
+ * containers are exempt. Mirrors the engine exactly, including its corner
+ * behaviour: the sequential ifs OVERWRITE, so a corner tile (e.g. x==48,
+ * y==48) is judged only by its last-matching side's edge tiles - the y-side
+ * list replaces the x-side one, same as the engine's checkConstructionSite.
+ */
+function besideOpenExit(terrain: RoomTerrain, x: number, y: number): boolean {
+  let edge: [number, number][] | null = null;
+  if (x === 1) edge = [[0, y - 1], [0, y], [0, y + 1]];
+  if (x === 48) edge = [[49, y - 1], [49, y], [49, y + 1]];
+  if (y === 1) edge = [[x - 1, 0], [x, 0], [x + 1, 0]];
+  if (y === 48) edge = [[x - 1, 49], [x, 49], [x + 1, 49]];
+  if (!edge) return false;
+  return edge.some(([ex, ey]) => (terrain.get(ex, ey) & TERRAIN_MASK_WALL) === 0);
 }
 
 /**

--- a/test/unit/corps/sourceHarvestSpot.test.ts
+++ b/test/unit/corps/sourceHarvestSpot.test.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "chai";
-import { setupGlobals, FIND_STRUCTURES, FIND_SOURCES, FIND_MINERALS, STRUCTURE_CONTAINER } from "../mock";
+import {
+  setupGlobals,
+  FIND_STRUCTURES,
+  FIND_SOURCES,
+  FIND_MINERALS,
+  STRUCTURE_CONTAINER,
+  STRUCTURE_LINK,
+} from "../mock";
 import { sourceHarvestSpot, bestAdjacentTile } from "../../../src/corps/nodeEnergy";
 
 const FIND_MY_CONSTRUCTION_SITES = 114;
@@ -145,5 +152,77 @@ describe("bestAdjacentTile (excludes source and mineral tiles)", () => {
     const spawnPos = { x: 1, y: 10, roomName: "W0N0" } as any;
     const tile = bestAdjacentTile(room, { x: 11, y: 10 } as any, 1, spawnPos)!;
     expect({ x: tile.x, y: tile.y }).to.not.deep.equal({ x: 10, y: 10 });
+  });
+});
+
+/**
+ * Engine rule (checkConstructionSite): a tile one step from the room edge
+ * (x or y == 1 or 48) can host most structures ONLY when all three edge tiles
+ * beside it are natural walls - an open exit tile there makes placement fail
+ * with ERR_INVALID_TARGET. Roads and containers are exempt. A picker that
+ * ignores this re-picks the SAME illegal tile every cooldown, so the structure
+ * never places (the W43N23 incident: a source pocketed against an open east
+ * exit, "[Construction] Failed to place link at W43N23 (48, 13): -7" forever).
+ */
+describe("bestAdjacentTile (exit-restricted structures shun the open-exit buffer)", () => {
+  beforeEach(() => setupGlobals());
+
+  /** Bare room: chosen walls, everything else plain - edge cols/rows open (exits). */
+  function roomWithWalls(walls: string[]): any {
+    const wallSet = new Set(walls);
+    return {
+      name: "W0N0",
+      getTerrain: () => ({ get: (x: number, y: number) => (wallSet.has(`${x},${y}`) ? 1 : 0) }),
+      find: () => [],
+    };
+  }
+
+  // The W43N23 pocket: spot at (47,13), every neighbour walled except the
+  // x=48 column, open exit tiles behind it at x=49.
+  const POCKET = ["46,12", "46,13", "46,14", "47,12", "47,14"];
+
+  it("returns null for a LINK when the only candidates sit beside an open exit (W43N23 repro)", () => {
+    const room = roomWithWalls(POCKET);
+    const spawnPos = { x: 25, y: 25, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 47, y: 13 } as any, 1, spawnPos, STRUCTURE_LINK);
+    expect(tile).to.equal(null);
+  });
+
+  it("still allows x=48 for a LINK when the edge tiles behind it are natural walls", () => {
+    // Same pocket, but the east edge is walled - no exit, so the engine allows it.
+    const room = roomWithWalls([...POCKET, "49,11", "49,12", "49,13", "49,14", "49,15"]);
+    const spawnPos = { x: 25, y: 25, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 47, y: 13 } as any, 1, spawnPos, STRUCTURE_LINK)!;
+    expect({ x: tile.x, y: tile.y }).to.deep.equal({ x: 48, y: 12 });
+  });
+
+  it("skips the nearer buffer tile and picks the next-best LEGAL tile", () => {
+    // (47,12) open as an alternative; spawn placed so the buffer tile (48,14)
+    // is strictly nearest - the old picker chose it and looped on -7.
+    const room = roomWithWalls(["46,12", "46,13", "46,14", "47,14"]);
+    const spawnPos = { x: 48, y: 40, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 47, y: 13 } as any, 1, spawnPos, STRUCTURE_LINK)!;
+    expect({ x: tile.x, y: tile.y }).to.deep.equal({ x: 47, y: 12 });
+  });
+
+  it("containers are exempt - the engine allows them beside exits", () => {
+    const room = roomWithWalls(POCKET);
+    const spawnPos = { x: 25, y: 25, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 47, y: 13 } as any, 1, spawnPos, STRUCTURE_CONTAINER)!;
+    expect({ x: tile.x, y: tile.y }).to.deep.equal({ x: 48, y: 12 });
+  });
+
+  it("stand-tile queries (no structure type) are unchanged - creeps may stand in the buffer", () => {
+    const room = roomWithWalls(POCKET);
+    const spawnPos = { x: 25, y: 25, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 47, y: 13 } as any, 1, spawnPos)!;
+    expect({ x: tile.x, y: tile.y }).to.deep.equal({ x: 48, y: 12 });
+  });
+
+  it("applies the same rule on the y side (bottom edge)", () => {
+    const room = roomWithWalls(["12,46", "13,46", "14,46", "12,47", "14,47"]);
+    const spawnPos = { x: 25, y: 25, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 13, y: 47 } as any, 1, spawnPos, STRUCTURE_LINK);
+    expect(tile).to.equal(null);
   });
 });

--- a/test/unit/mock.ts
+++ b/test/unit/mock.ts
@@ -179,6 +179,8 @@ export const STRUCTURE_EXTENSION = 'extension';
 export const STRUCTURE_STORAGE = 'storage';
 export const STRUCTURE_CONTAINER = 'container';
 export const STRUCTURE_CONTROLLER = 'controller';
+export const STRUCTURE_ROAD = 'road';
+export const STRUCTURE_LINK = 'link';
 
 export const OK = 0;
 export const ERR_NOT_IN_RANGE = -9;
@@ -225,6 +227,8 @@ export function setupGlobals(): void {
   (global as any).STRUCTURE_STORAGE = STRUCTURE_STORAGE;
   (global as any).STRUCTURE_CONTAINER = STRUCTURE_CONTAINER;
   (global as any).STRUCTURE_CONTROLLER = STRUCTURE_CONTROLLER;
+  (global as any).STRUCTURE_ROAD = STRUCTURE_ROAD;
+  (global as any).STRUCTURE_LINK = STRUCTURE_LINK;
 
   (global as any).OK = OK;
   (global as any).ERR_NOT_IN_RANGE = ERR_NOT_IN_RANGE;


### PR DESCRIPTION
## Summary

Fixes a critical bug where `bestAdjacentTile` would repeatedly select illegal tiles for structure placement beside open room exits, causing construction to fail indefinitely with `ERR_INVALID_TARGET (-7)`. The engine's `checkConstructionSite` rule forbids most structures on edge tiles (x/y == 1 or 48) unless all adjacent edge tiles are natural walls; containers and roads are exempt.

## Changes

- **`bestAdjacentTile` signature**: Added optional `forStructure?: BuildableStructureConstant` parameter to enable structure-type-aware tile legality checking
- **New `besideOpenExit` helper**: Implements the engine's exact exit-buffer rule, including corner-tile behavior where y-side checks overwrite x-side ones
- **Tile filtering**: When `forStructure` is specified and not a road/container, candidates beside open exits are now skipped
- **Call sites updated**: All `bestAdjacentTile` calls in `ConstructionCorp` now pass the target structure type (CONTAINER, TOWER, STORAGE, LINK)
- **Test coverage**: Added comprehensive test suite reproducing the W43N23 incident and validating the fix across edge cases (both axes, exempt structures, creep stand-tiles)
- **Mock exports**: Added `STRUCTURE_ROAD` and `STRUCTURE_LINK` constants to test mock

## Implementation Details

The `besideOpenExit` function mirrors the engine's sequential-if logic: corner tiles are judged only by their last-matching side's edge tiles (y-side replaces x-side), not both. This prevents false negatives on corners and matches engine behavior exactly.

The fix is backward-compatible: queries without a structure type (creep stand-tiles) remain unchanged and may still use the buffer zone, as creeps are allowed there.

https://claude.ai/code/session_01UNWTnmeDkt8ZPoibwnsf5S