### PR TITLE
Builder latch: sequential site targeting, repair-while-walking

### DIFF
--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -14,7 +14,13 @@ import { plan as governorPlan } from "../execution/CpuGovernor";
 import { SpawnDemand, SpawnDemandContext } from "../spawn/SpawnScheduler";
 import { Squad, SquadPlan, splitIntoMembers } from "./Squad";
 import { buildTankerBody, buildUpgraderBody } from "../spawn/BodyBuilder";
-import { pickCriticalRepairTarget, wantsCriticalRecovery, wantsMaintenanceBuilder, nextRepairTarget } from "./repair";
+import {
+  pickCriticalRepairTarget,
+  wantsCriticalRecovery,
+  wantsMaintenanceBuilder,
+  nextRepairTarget,
+  nextBuildTarget
+} from "./repair";
 import { MAX_BUILDERS } from "./CorpConstants";
 import { Position } from "../types/Position";
 import { SinkAllocation } from "../flow/FlowTypes";
@@ -341,6 +347,10 @@ export function trunkGateFromSurvey(s: TrunkSurvey): string {
  * demand wants a builder; no taker -> ordinary grace -> recycle refund.
  */
 export const RELEASED_BUILDER_CORP_ID = "released-builder";
+
+// Re-exported so the builder-assignment tests and callers reach the build-side
+// latch through the corp that owns it (its twin nextRepairTarget lives here too).
+export { nextBuildTarget };
 
 export function repairRoadEnRoute(creep: Creep): void {
   if (creep.store[RESOURCE_ENERGY] === 0 || creep.getActiveBodyparts(WORK) === 0) return;
@@ -2348,8 +2358,13 @@ export class ConstructionCorp extends Corp {
   private doMaintenance(creep: Creep, room: Room): void {
     // Latch onto one structure and repair it to the ceiling before switching, so
     // the builder finishes a structure instead of ping-ponging to whichever is
-    // momentarily most decayed (see nextRepairTarget).
-    const target = nextRepairTarget(this.roomRepairables(room), creep.memory.repairTargetId);
+    // momentarily most decayed. With nothing endangered the latch hands over the
+    // NEAREST below-ceiling structure next (the range lens), so the detail sweeps
+    // sequentially along a road instead of crisscrossing the room (see
+    // nextRepairTarget); endangered structures still preempt by fraction.
+    const target = nextRepairTarget(this.roomRepairables(room), creep.memory.repairTargetId, s =>
+      creep.pos.getRangeTo(s.pos)
+    );
     if (!target) {
       delete creep.memory.repairTargetId; // all healthy: idle until plan() retires this builder
       return;
@@ -2364,6 +2379,10 @@ export class ConstructionCorp extends Corp {
     const result = creep.repair(target);
     if (result === ERR_NOT_IN_RANGE) {
       creep.moveTo(target, { range: 1, visualizePathStyle: { stroke: "#00ff88" } });
+      // ERR_NOT_IN_RANGE means the target repair did NOT fire, so the work
+      // action group is free: repair the road underfoot on the walk (most
+      // damaged first), turning the commute into maintenance too.
+      repairRoadEnRoute(creep);
     }
   }
 
@@ -2477,7 +2496,9 @@ export class ConstructionCorp extends Corp {
   private doBuild(creep: Creep, room: Room): void {
     const sites = room.find(FIND_MY_CONSTRUCTION_SITES);
     if (sites.length === 0) {
-      // No construction sites - stay put
+      // No construction sites - stay put, and drop the latch so a stale id
+      // never survives into the next build-out.
+      delete creep.memory.buildTargetId;
       return;
     }
 
@@ -2493,14 +2514,22 @@ export class ConstructionCorp extends Corp {
       return;
     }
 
-    const target = creep.pos.findClosestByPath(sites) ?? sites[0];
+    // LATCH to one site and finish it before moving to the nearest next (owner
+    // 2026-07-22: "they just go to a site, stay there ... and build"). The old
+    // findClosestByPath re-picked every tick, so a builder drifting along a
+    // paving route kept re-choosing whichever tile was momentarily closest and
+    // ping-ponged; nextBuildTarget holds the site until it is built, then hands
+    // over the nearest remaining one - a sequential sweep.
+    const target = nextBuildTarget(sites, creep.memory.buildTargetId, s => creep.pos.getRangeTo(s.pos)) ?? sites[0];
     if (!target) return;
+    creep.memory.buildTargetId = target.id;
 
     const result = creep.build(target);
     if (result === ERR_NOT_IN_RANGE) {
       creep.moveTo(target, { visualizePathStyle: { stroke: "#ffaa00" } });
       // Only on the walk: a same-tick build already claimed the work action
-      // group, and repair would cancel it.
+      // group, and repair would cancel it. Spending carried energy on the road
+      // underfoot also lightens the load, so the walk itself is faster.
       repairRoadEnRoute(creep);
     } else if (result === OK) {
       const workParts = creep.getActiveBodyparts(WORK);
@@ -2515,6 +2544,10 @@ export class ConstructionCorp extends Corp {
   private doPickup(creep: Creep, _room: Room): void {
     const PICKUP_RANGE = 4; // Only grab energy within this range
 
+    // Any walk here can carry a partial load (the builder tops up over several
+    // ticks), so every moveTo repairs the road underfoot in the same tick -
+    // repairRoadEnRoute no-ops when the store is empty, so a fully-drained
+    // builder just walks (faster, unladen) and only a laden one maintains.
     // Check for dropped energy within range
     const dropped = creep.pos.findInRange(FIND_DROPPED_RESOURCES, PICKUP_RANGE, {
       filter: r => r.resourceType === RESOURCE_ENERGY && r.amount > 20
@@ -2523,6 +2556,7 @@ export class ConstructionCorp extends Corp {
       const target = dropped[0];
       if (creep.pickup(target) === ERR_NOT_IN_RANGE) {
         creep.moveTo(target);
+        repairRoadEnRoute(creep);
       }
       return;
     }
@@ -2535,6 +2569,7 @@ export class ConstructionCorp extends Corp {
       const target = tombstones[0];
       if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
         creep.moveTo(target);
+        repairRoadEnRoute(creep);
       }
       return;
     }
@@ -2547,6 +2582,7 @@ export class ConstructionCorp extends Corp {
       const target = ruins[0];
       if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
         creep.moveTo(target);
+        repairRoadEnRoute(creep);
       }
       return;
     }
@@ -2559,18 +2595,25 @@ export class ConstructionCorp extends Corp {
       const target = containers[0];
       if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
         creep.moveTo(target);
+        repairRoadEnRoute(creep);
       }
       return;
     }
 
-    // No energy in reach: park beside the site instead of freezing where we
-    // stand - deliveries (home tankers, the founding hauler lane) land AT the
-    // site, and a builder stranded outside doPickup's range-4 scan starves
-    // next to nothing (measured: the founding builder deadlocked empty on the
-    // border tile all window).
-    const site = _room.find(FIND_MY_CONSTRUCTION_SITES)[0];
+    // No energy in reach: park beside the builder's OWN latched site instead of
+    // freezing where we stand - deliveries (home tankers, the founding hauler
+    // lane) land AT the site, and a builder stranded outside doPickup's range-4
+    // scan starves next to nothing (measured: the founding builder deadlocked
+    // empty on the border tile all window). The latch keeps it walking back to
+    // the site it is building, not to whichever site find() happens to list
+    // first (a second site across the room would drag it off its own work).
+    const latched = creep.memory.buildTargetId
+      ? (Game.getObjectById(creep.memory.buildTargetId as Id<ConstructionSite>) as ConstructionSite | null)
+      : null;
+    const site = latched ?? (_room.find(FIND_MY_CONSTRUCTION_SITES)[0] as ConstructionSite | undefined);
     if (site && creep.pos.getRangeTo(site.pos) > PICKUP_RANGE) {
       creep.moveTo(site.pos, { range: 2, visualizePathStyle: { stroke: "#ffaa00" } });
+      repairRoadEnRoute(creep);
     }
   }
 

--- a/src/corps/repair.ts
+++ b/src/corps/repair.ts
@@ -96,13 +96,74 @@ interface Repairable {
  */
 export function nextRepairTarget<T extends Repairable & { id: string }>(
   structures: T[],
-  latchedId: string | undefined
+  latchedId: string | undefined,
+  rangeOf?: (s: T) => number
 ): T | null {
   if (latchedId) {
     const latched = structures.find(s => s.id === latchedId);
     if (latched && latched.hits < latched.hitsMax * REPAIR_TO) return latched;
   }
+  // SEQUENTIAL SWEEP (owner 2026-07-22: "repair things that are sequential
+  // logistically"): with a position lens, routine maintenance walks the
+  // NEAREST below-ceiling structure next, so the detail sweeps along a road
+  // instead of crisscrossing the room between whichever two structures trade
+  // the lowest fraction. Genuinely endangered structures (below the spawn
+  // gate, ~one full decay band down) still preempt by fraction - the danger
+  // band never waits on geography. Without a lens the fraction order stands
+  // (callers with no position, and the pure unit tests).
+  if (rangeOf) {
+    const endangered = pickRepairTarget(structures, REPAIR_SPAWN_BELOW);
+    if (endangered) return endangered;
+    return nearestBelowCeiling(structures, rangeOf);
+  }
   return pickRepairTarget(structures, REPAIR_TO);
+}
+
+/** The closest structure still under the repair ceiling, or null if all are healthy. */
+function nearestBelowCeiling<T extends Repairable>(structures: T[], rangeOf: (s: T) => number): T | null {
+  let best: T | null = null;
+  let bestRange = Infinity;
+  for (const s of structures) {
+    if (s.hits >= s.hitsMax * REPAIR_TO) continue;
+    const r = rangeOf(s);
+    if (r < bestRange) {
+      bestRange = r;
+      best = s;
+    }
+  }
+  return best;
+}
+
+/**
+ * The construction site a builder should build THIS tick - the build-side twin
+ * of {@link nextRepairTarget} (owner 2026-07-22: "they just go to a site, stay
+ * there ... and build"). It LATCHES to its current site until that site is
+ * gone (built - completed sites vanish from FIND_MY_CONSTRUCTION_SITES), then
+ * picks the NEAREST remaining one, so the builder finishes a site before
+ * walking to the logistically-adjacent next instead of re-deciding every tick
+ * (the old per-tick findClosestByPath flipped the target as the creep drifted
+ * along a paving route and tiles completed - the measured ping-pong). Pure and
+ * position-agnostic (the `rangeOf` lens) so it is unit-tested without a room.
+ */
+export function nextBuildTarget<T extends { id: string }>(
+  sites: T[],
+  latchedId: string | undefined,
+  rangeOf: (s: T) => number
+): T | null {
+  if (latchedId) {
+    const latched = sites.find(s => s.id === latchedId);
+    if (latched) return latched; // still standing => not finished => keep building it
+  }
+  let best: T | null = null;
+  let bestRange = Infinity;
+  for (const s of sites) {
+    const r = rangeOf(s);
+    if (r < bestRange) {
+      bestRange = r;
+      best = s;
+    }
+  }
+  return best;
 }
 
 /**

--- a/src/types/Memory.ts
+++ b/src/types/Memory.ts
@@ -584,6 +584,16 @@ declare global {
      * topping up neither. Cleared when the target reaches the ceiling or is gone.
      */
     repairTargetId?: string;
+    /**
+     * The construction site a builder is currently building. The build-side
+     * twin of repairTargetId (owner 2026-07-22: "they can't ping-pong around
+     * ... they just go to a site, stay there, get tankers coming, and build"):
+     * a builder LATCHES to one site and finishes it before moving to the
+     * NEAREST next one - a sequential sweep over the project instead of a
+     * per-tick findClosestByPath that flips targets as the creep drifts and
+     * sites complete. Cleared when the site is gone (built) or none remain.
+     */
+    buildTargetId?: string;
     /** This crew member IS the standing repair detail (owner 2026-07-18:
      * repair and building are separate functions). Sticky for life. */
     repairDetail?: boolean;

--- a/test/unit/corps/builderAssignment.test.ts
+++ b/test/unit/corps/builderAssignment.test.ts
@@ -1,0 +1,182 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import "../../../src/types/Memory";
+import { ConstructionCorp, nextBuildTarget } from "../../../src/corps/ConstructionCorp";
+
+/**
+ * BUILDER ASSIGNMENT (owner 2026-07-22: "they can't ping-pong around. they
+ * just go to a site, stay there, get tankers coming, and build ... they
+ * should build/repair things that are sequential logistically"):
+ *
+ * - nextBuildTarget is the build-side twin of the repair latch: a builder
+ *   LATCHES to one site until it completes/vanishes, then picks the NEAREST
+ *   site from where it stands - a sequential chain over the project, never a
+ *   per-tick re-pick that flips targets as the creep drifts (the old
+ *   findClosestByPath-every-tick did exactly that, and paid a path search
+ *   per builder per tick for the privilege).
+ * - Every walking tick with energy aboard repairs the road underfoot
+ *   (repairRoadEnRoute): repair rides the work action group, move rides its
+ *   own, so they stack in one tick - and spending carry LIGHTENS the body
+ *   (stored energy is weight), so the walk itself gets faster. The wiring
+ *   must cover the maintenance walk and the pickup walk, not just the
+ *   cross-room marches.
+ */
+describe("builder assignment (latch to a site, sequential targets, repair while walking)", () => {
+  beforeEach(() => {
+    (global as any).RESOURCE_ENERGY = "energy";
+    (global as any).WORK = "work";
+    (global as any).FIND_STRUCTURES = 107;
+    (global as any).FIND_DROPPED_RESOURCES = 108;
+    (global as any).FIND_TOMBSTONES = 118;
+    (global as any).FIND_RUINS = 123;
+    (global as any).FIND_MY_CONSTRUCTION_SITES = 114;
+    (global as any).STRUCTURE_ROAD = "road";
+    (global as any).STRUCTURE_CONTAINER = "container";
+    (global as any).STRUCTURE_STORAGE = "storage";
+    (global as any).OK = 0;
+    (global as any).ERR_NOT_IN_RANGE = -9;
+    (global as any).Game = { creeps: {}, rooms: {}, time: 500, getObjectById: () => null };
+    (global as any).Memory = { creeps: {}, rooms: {} };
+  });
+
+  describe("nextBuildTarget (finish one site, then the nearest next)", () => {
+    interface TSite {
+      id: string;
+      pos: { x: number; y: number };
+    }
+    const site = (id: string, x: number): TSite => ({ id, pos: { x, y: 10 } });
+    const rangeFrom = (x: number) => (s: TSite) => Math.abs(s.pos.x - x);
+
+    it("latches: keeps the current site even when another is now nearer", () => {
+      const latched = site("far", 20);
+      const nearer = site("near", 2);
+      expect(nextBuildTarget([nearer, latched], "far", rangeFrom(0))).to.equal(latched);
+    });
+
+    it("latch gone (site completed): picks the NEAREST site from where the builder stands", () => {
+      const next = site("b", 12);
+      const distant = site("c", 40);
+      // The builder finished its site at x=10 - the chain continues at x=12,
+      // not at whatever find() happened to list first.
+      expect(nextBuildTarget([distant, next], "done-and-gone", rangeFrom(10))).to.equal(next);
+    });
+
+    it("no latch yet: nearest site wins (the chain starts where the builder is)", () => {
+      const near = site("a", 5);
+      expect(nextBuildTarget([site("b", 30), near], undefined, rangeFrom(4))).to.equal(near);
+    });
+
+    it("no sites: null", () => {
+      expect(nextBuildTarget([], "anything", rangeFrom(0))).to.equal(null);
+    });
+  });
+
+  describe("repair-while-walking wiring (the walks that carried energy without spending it)", () => {
+    function makeCorp(): ConstructionCorp {
+      return new ConstructionCorp("W1N1-construction", "spawn1");
+    }
+
+    /** A creep whose pos serves both the repairables scan and the en-route scan. */
+    function walkerCreep(opts: { energy: number; underfoot: any[] }): {
+      creep: any;
+      repairs: any[];
+      moves: any[];
+      pickups: any[];
+    } {
+      const repairs: any[] = [];
+      const moves: any[] = [];
+      const pickups: any[] = [];
+      const creep = {
+        name: "b1",
+        memory: {} as any,
+        store: { energy: opts.energy, getFreeCapacity: () => 50 },
+        getActiveBodyparts: (p: string) => (p === "work" ? 2 : 0),
+        room: { name: "W1N1" },
+        pos: {
+          x: 10,
+          y: 10,
+          roomName: "W1N1",
+          getRangeTo: (t: any) => {
+            const p = t.pos ?? t;
+            return Math.max(Math.abs((p.x ?? 0) - 10), Math.abs((p.y ?? 0) - 10));
+          },
+          findInRange: (type: number, _range: number, o?: any) => {
+            if (type !== (global as any).FIND_STRUCTURES) return [];
+            return o?.filter ? opts.underfoot.filter(o.filter) : opts.underfoot;
+          },
+          findClosestByPath: () => null
+        },
+        repair: (t: any) => {
+          repairs.push(t);
+          // Far targets (outside range 3) are out of range; near ones succeed.
+          const p = t.pos ?? { x: 10, y: 10 };
+          return Math.max(Math.abs(p.x - 10), Math.abs(p.y - 10)) > 3 ? -9 : 0;
+        },
+        pickup: (t: any) => {
+          pickups.push(t);
+          return -9; // out of range - forces the walk
+        },
+        moveTo: (...args: any[]) => {
+          moves.push(args);
+          return 0;
+        }
+      };
+      return { creep, repairs, moves, pickups };
+    }
+
+    it("doMaintenance: walking toward a far latched target still repairs the road underfoot", () => {
+      const corp = makeCorp();
+      const farRoad = { id: "far", structureType: "road", hits: 2000, hitsMax: 5000, pos: { x: 40, y: 40 } };
+      const underfoot = { id: "under", structureType: "road", hits: 4000, hitsMax: 5000 };
+      const room: any = {
+        name: "W1N1",
+        controller: undefined,
+        storage: undefined,
+        find: (type: number, o?: any) => {
+          const all = type === (global as any).FIND_STRUCTURES ? [farRoad] : [];
+          return o?.filter ? all.filter(o.filter) : all;
+        }
+      };
+      const w = walkerCreep({ energy: 100, underfoot: [underfoot] });
+      (corp as any).doMaintenance(w.creep, room);
+      expect(w.moves.length, "walked toward the latched target").to.equal(1);
+      expect(w.repairs, "far repair bounced (range), underfoot road repaired in the same tick").to.deep.equal([
+        farRoad,
+        underfoot
+      ]);
+    });
+
+    it("doPickup: walking to energy with a partial load repairs the road underfoot", () => {
+      const corp = makeCorp();
+      const underfoot = { id: "under", structureType: "road", hits: 3000, hitsMax: 5000 };
+      const pile = { id: "pile", resourceType: "energy", amount: 100, pos: { x: 14, y: 10 } };
+      const room: any = { name: "W1N1", find: () => [] };
+      const w = walkerCreep({ energy: 50, underfoot: [underfoot] });
+      w.creep.pos.findInRange = (type: number, _r: number, o?: any) => {
+        if (type === (global as any).FIND_DROPPED_RESOURCES) return o?.filter ? [pile].filter(o.filter) : [pile];
+        if (type === (global as any).FIND_STRUCTURES) return o?.filter ? [underfoot].filter(o.filter) : [underfoot];
+        return [];
+      };
+      (corp as any).doPickup(w.creep, room);
+      expect(w.pickups, "went for the pile").to.deep.equal([pile]);
+      expect(w.moves.length, "walked toward it").to.equal(1);
+      expect(w.repairs, "and still repaired the road underfoot").to.deep.equal([underfoot]);
+    });
+
+    it("doPickup: nothing in reach parks at the LATCHED site, not at find()[0]", () => {
+      const corp = makeCorp();
+      const latchedSite = { id: "mine", pos: { x: 20, y: 10, roomName: "W1N1" } };
+      const otherSite = { id: "other", pos: { x: 45, y: 45, roomName: "W1N1" } };
+      (global as any).Game.getObjectById = (id: string) => (id === "mine" ? latchedSite : null);
+      const room: any = {
+        name: "W1N1",
+        find: (type: number) => (type === (global as any).FIND_MY_CONSTRUCTION_SITES ? [otherSite, latchedSite] : [])
+      };
+      const w = walkerCreep({ energy: 0, underfoot: [] });
+      w.creep.memory.buildTargetId = "mine";
+      (corp as any).doPickup(w.creep, room);
+      expect(w.moves.length, "parked toward a site").to.equal(1);
+      expect(w.moves[0][0], "the latched site's pos, not the arbitrary first find() entry").to.equal(latchedSite.pos);
+    });
+  });
+});

--- a/test/unit/corps/repair.test.ts
+++ b/test/unit/corps/repair.test.ts
@@ -105,6 +105,46 @@ describe("corps/repair", () => {
     });
   });
 
+  describe("nextRepairTarget sequential sweep (owner 2026-07-22: repair things sequentially, logistically)", () => {
+    // Routine maintenance is a SPATIAL sweep, not a fraction leaderboard: with
+    // nothing endangered, finishing a target hands the detail the NEAREST
+    // below-ceiling structure, so it works its way along a road instead of
+    // crisscrossing the room between whichever two structures happen to trade
+    // the lowest fraction. Structures below the spawn gate still preempt by
+    // fraction - the danger band never waits on geography.
+    interface RStruct {
+      id: string;
+      hits: number;
+      hitsMax: number;
+      pos: { x: number };
+    }
+    const rid = (id: string, hits: number, x: number, hitsMax = 5000): RStruct => ({ id, hits, hitsMax, pos: { x } });
+    const rangeFrom = (x: number) => (s: RStruct) => Math.abs(s.pos.x - x);
+
+    it("nothing endangered: the NEAREST below-ceiling structure wins, not the worst fraction", () => {
+      const nearMild = rid("near", 4700, 2); // 94%, two tiles away
+      const farWorse = rid("far", 3500, 40); // 70%, across the room
+      expect(nextRepairTarget([farWorse, nearMild], undefined, rangeFrom(0))).to.equal(nearMild);
+    });
+
+    it("an endangered structure (below the spawn gate) preempts the sweep even when farther", () => {
+      const nearMild = rid("near", 4700, 2); // 94%
+      const farLow = rid("low", 2500, 40); // 50% - below REPAIR_SPAWN_BELOW
+      expect(nextRepairTarget([nearMild, farLow], undefined, rangeFrom(0))).to.equal(farLow);
+    });
+
+    it("the latch still beats the sweep: finish the current target before the nearest next", () => {
+      const latched = rid("mine", 4000, 30); // 80%, mid-repair
+      const nearer = rid("near", 4700, 1);
+      expect(nextRepairTarget([nearer, latched], "mine", rangeFrom(0))).to.equal(latched);
+    });
+
+    it("without a range lens the old fraction order stands (callers without a position)", () => {
+      const worse = rid("worse", 4000, 40);
+      expect(nextRepairTarget([rid("mild", 4700, 2), worse], undefined)).to.equal(worse);
+    });
+  });
+
   describe("repair efficiency (WORK spent repairing, not commuting)", () => {
     // A builder that re-picks the lowest-fraction target EVERY tick ping-pongs
     // between two similarly-decayed structures: it repairs the worst a little,


### PR DESCRIPTION
## Summary

Implement builder latching to construction sites (the build-side twin of repair targeting) so builders finish one site before moving to the nearest next, eliminating per-tick target re-picking that caused ping-ponging. Extend repair-while-walking to all builder movement phases so maintenance happens during every walk, lightening the load and accelerating transit.

## Key Changes

- **Builder site latching** (`nextBuildTarget`): builders now latch to a construction site via `creep.memory.buildTargetId` and hold it until completion, then pick the nearest remaining site. Replaces per-tick `findClosestByPath` that re-evaluated every tick as creeps drifted and sites completed.

- **Sequential repair sweep** (`nextRepairTarget` with range lens): routine maintenance now walks the nearest below-ceiling structure when nothing is endangered, sweeping sequentially along roads instead of crisscrossing between whichever two structures trade the lowest fraction. Endangered structures (below spawn gate) still preempt by fraction.

- **Repair-while-walking extended**: `repairRoadEnRoute` now fires on every builder walk—`doPickup` (dropped energy, tombstones, ruins, containers, parking at latched site) and `doMaintenance` (walking to far targets)—not just `doBuild`. Spending energy on the road underfoot lightens the creep, accelerating the walk itself.

- **Memory schema**: added `buildTargetId` to creep memory (twin of `repairTargetId`), cleared when the site is built or no sites remain.

- **Test coverage**: comprehensive unit tests for `nextBuildTarget` (latch, nearest-pick, no-sites cases) and repair-while-walking wiring in all movement phases (`doMaintenance`, `doPickup` with partial load, parking at latched site).

## Implementation Details

- `nextBuildTarget` is pure and position-agnostic (takes a `rangeOf` lens), matching `nextRepairTarget`'s design for testability without a room.
- The latch in `doPickup` ensures a builder parks at its own latched site, not whichever site `find()` lists first—preventing a second site across the room from dragging it off its work.
- `doMaintenance` now passes a range lens to `nextRepairTarget`, enabling the sequential sweep while preserving the old fraction-based order for callers without position (pure unit tests).
- All `doPickup` branches that walk now call `repairRoadEnRoute`, turning every commute into maintenance; the function no-ops when the store is empty, so a fully-drained builder just walks faster.

https://claude.ai/code/session_01DRf2L7cM3V6GRyt4gBax1t