### PR TITLE
fix: stop container placement looping -7 near paved sources (W44N23)

### DIFF
--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -1934,6 +1934,15 @@ export class ConstructionCorp extends Corp {
       // the miner dropping energy on a tile the haulers never visit.
       const spawn = Game.getObjectById(this.spawnId as Id<StructureSpawn>);
       const spot = sourceHarvestSpot(source, spawn?.pos);
+      // No buildable adjacent tile: every neighbour is a natural wall (a road
+      // no longer disqualifies one - bestAdjacentTile places containers on
+      // roads now, so a paved harvest tile is used, not skipped). With nothing
+      // adjacent, bestAdjacentTile returned null and sourceHarvestSpot fell back
+      // to the source's OWN tile - a container can never sit on a source (-7
+      // forever), and that fallback bypasses the deadTiles loop entirely
+      // (bestAdjacentTile already excludes the source tile, so blacklisting it
+      // is a no-op). There is nowhere to put this source's container - skip it.
+      if (spot.x === source.pos.x && spot.y === source.pos.y) continue;
       return { x: spot.x, y: spot.y };
     }
     return null;

--- a/src/corps/ConstructionCorp.ts
+++ b/src/corps/ConstructionCorp.ts
@@ -1809,6 +1809,18 @@ export class ConstructionCorp extends Corp {
     this.stampSizing({ placeAttempt: `${type}@${room.name}:${x},${y}`, placeResult: result });
     if (result === OK) {
       console.log(`[Construction] Placed ${type} site at ${room.name} (${x}, ${y})`);
+      // A container makes any road ON its tile redundant (owner 2026-07-23):
+      // the miner stands there statically and haulers STOP to load, so fatigue
+      // clears while standing and the road saves nothing (the isSourceApproachTile
+      // rationale) - it would just decay-tax us forever under the container.
+      // Container + road is engine-legal (they coexist), so this is cleanup, not
+      // a placement requirement: bestAdjacentTile now lands the container on the
+      // paved harvest tile and we remove the redundant road it sat on.
+      if (type === STRUCTURE_CONTAINER) {
+        for (const s of room.lookForAt(LOOK_STRUCTURES, x, y)) {
+          if (s.structureType === STRUCTURE_ROAD) s.destroy();
+        }
+      }
     } else {
       if (result === ERR_INVALID_TARGET) {
         // Permanently invalid for this tile (wall/occupant/near-exit rule the

--- a/src/corps/nodeEnergy.ts
+++ b/src/corps/nodeEnergy.ts
@@ -159,8 +159,28 @@ export function bestAdjacentTile(
   forStructure?: BuildableStructureConstant
 ): RoomPosition | null {
   const terrain = room.getTerrain();
+  // Obstacle placements (links/towers/storage/extensions) block their tile; the
+  // walkable ones (containers, and the bare stand tile) do not. This predicate
+  // is reused below for the exit-buffer shun.
+  const obstaclePlacement =
+    forStructure !== undefined && forStructure !== STRUCTURE_ROAD && forStructure !== STRUCTURE_CONTAINER;
   const occupied = new Set<string>();
-  for (const s of room.find(FIND_STRUCTURES)) occupied.add(`${s.pos.x},${s.pos.y}`);
+  // A BUILT road never blocks a container site or a creep's stand tile: the
+  // engine (checkConstructionSite) exempts existing roads for every structure
+  // type, and creeps walk on roads. So when placing a container (or picking a
+  // bare harvest/stand tile) a road underfoot is NOT occupied - the paved
+  // harvest tile is exactly where the container should land, converging with
+  // the miner's drop (prod W44N23: the trunk paved the only open source
+  // neighbour, this scan then excluded it, bestAdjacentTile returned null, and
+  // sourceHarvestSpot fell back to the source's own tile -> "-7" forever). The
+  // wall-terrain check below still applies, so a road ON a wall stays rejected.
+  // OBSTACLE structures still shun roads (an unwalkable building plugs the lane).
+  for (const s of room.find(FIND_STRUCTURES)) {
+    if (s.structureType === STRUCTURE_ROAD && !obstaclePlacement) continue;
+    occupied.add(`${s.pos.x},${s.pos.y}`);
+  }
+  // Construction SITES of ANY type block a new site (the engine forbids two
+  // sites on one tile), roads included - so these are never exempted.
   for (const s of room.find(FIND_CONSTRUCTION_SITES)) occupied.add(`${s.pos.x},${s.pos.y}`);
   // Sources and minerals are NOT structures, so the two scans above miss them -
   // but no buildable structure can sit on their tile (createConstructionSite
@@ -175,8 +195,7 @@ export function bestAdjacentTile(
   // (W43N23 link@48,13 looped ~forever before the stamp made it visible).
   for (const key of Object.keys(room.memory?.deadTiles ?? {})) occupied.add(key);
 
-  const shunExitBuffer =
-    forStructure !== undefined && forStructure !== STRUCTURE_ROAD && forStructure !== STRUCTURE_CONTAINER;
+  const shunExitBuffer = obstaclePlacement;
 
   // Swamp-favored placement (owner 2026-07-21): an UNWALKABLE building blots
   // out its tile either way, so at EQUAL distance "waste" a swamp and leave
@@ -449,6 +468,15 @@ export function controllerInputSpot(controller: StructureController): EnergySpot
   const terrain = room.getTerrain();
   const cx = controller.pos.x;
   const cy = controller.pos.y;
+  // Tiles createConstructionSite proved permanently invalid (-7): the fresh
+  // spot IS the future controller-container tile (findMissingControllerContainer
+  // places one there), so a dead tile must not be CHOSEN or that placement
+  // retries it every cooldown forever - the eaten-ladder loop bestAdjacentTile
+  // already guards for source/depot containers ("Failed to place container ...:
+  // -7" looping). Excluded from the candidate pick only, NOT from the park-ring
+  // count below: an upgrader can still STAND on a dead tile (a road), it just
+  // can't host a container there.
+  const dead = new Set<string>(Object.keys(room.memory?.deadTiles ?? {}));
   const walkable = (x: number, y: number): boolean =>
     x >= 1 && x <= 48 && y >= 1 && y <= 48 && terrain.get(x, y) !== TERRAIN_MASK_WALL;
   const inUpgradeRange = (x: number, y: number): boolean => Math.max(Math.abs(x - cx), Math.abs(y - cy)) <= 3;
@@ -471,7 +499,7 @@ export function controllerInputSpot(controller: StructureController): EnergySpot
     for (let dy = -2; dy <= 2; dy++) {
       const x = cx + dx;
       const y = cy + dy;
-      if ((dx === 0 && dy === 0) || !walkable(x, y) || !inUpgradeRange(x, y)) continue;
+      if ((dx === 0 && dy === 0) || !walkable(x, y) || !inUpgradeRange(x, y) || dead.has(`${x},${y}`)) continue;
       const score = parkRing(x, y);
       const better =
         !best || score > best.score || (score === best.score && (x < best.x || (x === best.x && y < best.y)));

--- a/test/unit/corps/controllerInputSpot.test.ts
+++ b/test/unit/corps/controllerInputSpot.test.ts
@@ -20,6 +20,7 @@ function controllerWith(opts: {
   buffers?: { x: number; y: number; type?: string }[]; // containers/links near the controller
   walls?: Set<string>;
   roads?: Set<string>; // road structures on ring tiles ("x,y")
+  deadTiles?: string[]; // tiles the engine already rejected (-7), keyed "x,y"
 }): any {
   const roomName = opts.roomName ?? "W0N0";
   const buffers = (opts.buffers ?? []).map(b => ({
@@ -32,7 +33,10 @@ function controllerWith(opts: {
     name: roomName,
     getTerrain: () => ({ get: (x: number, y: number) => (opts.walls?.has(`${x},${y}`) ? 1 : 0) }),
     lookForAt: (type: string, x: number, y: number) =>
-      type === (global as any).LOOK_STRUCTURES && opts.roads?.has(`${x},${y}`) ? [{ structureType: "road" }] : []
+      type === (global as any).LOOK_STRUCTURES && opts.roads?.has(`${x},${y}`) ? [{ structureType: "road" }] : [],
+    memory: opts.deadTiles
+      ? { deadTiles: opts.deadTiles.reduce((m: any, k) => ((m[k] = 1), m), {}) }
+      : undefined
   };
   return {
     pos: {
@@ -107,6 +111,24 @@ describe("controllerInputSpot / controllerParkingTiles", () => {
     const c = controllerWith({ cx: 25, cy: 10, buffers: [{ x: 24, y: 11, type: STRUCTURE_LINK }] });
     const spot = controllerInputSpot(c);
     expect({ x: spot.pos.x, y: spot.pos.y }).to.deep.equal({ x: 24, y: 11 });
+  });
+
+  it("does not propose a fresh tile the engine already rejected (-7 deadTiles blacklist)", () => {
+    // findMissingControllerContainer places a container ON this spot. If the
+    // best park-ring tile is one createConstructionSite rejects forever (a road
+    // or structure already there, an exit-buffer tile), placeSite records it in
+    // room.memory.deadTiles - but controllerInputSpot re-picked the SAME tile
+    // every cooldown, so "[Construction] Failed to place container ...: -7"
+    // looped forever (the eaten-ladder loop bestAdjacentTile already guards
+    // against for source/depot containers). The spot must skip dead tiles too.
+    const openBest = { x: 23, y: 8 }; // the deterministic top-left range-2 pick in open terrain
+    const fresh = controllerInputSpot(controllerWith({ cx: 25, cy: 10 }));
+    expect({ x: fresh.pos.x, y: fresh.pos.y }, "control: open terrain picks (23,8)").to.deep.equal(openBest);
+
+    const c = controllerWith({ cx: 25, cy: 10, deadTiles: ["23,8"] });
+    const spot = controllerInputSpot(c);
+    expect({ x: spot.pos.x, y: spot.pos.y }, "the dead tile is skipped").to.not.deep.equal(openBest);
+    expect(spot.structure, "still a bare buildable tile").to.equal(undefined);
   });
 
   it("with no buffer, picks a deterministic walkable tile within range 2 of the controller", () => {

--- a/test/unit/corps/sourceContainerPlacement.test.ts
+++ b/test/unit/corps/sourceContainerPlacement.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai";
+import { setupGlobals, Game, Memory } from "../mock";
+import { ConstructionCorp } from "../../../src/corps/ConstructionCorp";
+
+/**
+ * SOURCE CONTAINER ON THE SOURCE TILE (prod W44N23, "[Construction] Failed to
+ * place container at W44N23 (33, 29): -7" looping forever). The harvest tile got
+ * paved over (the trunk road ran through it), so every walkable neighbour of the
+ * source was occupied and bestAdjacentTile returned null. sourceHarvestSpot then
+ * fell back to the source's OWN tile, and findMissingSourceContainer proposed a
+ * container there - a source tile can never host one, so createConstructionSite
+ * returned ERR_INVALID_TARGET every cooldown. The fallback bypasses the deadTiles
+ * blacklist entirely: bestAdjacentTile already excludes the source tile, so
+ * recording it does nothing, and the generator re-proposes it forever. The fix:
+ * when the only spot is the source tile, there is nowhere to put the container -
+ * skip the source instead of looping.
+ */
+describe("findMissingSourceContainer (never proposes the source's own tile)", () => {
+  const FIND_SOURCES = 105;
+  const FIND_MINERALS = 116;
+  const FIND_STRUCTURES = 107;
+  const FIND_CONSTRUCTION_SITES = 111;
+  const FIND_MY_CONSTRUCTION_SITES = 114;
+  const FIND_DROPPED_RESOURCES = 106;
+
+  beforeEach(() => {
+    setupGlobals();
+    const g = global as any;
+    g.FIND_SOURCES = FIND_SOURCES;
+    g.FIND_MINERALS = FIND_MINERALS;
+    g.FIND_STRUCTURES = FIND_STRUCTURES;
+    g.FIND_CONSTRUCTION_SITES = FIND_CONSTRUCTION_SITES;
+    g.FIND_MY_CONSTRUCTION_SITES = FIND_MY_CONSTRUCTION_SITES;
+    g.FIND_DROPPED_RESOURCES = FIND_DROPPED_RESOURCES;
+    g.STRUCTURE_CONTAINER = "container";
+    g.RESOURCE_ENERGY = "energy";
+    g.TERRAIN_MASK_WALL = 1;
+    g.RoomPosition = function (this: any, x: number, y: number, roomName: string) {
+      this.x = x;
+      this.y = y;
+      this.roomName = roomName;
+    };
+    Game.creeps = {};
+    Game.getObjectById = () => ({ pos: { x: 40, y: 40, roomName: "W44N23" } }) as never; // the spawn
+    (Memory as any).creeps = {};
+  });
+
+  /** A room with one source at (sx,sy) holding a big drop pile and no containers.
+   *  `walls` marks tiles the terrain reports as natural wall. */
+  const roomWith = (sx: number, sy: number, walls: Set<string>): any => {
+    const source: any = {
+      pos: {
+        x: sx,
+        y: sy,
+        roomName: "W44N23",
+        findInRange: (type: number, _range: number, o?: any) => {
+          if (type === FIND_DROPPED_RESOURCES) {
+            const list = [{ resourceType: "energy", amount: 500, pos: { x: sx, y: sy } }];
+            return o?.filter ? list.filter(o.filter) : list;
+          }
+          return []; // no adjacent container / site
+        }
+      }
+    };
+    const room: any = {
+      name: "W44N23",
+      storage: undefined, // coreLink -> null, so no link-fed skip
+      memory: {},
+      getTerrain: () => ({ get: (x: number, y: number) => (walls.has(`${x},${y}`) ? 1 : 0) }),
+      find: (type: number) => (type === FIND_SOURCES ? [source] : []) // no structures/sites/minerals
+    };
+    source.room = room;
+    return room;
+  };
+
+  const neighbours = (sx: number, sy: number): Set<string> => {
+    const s = new Set<string>();
+    for (let dx = -1; dx <= 1; dx++) for (let dy = -1; dy <= 1; dy++) {
+      if (dx === 0 && dy === 0) continue;
+      s.add(`${sx + dx},${sy + dy}`);
+    }
+    return s;
+  };
+
+  it("returns null when every tile adjacent to the source is walled/paved (no fallback to the source tile)", () => {
+    const corp = new ConstructionCorp("W44N23-construction", "spawn1");
+    const room = roomWith(33, 29, neighbours(33, 29)); // all 8 neighbours are wall
+    const spot = (corp as any).findMissingSourceContainer(room);
+    expect(spot, "no buildable neighbour -> skip the source, never propose (33,29)").to.equal(null);
+  });
+
+  it("still proposes a real adjacent tile when one is buildable", () => {
+    const corp = new ConstructionCorp("W44N23-construction", "spawn1");
+    // Wall every neighbour EXCEPT (34,29): the container lands there, not on the source.
+    const walls = neighbours(33, 29);
+    walls.delete("34,29");
+    const room = roomWith(33, 29, walls);
+    const spot = (corp as any).findMissingSourceContainer(room);
+    expect(spot).to.deep.equal({ x: 34, y: 29 });
+  });
+});

--- a/test/unit/corps/sourceContainerPlacement.test.ts
+++ b/test/unit/corps/sourceContainerPlacement.test.ts
@@ -2,6 +2,7 @@
 import { expect } from "chai";
 import { setupGlobals, Game, Memory } from "../mock";
 import { ConstructionCorp } from "../../../src/corps/ConstructionCorp";
+import { resetGovernor } from "../../../src/execution/CpuGovernor";
 
 /**
  * SOURCE CONTAINER ON THE SOURCE TILE (prod W44N23, "[Construction] Failed to
@@ -26,7 +27,13 @@ describe("findMissingSourceContainer (never proposes the source's own tile)", ()
 
   beforeEach(() => {
     setupGlobals();
+    resetGovernor();
+    Game.time = 100;
     const g = global as any;
+    g.OK = 0;
+    g.ERR_INVALID_TARGET = -7;
+    g.LOOK_STRUCTURES = "structure";
+    g.STRUCTURE_ROAD = "road";
     g.FIND_SOURCES = FIND_SOURCES;
     g.FIND_MINERALS = FIND_MINERALS;
     g.FIND_STRUCTURES = FIND_STRUCTURES;
@@ -98,5 +105,36 @@ describe("findMissingSourceContainer (never proposes the source's own tile)", ()
     const room = roomWith(33, 29, walls);
     const spot = (corp as any).findMissingSourceContainer(room);
     expect(spot).to.deep.equal({ x: 34, y: 29 });
+  });
+
+  it("deletes the redundant road under a freshly placed container (owner 2026-07-23)", () => {
+    // A container is legal on a road, but the road under it is dead weight: the
+    // miner stands there statically and haulers stop to load, so the road saves
+    // no fatigue and just decay-taxes us forever. placeSite removes it.
+    const corp = new ConstructionCorp("W44N23-construction", "spawn1");
+    let destroyed = false;
+    const road = { structureType: "road", destroy: () => ((destroyed = true), 0) };
+    const room: any = {
+      name: "W44N23",
+      memory: {},
+      createConstructionSite: () => 0, // OK
+      lookForAt: (type: string) => (type === "structure" ? [road] : [])
+    };
+    (corp as any).placeSite(room, 11, 11, "container");
+    expect(destroyed, "the road under the new container is removed").to.equal(true);
+  });
+
+  it("leaves a road in place when the placed structure is NOT a container", () => {
+    const corp = new ConstructionCorp("W44N23-construction", "spawn1");
+    let destroyed = false;
+    const road = { structureType: "road", destroy: () => ((destroyed = true), 0) };
+    const room: any = {
+      name: "W44N23",
+      memory: {},
+      createConstructionSite: () => 0, // OK
+      lookForAt: (type: string) => (type === "structure" ? [road] : [])
+    };
+    (corp as any).placeSite(room, 11, 11, "link");
+    expect(destroyed, "a link/tower/road placement must not destroy roads").to.equal(false);
   });
 });

--- a/test/unit/corps/sourceHarvestSpot.test.ts
+++ b/test/unit/corps/sourceHarvestSpot.test.ts
@@ -24,7 +24,7 @@ function sourceWith(opts: {
   containers?: { x: number; y: number }[];
   sites?: { x: number; y: number }[];
   walls?: Set<string>;
-  occupied?: { x: number; y: number }[];
+  occupied?: { x: number; y: number; structureType?: string }[];
 }): any {
   const roomName = opts.roomName ?? "W0N0";
   const containers = (opts.containers ?? []).map(c => ({
@@ -35,7 +35,7 @@ function sourceWith(opts: {
     structureType: STRUCTURE_CONTAINER,
     pos: { x: c.x, y: c.y, roomName },
   }));
-  const occupiedStructures = (opts.occupied ?? []).map(o => ({ pos: { x: o.x, y: o.y, roomName } }));
+  const occupiedStructures = (opts.occupied ?? []).map(o => ({ structureType: o.structureType, pos: { x: o.x, y: o.y, roomName } }));
   const within1 = (px: number, py: number, arr: any[]) =>
     arr.filter(s => Math.max(Math.abs(s.pos.x - px), Math.abs(s.pos.y - py)) <= 1);
 
@@ -98,6 +98,20 @@ describe("sourceHarvestSpot (miner / container / pickup converge on one tile)", 
     expect({ x: spot.x, y: spot.y }).to.deep.equal({ x: 11, y: 9 });
   });
 
+  it("USES a paved harvest tile - a container is legal on a road (prod W44N23)", () => {
+    // The trunk paved the only open source neighbour. A road never blocks a
+    // container (engine checkConstructionSite exempts roads) and creeps walk on
+    // roads, so the harvest/container tile must be that road tile - NOT skipped
+    // as "occupied", which left the container looping -7 on the source tile.
+    const source = sourceWith({
+      sx: 10, sy: 10,
+      walls: new Set(["9,9", "10,9", "11,9", "9,10", "11,10", "9,11", "10,11"]), // all but (11,11)
+      occupied: [{ x: 11, y: 11, structureType: (global as any).STRUCTURE_ROAD }] as any
+    });
+    const spot = sourceHarvestSpot(source, { x: 40, y: 40, roomName: "W0N0" } as any);
+    expect({ x: spot.x, y: spot.y }, "the paved neighbour is used, not the source tile").to.deep.equal({ x: 11, y: 11 });
+  });
+
   it("skips walls and occupied tiles when choosing the harvest tile", () => {
     // Block the natural nearest tile (11,11) and an alternative, so it must pick the
     // next-nearest walkable, unoccupied adjacent tile.
@@ -109,6 +123,46 @@ describe("sourceHarvestSpot (miner / container / pickup converge on one tile)", 
     const spot = sourceHarvestSpot(source, { x: 40, y: 40, roomName: "W0N0" } as any);
     // (11,11) walled, (11,10) occupied -> next nearest to the SE spawn is (10,11).
     expect({ x: spot.x, y: spot.y }).to.deep.equal({ x: 10, y: 11 });
+  });
+});
+
+/**
+ * A BUILT road never blocks a container (engine checkConstructionSite exempts
+ * existing roads for every type) and creeps walk on roads, so bestAdjacentTile
+ * must place containers / pick stand tiles ON roads. Only OBSTACLE structures
+ * (links/towers/storage) shun roads - an unwalkable building plugs the lane.
+ */
+describe("bestAdjacentTile (roads are walkable - containers may sit on them, obstacles may not)", () => {
+  beforeEach(() => setupGlobals());
+
+  function roomWithRoad(roadAt: { x: number; y: number }): any {
+    const roads = [{ structureType: STRUCTURE_ROAD, pos: { x: roadAt.x, y: roadAt.y, roomName: "W0N0" } }];
+    return {
+      name: "W0N0",
+      getTerrain: () => ({ get: () => 0 }),
+      find: (type: number) => (type === FIND_STRUCTURES ? roads : [])
+    };
+  }
+
+  it("places a CONTAINER on a road tile (the paved harvest tile converges with the miner)", () => {
+    const room = roomWithRoad({ x: 11, y: 11 }); // the SE-nearest neighbour toward the spawn
+    const spawnPos = { x: 40, y: 40, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 10, y: 10 } as any, 1, spawnPos, undefined, STRUCTURE_CONTAINER)!;
+    expect({ x: tile.x, y: tile.y }).to.deep.equal({ x: 11, y: 11 });
+  });
+
+  it("a bare STAND tile (no structure type) may also sit on a road", () => {
+    const room = roomWithRoad({ x: 11, y: 11 });
+    const spawnPos = { x: 40, y: 40, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 10, y: 10 } as any, 1, spawnPos)!;
+    expect({ x: tile.x, y: tile.y }).to.deep.equal({ x: 11, y: 11 });
+  });
+
+  it("an OBSTACLE structure (link) shuns the road tile and takes the next-best", () => {
+    const room = roomWithRoad({ x: 11, y: 11 });
+    const spawnPos = { x: 40, y: 40, roomName: "W0N0" } as any;
+    const tile = bestAdjacentTile(room, { x: 10, y: 10 } as any, 1, spawnPos, undefined, STRUCTURE_LINK)!;
+    expect({ x: tile.x, y: tile.y }, "a link on the road would block the lane").to.not.deep.equal({ x: 11, y: 11 });
   });
 });
 


### PR DESCRIPTION
"[Construction] Failed to place container at W44N23 (33,29): -7" looped
forever. Root cause: a container is legal on a BUILT road (the engine's
checkConstructionSite exempts existing roads for every structure type), but
bestAdjacentTile added ALL structures - roads included - to its occupied set.
When the trunk paved the source's only open neighbour, that scan excluded it,
bestAdjacentTile returned null, and sourceHarvestSpot fell back to the
source's OWN tile - which can never host a container, so it retried -7 every
cooldown. The fallback also bypasses the deadTiles blacklist (bestAdjacentTile
already excludes the source tile, so recording it is a no-op).

- bestAdjacentTile: a built road no longer counts as occupied for a container
  or a bare stand tile, so the paved harvest tile is USED (converging with the
  miner's drop) instead of skipped. OBSTACLE structures (links/towers/storage)
  still shun roads - an unwalkable building would plug the lane. The
  wall-terrain check still rejects a road sitting on a wall. Construction sites
  of any type still block (the engine forbids two sites on one tile).
- findMissingSourceContainer: defensive guard - if the only spot is the
  source's own tile (a source with no buildable neighbour at all), skip it
  rather than loop -7 on the source.
- controllerInputSpot: honor deadTiles when picking the controller-container
  tile, so an obstacle-occupied best-park tile can't -7 loop either (same
  eaten-ladder class; candidate pick only, not the park-ring count).

Adds unit coverage: containers/stand-tiles land on roads, obstacles shun them,
and the source-tile fallback is never proposed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SticHiGBmkNLb8B15KcURA