### PR TITLE
spec-06: document expansion implementation & clean up ROI interface

### DIFF
--- a/docs/specs/06-expansion.md
+++ b/docs/specs/06-expansion.md
@@ -1,8 +1,15 @@
 # 06 — Expansion: claim the next room ("spread like a disease")
 
-**Status:** not started. This is the payoff the node/ROI/spawn-placement
-machinery was built for, and the owner's stated strategy: losing rooms is fine,
-spreading is the win condition.
+**Status:** implemented. All three pieces are live — the pure `shouldExpand`
+trigger + campaign state machine (`economy/expansion.ts`), the ClaimCorp
+(`corps/kinds/claimKind.ts`, `corps/ClaimCorp.ts`), and sink-based founding via
+the flow planner's `NEW_SPAWN_SITE_VALUE`. Acceptance moved from the
+single-shot integration test the design named below to the T5 grid cells
+`exp-t5-claimer-claims-and-founds` and `exp-t5-founding-funnels-to-completion`
+(`test/grid/cells/expansion.ts`), which exercise the claim moment and the
+sink-founding moment against real terrain. This is the payoff the
+node/ROI/spawn-placement machinery was built for, and the owner's stated
+strategy: losing rooms is fine, spreading is the win condition.
 **Priority:** P2 (after the economy specs; an expansion that out-runs its
 economy just starves two rooms instead of one).
 
@@ -120,7 +127,15 @@ Three small pieces, all riding existing rails:
 
 ## Acceptance tests
 
-### Unit: `test/unit/expansion/shouldExpand.test.ts` — exact, exhaustive gate
+> Implemented locations (2026-07): the gate lives in
+> `test/unit/economy/expansion.test.ts`, claimer demand in
+> `test/unit/corps/ClaimCorp.test.ts` + `test/unit/framework/claimKind.test.ts`,
+> and the end-to-end arc in the T5 grid cells (`test/grid/cells/expansion.ts`)
+> rather than the standalone `test/integration/expansion.test.ts` the design
+> below sketched — that file was never created; the grid cells own its
+> acceptance. The scenarios below are the original design intent, preserved.
+
+### Unit: `test/unit/economy/expansion.test.ts` — exact, exhaustive gate
 
 1. GCL 2, 1 owned room, candidate score 50 (≥ threshold) → `true`.
 2. GCL 1, 1 owned room, any candidate → `false` (no GCL headroom).
@@ -137,7 +152,15 @@ Three small pieces, all riding existing rails:
 2. Claimer alive → no demand. Controller owned → no demand AND the corp
    reports demobilization (recycle flag), mirroring the reserver pin.
 
-### Integration: `test/integration/expansion.test.ts`
+### End-to-end: the T5 expansion grid cells (`test/grid/cells/expansion.ts`)
+
+Realised as two grid cells rather than the single integration test sketched
+here: `exp-t5-claimer-claims-and-founds` (the claim moment — held-funded
+claimer walks in, claims the controller, founding spawn site placed at the
+campaign's `spawnPos`) and `exp-t5-founding-funnels-to-completion` (the
+sink-founding moment — energy funnels cross-room to the site, the spawn
+completes, and the campaign closes). The original single-test design intent,
+preserved for reference:
 
 World: two real-terrain rooms side by side (W0N0 owned at RCL4 with the
 storage-depot layout; W1N0 with 2 sources + controller, layout via

--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -72,17 +72,6 @@ export interface PotentialCorp {
 }
 
 /**
- * Information about a reachable source from an adjacent node.
- * Used to calculate expansion scores.
- */
-export interface ReachableSource {
-  /** Source capacity (energy per regen cycle) */
-  capacity: number;
-  /** Distance from the target node's peak to this source */
-  distance: number;
-}
-
-/**
  * Potential corp ROI summary for a node.
  */
 export interface PotentialCorpROI {
@@ -277,7 +266,10 @@ export function deserializeNode(data: SerializedNode): Node {
  * @param peakHeight - The peak height from spatial analysis
  * @param ownedRooms - Set of owned room names for distance calculation
  * @param potentialCorps - Potential corps from NodeSurveyor (optional, for pre-computed survey)
- * @param reachableSources - Sources from adjacent nodes that could be mined if we expand here
+ * @param economicValue - The node's marginal contribution to the colony economy
+ *   (economy/siteValue.marginalSiteValue, computed by the caller). This is the
+ *   real driver of the score; reachable adjacent-node sources are already folded
+ *   in upstream via the shared source pool, so no per-node reachable list here.
  * @returns ROI metrics
  */
 export function calculateNodeROI(

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -5,7 +5,6 @@ export {
   NodeROI,
   PotentialCorpROI,
   PotentialCorp,
-  ReachableSource,
   SerializedNode,
   createNodeId,
   createNode,

--- a/src/spatial/spawnPlacement.ts
+++ b/src/spatial/spawnPlacement.ts
@@ -3,8 +3,16 @@
  *
  * The natural "a player would plant here" spot: the open plain tile (all 8
  * neighbours plain) nearest the centroid of the room's sources and
- * controller, clear of the objects themselves. Used by the real-map sim
- * harness today and by expansion (spec 06) when the bot claims rooms itself.
+ * controller, clear of the objects themselves.
+ *
+ * SCOPE: this is a geometric heuristic used ONLY by the real-map sim harness
+ * (scripts/sim-real-rooms.ts, fixture-index.ts) to plant a starting spawn in a
+ * captured fixture room. It is NOT the live expansion placement: when the bot
+ * claims a room itself (spec 06), the founding spawn tile is the econ-optimal
+ * one from Memory.spawnPlacements (planner-backed spawnSiteValue via
+ * execution/SpawnPlacementScheduler + planning/SpawnPlacement), not this
+ * centroid pick. Do not wire this into the live founding path - it would swap
+ * planner economics for terrain geometry.
  *
  * Pure over a row-major terrain representation (50 strings of '.', '#', '~')
  * so it unit-tests without a live room; in-game callers build the rows from


### PR DESCRIPTION
## Summary

Update spec 06 (Expansion) documentation to reflect the completed implementation, and clean up the Node ROI interface by removing the now-unused `ReachableSource` type.

## Key changes

- **Spec 06 status update**: Mark expansion as "implemented" with details on the three live pieces (shouldExpand trigger, ClaimCorp, sink-based founding) and acceptance test locations (T5 grid cells `exp-t5-claimer-claims-and-founds` and `exp-t5-founding-funnels-to-completion` in `test/grid/cells/expansion.ts`)

- **Test location documentation**: Add implementation notes clarifying that acceptance moved from the originally-sketched `test/integration/expansion.test.ts` (never created) to the T5 grid cells, which exercise the claim and sink-founding moments against real terrain

- **ROI interface cleanup**: Remove `ReachableSource` interface from `src/nodes/Node.ts` — this type is no longer used since adjacent-node sources are now folded into the shared source pool upstream and passed as `economicValue` rather than a per-node reachable list

- **spawnPlacement scope clarification**: Document that `calculateSpawnPlacement` is a geometric heuristic used only by the sim harness fixture setup, NOT the live expansion path (which uses planner-backed `spawnSiteValue` instead)

- **Export cleanup**: Remove `ReachableSource` from `src/nodes/index.ts` exports

## Implementation details

The expansion machinery is now fully live: the pure `shouldExpand` trigger (economy/expansion.ts) gates the campaign state machine, the ClaimCorp materializes the claimer, and sink-based founding via `NEW_SPAWN_SITE_VALUE` completes the room claim. The ROI calculation now receives pre-computed `economicValue` rather than managing its own source reachability, simplifying the interface and centralizing economic logic in the planner.

https://claude.ai/code/session_01LpiFv3T8rEZ7aPjPtzBTFy